### PR TITLE
Various performance fixes and experiments

### DIFF
--- a/RepoDb/RepoDb/ClassProperty.cs
+++ b/RepoDb/RepoDb/ClassProperty.cs
@@ -272,7 +272,7 @@ namespace RepoDb
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/ClassProperty.cs
+++ b/RepoDb/RepoDb/ClassProperty.cs
@@ -272,7 +272,7 @@ namespace RepoDb
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Enumerations/Conjunction.cs
+++ b/RepoDb/RepoDb/Enumerations/Conjunction.cs
@@ -5,15 +5,15 @@ namespace RepoDb.Enumerations
     /// <summary>
     /// An enumeration used to define a conjuction for the query grouping. This enumeration is used at <see cref="QueryGroup"/> object.
     /// </summary>
-    public enum Conjunction
+    public enum Conjunction : short
     {
         /// <summary>
         /// The (AND) conjunction.
         /// </summary>
-        [Text("AND")] And = 446274343,
+        [Text("AND")] And = 1,
         /// <summary>
         /// The (OR) conjunction.
         /// </summary>
-        [Text("OR")] Or = 1382346125
+        [Text("OR")] Or = 2
     }
 }

--- a/RepoDb/RepoDb/Enumerations/Conjunction.cs
+++ b/RepoDb/RepoDb/Enumerations/Conjunction.cs
@@ -5,15 +5,15 @@ namespace RepoDb.Enumerations
     /// <summary>
     /// An enumeration used to define a conjuction for the query grouping. This enumeration is used at <see cref="QueryGroup"/> object.
     /// </summary>
-    public enum Conjunction : short
+    public enum Conjunction
     {
         /// <summary>
         /// The (AND) conjunction.
         /// </summary>
-        [Text("AND")] And = 1,
+        [Text("AND")] And = 446274343,
         /// <summary>
         /// The (OR) conjunction.
         /// </summary>
-        [Text("OR")] Or = 2
+        [Text("OR")] Or = 1382346125
     }
 }

--- a/RepoDb/RepoDb/Enumerations/Operation.cs
+++ b/RepoDb/RepoDb/Enumerations/Operation.cs
@@ -5,55 +5,55 @@ namespace RepoDb.Enumerations
     /// <summary>
     /// An enumeration used to define an operation on the query expression.
     /// </summary>
-    public enum Operation
+    public enum Operation : short
     {
         /// <summary>
         /// An equal operation.
         /// </summary>
-        [Text("=")] Equal = 1968935258,
+        [Text("=")] Equal,
         /// <summary>
         /// A not-equal operation.
         /// </summary>
-        [Text("<>")] NotEqual = 1861928312,
+        [Text("<>")] NotEqual,
         /// <summary>
         /// A less-than operation.
         /// </summary>
-        [Text("<")] LessThan = 1185489222,
+        [Text("<")] LessThan,
         /// <summary>
         /// A greater-than operation.
         /// </summary>
-        [Text(">")] GreaterThan = 1904766133,
+        [Text(">")] GreaterThan,
         /// <summary>
         /// A less-than-or-equal operation.
         /// </summary>
-        [Text("<=")] LessThanOrEqual = 1969886037,
+        [Text("<=")] LessThanOrEqual,
         /// <summary>
         /// A greater-than-or-equal operation.
         /// </summary>
-        [Text(">=")] GreaterThanOrEqual = 1388583607,
+        [Text(">=")] GreaterThanOrEqual,
         /// <summary>
         /// A like operation. Defines the (LIKE) keyword in SQL Statement.
         /// </summary>
-        [Text("LIKE")] Like = 761684150,
+        [Text("LIKE")] Like,
         /// <summary>
         /// A not-like operation. Defines the (NOT LIKE) keyword in SQL Statement.
         /// </summary>
-        [Text("NOT LIKE")] NotLike = 9672391,
+        [Text("NOT LIKE")] NotLike,
         /// <summary>
         /// A between operation. Defines the (BETWEEN) keyword in SQL Statement.
         /// </summary>
-        [Text("BETWEEN")] Between = 1639933206,
+        [Text("BETWEEN")] Between,
         /// <summary>
         /// A not-between operation. Defines the (NOT BETWEEN) keyword in SQL Statement.
         /// </summary>
-        [Text("NOT BETWEEN")] NotBetween = 729234306,
+        [Text("NOT BETWEEN")] NotBetween,
         /// <summary>
         /// An in operation. Defines the (IN) keyword in SQL Statement.
         /// </summary>
-        [Text("IN")] In = 1986985380,
+        [Text("IN")] In,
         /// <summary>
         /// A non-in operation. Defines the (NOT IN) keyword in SQL Statement.
         /// </summary>
-        [Text("NOT IN")] NotIn = 277789918
+        [Text("NOT IN")] NotIn
     }
 }

--- a/RepoDb/RepoDb/Enumerations/Operation.cs
+++ b/RepoDb/RepoDb/Enumerations/Operation.cs
@@ -5,55 +5,55 @@ namespace RepoDb.Enumerations
     /// <summary>
     /// An enumeration used to define an operation on the query expression.
     /// </summary>
-    public enum Operation : short
+    public enum Operation
     {
         /// <summary>
         /// An equal operation.
         /// </summary>
-        [Text("=")] Equal,
+        [Text("=")] Equal = 1968935258,
         /// <summary>
         /// A not-equal operation.
         /// </summary>
-        [Text("<>")] NotEqual,
+        [Text("<>")] NotEqual = 1861928312,
         /// <summary>
         /// A less-than operation.
         /// </summary>
-        [Text("<")] LessThan,
+        [Text("<")] LessThan = 1185489222,
         /// <summary>
         /// A greater-than operation.
         /// </summary>
-        [Text(">")] GreaterThan,
+        [Text(">")] GreaterThan = 1904766133,
         /// <summary>
         /// A less-than-or-equal operation.
         /// </summary>
-        [Text("<=")] LessThanOrEqual,
+        [Text("<=")] LessThanOrEqual = 1969886037,
         /// <summary>
         /// A greater-than-or-equal operation.
         /// </summary>
-        [Text(">=")] GreaterThanOrEqual,
+        [Text(">=")] GreaterThanOrEqual = 1388583607,
         /// <summary>
         /// A like operation. Defines the (LIKE) keyword in SQL Statement.
         /// </summary>
-        [Text("LIKE")] Like,
+        [Text("LIKE")] Like = 761684150,
         /// <summary>
         /// A not-like operation. Defines the (NOT LIKE) keyword in SQL Statement.
         /// </summary>
-        [Text("NOT LIKE")] NotLike,
+        [Text("NOT LIKE")] NotLike = 9672391,
         /// <summary>
         /// A between operation. Defines the (BETWEEN) keyword in SQL Statement.
         /// </summary>
-        [Text("BETWEEN")] Between,
+        [Text("BETWEEN")] Between = 1639933206,
         /// <summary>
         /// A not-between operation. Defines the (NOT BETWEEN) keyword in SQL Statement.
         /// </summary>
-        [Text("NOT BETWEEN")] NotBetween,
+        [Text("NOT BETWEEN")] NotBetween = 729234306,
         /// <summary>
         /// An in operation. Defines the (IN) keyword in SQL Statement.
         /// </summary>
-        [Text("IN")] In,
+        [Text("IN")] In = 1986985380,
         /// <summary>
         /// A non-in operation. Defines the (NOT IN) keyword in SQL Statement.
         /// </summary>
-        [Text("NOT IN")] NotIn
+        [Text("NOT IN")] NotIn = 277789918
     }
 }

--- a/RepoDb/RepoDb/Enumerations/Order.cs
+++ b/RepoDb/RepoDb/Enumerations/Order.cs
@@ -5,15 +5,15 @@ namespace RepoDb.Enumerations
     /// <summary>
     /// An enumeration used to define the ordering of the query field.
     /// </summary>
-    public enum Order
+    public enum Order : short
     {
         /// <summary>
         /// The ascending order.
         /// </summary>
-        [Text("ASC")] Ascending = 720208773,
+        [Text("ASC")] Ascending = 1,
         /// <summary>
         /// The descending order.
         /// </summary>
-        [Text("DESC")] Descending = 1249030520
+        [Text("DESC")] Descending = 2
     }
 }

--- a/RepoDb/RepoDb/Enumerations/Order.cs
+++ b/RepoDb/RepoDb/Enumerations/Order.cs
@@ -5,15 +5,15 @@ namespace RepoDb.Enumerations
     /// <summary>
     /// An enumeration used to define the ordering of the query field.
     /// </summary>
-    public enum Order : short
+    public enum Order
     {
         /// <summary>
         /// The ascending order.
         /// </summary>
-        [Text("ASC")] Ascending = 1,
+        [Text("ASC")] Ascending = 720208773,
         /// <summary>
         /// The descending order.
         /// </summary>
-        [Text("DESC")] Descending = 2
+        [Text("DESC")] Descending = 1249030520
     }
 }

--- a/RepoDb/RepoDb/Field.cs
+++ b/RepoDb/RepoDb/Field.cs
@@ -82,7 +82,7 @@ namespace RepoDb
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace RepoDb
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(Field other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace RepoDb
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Field.cs
+++ b/RepoDb/RepoDb/Field.cs
@@ -82,7 +82,7 @@ namespace RepoDb
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace RepoDb
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(Field other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace RepoDb
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/OrderField.cs
+++ b/RepoDb/RepoDb/OrderField.cs
@@ -140,7 +140,7 @@ namespace RepoDb
         /// <returns>The hashcode value.</returns>
         public override int GetHashCode()
         {
-            return Name.GetHashCode() + Order.GetHashCode();
+            return Name.GetHashCode() + (int)Order;
         }
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace RepoDb
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace RepoDb
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(OrderField other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace RepoDb
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/OrderField.cs
+++ b/RepoDb/RepoDb/OrderField.cs
@@ -140,7 +140,7 @@ namespace RepoDb
         /// <returns>The hashcode value.</returns>
         public override int GetHashCode()
         {
-            return Name.GetHashCode() + (int)Order;
+            return Name.GetHashCode() + Order.GetHashCode();
         }
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace RepoDb
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace RepoDb
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(OrderField other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace RepoDb
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Parameter.cs
+++ b/RepoDb/RepoDb/Parameter.cs
@@ -90,7 +90,7 @@ namespace RepoDb
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace RepoDb
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(Parameter other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace RepoDb
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Parameter.cs
+++ b/RepoDb/RepoDb/Parameter.cs
@@ -90,7 +90,7 @@ namespace RepoDb
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace RepoDb
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(Parameter other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace RepoDb
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/QueryBuilder.cs
+++ b/RepoDb/RepoDb/QueryBuilder.cs
@@ -13,15 +13,7 @@ namespace RepoDb
     public class QueryBuilder<TEntity>
         where TEntity : class
     {
-        // A StringBuilder's capacity grows dynamically as required (e.g. during append operations), but there's a 
-        // perfomance penalty to be paid every time this happens (memory allocation + copy). The initial capacity
-        // of a StringBuilder buffer is only 16 characters by default - too small to hold any meaningful query string,
-        // so let's increase this to somthing more sensible. This should improve overall performance at the expense
-        // of higher memory usage for short queries.
-
-        //TODO: Tune this value
-        private const int INITIAL_STRINGBUILDER_CAPACITY = 2048;
-        private readonly StringBuilder m_stringBuilder = new StringBuilder(INITIAL_STRINGBUILDER_CAPACITY);
+        private readonly StringBuilder m_stringBuilder = new StringBuilder();
 
         /// <summary>
         /// Stringify the current object.
@@ -39,12 +31,11 @@ namespace RepoDb
 
         /// <summary>
         /// Gets the string that corresponds to the composed SQL Query Statement.
-        /// Starts at index 1 to drop the leading space.
         /// </summary>
         /// <returns>The current instance.</returns>
         public string GetString()
         {
-            return m_stringBuilder.ToString(1, m_stringBuilder.Length - 1);
+            return m_stringBuilder.ToString();
         }
 
         /// <summary>
@@ -67,13 +58,12 @@ namespace RepoDb
         }
 
         /// <summary>
-        /// Appends a line terminator to the SQL Query Statement.
+        /// Appends a new-line to the SQL Query Statement.
         /// </summary>
         /// <returns>The current instance.</returns>
         public QueryBuilder<TEntity> NewLine()
         {
-            m_stringBuilder.AppendLine();
-            return this;
+            return Append("\n");
         }
 
         /// <summary>
@@ -88,7 +78,7 @@ namespace RepoDb
 
         private QueryBuilder<TEntity> Append(string value)
         {
-            m_stringBuilder.Append(string.Concat(" ", value));
+            m_stringBuilder.Append(m_stringBuilder.Length > 0 ? string.Concat(" ", value) : value);
             return this;
         }
 

--- a/RepoDb/RepoDb/QueryBuilder.cs
+++ b/RepoDb/RepoDb/QueryBuilder.cs
@@ -20,7 +20,7 @@ namespace RepoDb
         // of higher memory usage for short queries.
 
         //TODO: Tune this value
-        private const int INITIAL_STRINGBUILDER_CAPACITY = 2048;
+        private const int INITIAL_STRINGBUILDER_CAPACITY = 256;
         private readonly StringBuilder m_stringBuilder = new StringBuilder(INITIAL_STRINGBUILDER_CAPACITY);
 
         /// <summary>

--- a/RepoDb/RepoDb/QueryBuilder.cs
+++ b/RepoDb/RepoDb/QueryBuilder.cs
@@ -13,7 +13,15 @@ namespace RepoDb
     public class QueryBuilder<TEntity>
         where TEntity : class
     {
-        private readonly StringBuilder m_stringBuilder = new StringBuilder();
+        // A StringBuilder's capacity grows dynamically as required (e.g. during append operations), but there's a 
+        // perfomance penalty to be paid every time this happens (memory allocation + copy). The initial capacity
+        // of a StringBuilder buffer is only 16 characters by default - too small to hold any meaningful query string,
+        // so let's increase this to somthing more sensible. This should improve overall performance at the expense
+        // of higher memory usage for short queries.
+
+        //TODO: Tune this value
+        private const int INITIAL_STRINGBUILDER_CAPACITY = 2048;
+        private readonly StringBuilder m_stringBuilder = new StringBuilder(INITIAL_STRINGBUILDER_CAPACITY);
 
         /// <summary>
         /// Stringify the current object.
@@ -31,11 +39,12 @@ namespace RepoDb
 
         /// <summary>
         /// Gets the string that corresponds to the composed SQL Query Statement.
+        /// Starts at index 1 to drop the leading space.
         /// </summary>
         /// <returns>The current instance.</returns>
         public string GetString()
         {
-            return m_stringBuilder.ToString();
+            return m_stringBuilder.ToString(1, m_stringBuilder.Length - 1);
         }
 
         /// <summary>
@@ -58,12 +67,13 @@ namespace RepoDb
         }
 
         /// <summary>
-        /// Appends a new-line to the SQL Query Statement.
+        /// Appends a line terminator to the SQL Query Statement.
         /// </summary>
         /// <returns>The current instance.</returns>
         public QueryBuilder<TEntity> NewLine()
         {
-            return Append("\n");
+            m_stringBuilder.AppendLine();
+            return this;
         }
 
         /// <summary>
@@ -78,7 +88,7 @@ namespace RepoDb
 
         private QueryBuilder<TEntity> Append(string value)
         {
-            m_stringBuilder.Append(m_stringBuilder.Length > 0 ? string.Concat(" ", value) : value);
+            m_stringBuilder.Append(string.Concat(" ", value));
             return this;
         }
 

--- a/RepoDb/RepoDb/QueryField.cs
+++ b/RepoDb/RepoDb/QueryField.cs
@@ -189,7 +189,7 @@ namespace RepoDb
             var hashCode = 0;
 
             // Set in the combination of the properties
-            hashCode += (Field.GetHashCode() + Operation.GetHashCode() + Parameter.GetHashCode());
+            hashCode += (Field.GetHashCode() + (int)Operation + Parameter.GetHashCode());
 
             // The (IS NULL) affects the uniqueness of the object
             if (Operation == Operation.Equal && ReferenceEquals(null, Parameter.Value))
@@ -222,7 +222,7 @@ namespace RepoDb
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -232,7 +232,7 @@ namespace RepoDb
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(QueryField other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -247,7 +247,7 @@ namespace RepoDb
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/QueryField.cs
+++ b/RepoDb/RepoDb/QueryField.cs
@@ -189,7 +189,7 @@ namespace RepoDb
             var hashCode = 0;
 
             // Set in the combination of the properties
-            hashCode += (Field.GetHashCode() + (int)Operation + Parameter.GetHashCode());
+            hashCode += (Field.GetHashCode() + Operation.GetHashCode() + Parameter.GetHashCode());
 
             // The (IS NULL) affects the uniqueness of the object
             if (Operation == Operation.Equal && ReferenceEquals(null, Parameter.Value))
@@ -222,7 +222,7 @@ namespace RepoDb
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -232,7 +232,7 @@ namespace RepoDb
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(QueryField other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -247,7 +247,7 @@ namespace RepoDb
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/QueryGroup.cs
+++ b/RepoDb/RepoDb/QueryGroup.cs
@@ -943,7 +943,7 @@ namespace RepoDb
             }
 
             // Set with conjunction
-            hashCode += Conjunction.GetHashCode();
+            hashCode += (int)Conjunction;
 
             // Set the IsNot
             hashCode += IsNot.GetHashCode();
@@ -962,7 +962,7 @@ namespace RepoDb
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -972,7 +972,7 @@ namespace RepoDb
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(QueryGroup other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -987,7 +987,7 @@ namespace RepoDb
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/QueryGroup.cs
+++ b/RepoDb/RepoDb/QueryGroup.cs
@@ -943,7 +943,7 @@ namespace RepoDb
             }
 
             // Set with conjunction
-            hashCode += (int)Conjunction;
+            hashCode += Conjunction.GetHashCode();
 
             // Set the IsNot
             hashCode += IsNot.GetHashCode();
@@ -962,7 +962,7 @@ namespace RepoDb
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -972,7 +972,7 @@ namespace RepoDb
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(QueryGroup other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -987,7 +987,7 @@ namespace RepoDb
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/BatchQueryRequest.cs
+++ b/RepoDb/RepoDb/Requests/BatchQueryRequest.cs
@@ -123,7 +123,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(BatchQueryRequest other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/BatchQueryRequest.cs
+++ b/RepoDb/RepoDb/Requests/BatchQueryRequest.cs
@@ -123,7 +123,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(BatchQueryRequest other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/CountRequest.cs
+++ b/RepoDb/RepoDb/Requests/CountRequest.cs
@@ -79,7 +79,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(CountRequest other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/CountRequest.cs
+++ b/RepoDb/RepoDb/Requests/CountRequest.cs
@@ -79,7 +79,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(CountRequest other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/DeleteAllRequest.cs
+++ b/RepoDb/RepoDb/Requests/DeleteAllRequest.cs
@@ -53,7 +53,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(DeleteAllRequest other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/DeleteAllRequest.cs
+++ b/RepoDb/RepoDb/Requests/DeleteAllRequest.cs
@@ -53,7 +53,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(DeleteAllRequest other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/DeleteRequest.cs
+++ b/RepoDb/RepoDb/Requests/DeleteRequest.cs
@@ -66,7 +66,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(DeleteRequest other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/DeleteRequest.cs
+++ b/RepoDb/RepoDb/Requests/DeleteRequest.cs
@@ -66,7 +66,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(DeleteRequest other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/InlineInsertRequest.cs
+++ b/RepoDb/RepoDb/Requests/InlineInsertRequest.cs
@@ -70,7 +70,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(InlineInsertRequest other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/InlineInsertRequest.cs
+++ b/RepoDb/RepoDb/Requests/InlineInsertRequest.cs
@@ -70,7 +70,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(InlineInsertRequest other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/InlineMergeRequest.cs
+++ b/RepoDb/RepoDb/Requests/InlineMergeRequest.cs
@@ -87,7 +87,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(InlineMergeRequest other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/InlineMergeRequest.cs
+++ b/RepoDb/RepoDb/Requests/InlineMergeRequest.cs
@@ -87,7 +87,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(InlineMergeRequest other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/InlineUpdateRequest.cs
+++ b/RepoDb/RepoDb/Requests/InlineUpdateRequest.cs
@@ -84,7 +84,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(InlineUpdateRequest other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/InlineUpdateRequest.cs
+++ b/RepoDb/RepoDb/Requests/InlineUpdateRequest.cs
@@ -84,7 +84,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(InlineUpdateRequest other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/InsertRequest.cs
+++ b/RepoDb/RepoDb/Requests/InsertRequest.cs
@@ -53,7 +53,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(InsertRequest other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/InsertRequest.cs
+++ b/RepoDb/RepoDb/Requests/InsertRequest.cs
@@ -53,7 +53,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(InsertRequest other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/MergeRequest.cs
+++ b/RepoDb/RepoDb/Requests/MergeRequest.cs
@@ -70,7 +70,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(MergeRequest other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/MergeRequest.cs
+++ b/RepoDb/RepoDb/Requests/MergeRequest.cs
@@ -70,7 +70,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(MergeRequest other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/QueryMultipleRequest.cs
+++ b/RepoDb/RepoDb/Requests/QueryMultipleRequest.cs
@@ -123,7 +123,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(QueryMultipleRequest other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/QueryMultipleRequest.cs
+++ b/RepoDb/RepoDb/Requests/QueryMultipleRequest.cs
@@ -123,7 +123,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(QueryMultipleRequest other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/QueryRequest.cs
+++ b/RepoDb/RepoDb/Requests/QueryRequest.cs
@@ -110,7 +110,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(QueryRequest other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/QueryRequest.cs
+++ b/RepoDb/RepoDb/Requests/QueryRequest.cs
@@ -110,7 +110,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(QueryRequest other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/TruncateRequest.cs
+++ b/RepoDb/RepoDb/Requests/TruncateRequest.cs
@@ -53,7 +53,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(TruncateRequest other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/TruncateRequest.cs
+++ b/RepoDb/RepoDb/Requests/TruncateRequest.cs
@@ -53,7 +53,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(TruncateRequest other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/UpdateRequest.cs
+++ b/RepoDb/RepoDb/Requests/UpdateRequest.cs
@@ -66,7 +66,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return GetHashCode() == obj?.GetHashCode();
+            return obj?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(UpdateRequest other)
         {
-            return GetHashCode() == other?.GetHashCode();
+            return other?.GetHashCode() == GetHashCode();
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objA?.GetHashCode() == objB?.GetHashCode();
+            return objB?.GetHashCode() == objA.GetHashCode();
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/Requests/UpdateRequest.cs
+++ b/RepoDb/RepoDb/Requests/UpdateRequest.cs
@@ -66,7 +66,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equals.</returns>
         public override bool Equals(object obj)
         {
-            return obj?.GetHashCode() == GetHashCode();
+            return GetHashCode() == obj?.GetHashCode();
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace RepoDb.Requests
         /// <returns>True if the instances are equal.</returns>
         public bool Equals(UpdateRequest other)
         {
-            return other?.GetHashCode() == GetHashCode();
+            return GetHashCode() == other?.GetHashCode();
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace RepoDb.Requests
             {
                 return ReferenceEquals(null, objB);
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA?.GetHashCode() == objB?.GetHashCode();
         }
 
         /// <summary>


### PR DESCRIPTION
Hi Mike,
Here's the pull request for the enum changes discussed in #107, along with various other performance tweaks I've made in the same area.

I haven't benchmarked any of this, so can't be sure if any of them make a material difference to performance. I suspect the StringBuilder changes would at least move the needle slightly, but it's worth playing with the value of INITIAL_STRINGBUILDER_CAPACITY to find a sensible default for 'typical' workloads.

Let me know if you have any questions.

__Enum changes__

 * Use int in place of short for Conjunction, Operation and Order enums and assign hash values to them directly, removing the need to call GetHashCode() on them at runtime.

__Various null-checking improvements__

 * Remove redundant null checks from equality methods and perform remaining null-checking early to short-circuit some more GetHashCode() calls.

__QueryBuilder changes__

 * Increase the initial size of the QueryBuilder StringBuilder buffer.
 * Avoid a length comparison every time we append to StringBuilder. Instead, remove the leading space only when we finally convert back to a string.
 * Use StringBuilder.AppendLine in place of a hard-coded "\n".

__TODO__
 * Tune initial StringBuilder buffer size to balance memory usage vs. performance.
 * Abstract the common equality methods out to BaseRequest.