### PR TITLE
Revert "Combine hash values by XORing them together rather than ADDing them."

### DIFF
--- a/RepoDb/RepoDb/OrderField.cs
+++ b/RepoDb/RepoDb/OrderField.cs
@@ -140,7 +140,7 @@ namespace RepoDb
         /// <returns>The hashcode value.</returns>
         public override int GetHashCode()
         {
-            return Name.GetHashCode() ^ (int)Order;
+            return Name.GetHashCode() + (int)Order;
         }
 
         /// <summary>

--- a/RepoDb/RepoDb/QueryField.cs
+++ b/RepoDb/RepoDb/QueryField.cs
@@ -189,25 +189,23 @@ namespace RepoDb
             var hashCode = 0;
 
             // Set in the combination of the properties
-            hashCode ^= Field.GetHashCode();
-            hashCode ^= (int)Operation;
-            hashCode ^= Parameter.GetHashCode();
+            hashCode += (Field.GetHashCode() + (int)Operation + Parameter.GetHashCode());
 
             // The (IS NULL) affects the uniqueness of the object
             if (Operation == Operation.Equal && ReferenceEquals(null, Parameter.Value))
             {
-                hashCode ^= HASHCODE_ISNULL;
+                hashCode += HASHCODE_ISNULL;
             }
             // The (IS NOT NULL) affects the uniqueness of the object
             else if (Operation == Operation.NotEqual && ReferenceEquals(null, Parameter.Value))
             {
-                hashCode ^= HASHCODE_ISNOTNULL;
+                hashCode += HASHCODE_ISNOTNULL;
             }
             // The parameter's length affects the uniqueness of the object
             else if ((Operation == Operation.In || Operation == Operation.NotIn) &&
                 !ReferenceEquals(null, Parameter.Value) && Parameter.Value is Array)
             {
-                hashCode ^= ((Array)Parameter.Value).Length.GetHashCode();
+                hashCode += ((Array)Parameter.Value).Length.GetHashCode();
             }
 
             // Set back the value

--- a/RepoDb/RepoDb/QueryGroup.cs
+++ b/RepoDb/RepoDb/QueryGroup.cs
@@ -929,7 +929,7 @@ namespace RepoDb
             {
                 foreach (var queryField in QueryFields)
                 {
-                    hashCode ^= queryField.GetHashCode();
+                    hashCode += queryField.GetHashCode();
                 }
             }
 
@@ -938,15 +938,15 @@ namespace RepoDb
             {
                 foreach (var queryGroup in QueryGroups)
                 {
-                    hashCode ^= queryGroup.GetHashCode();
+                    hashCode += queryGroup.GetHashCode();
                 }
             }
 
             // Set with conjunction
-            hashCode ^= (int)Conjunction;
+            hashCode += (int)Conjunction;
 
             // Set the IsNot
-            hashCode ^= IsNot.GetHashCode();
+            hashCode += IsNot.GetHashCode();
 
             // Set back the hashcode value
             m_hashCode = hashCode;

--- a/RepoDb/RepoDb/Requests/BatchQueryRequest.cs
+++ b/RepoDb/RepoDb/Requests/BatchQueryRequest.cs
@@ -79,19 +79,19 @@ namespace RepoDb.Requests
             // Add the expression
             if (!ReferenceEquals(null, Where))
             {
-                hashCode ^= Where.GetHashCode();
+                hashCode += Where.GetHashCode();
             }
 
             // Add the filter
             if (!ReferenceEquals(null, Page))
             {
-                hashCode ^= Page.GetHashCode();
+                hashCode += Page.GetHashCode();
             }
 
             // Add the filter
             if (!ReferenceEquals(null, RowsPerBatch))
             {
-                hashCode ^= RowsPerBatch.GetHashCode();
+                hashCode += RowsPerBatch.GetHashCode();
             }
 
             // Add the order fields
@@ -99,14 +99,14 @@ namespace RepoDb.Requests
             {
                 foreach (var orderField in OrderBy)
                 {
-                    hashCode ^= orderField.GetHashCode();
+                    hashCode += orderField.GetHashCode();
                 }
             }
 
             // Add the hints
             if (!ReferenceEquals(null, Hints))
             {
-                hashCode ^= Hints.GetHashCode();
+                hashCode += Hints.GetHashCode();
             }
 
             // Set back the hash code value

--- a/RepoDb/RepoDb/Requests/CountRequest.cs
+++ b/RepoDb/RepoDb/Requests/CountRequest.cs
@@ -56,13 +56,13 @@ namespace RepoDb.Requests
             // Get the properties hash codes
             if (Where != null)
             {
-                hashCode ^= Where.GetHashCode();
+                hashCode += Where.GetHashCode();
             }
 
             // Add the hints
             if (!ReferenceEquals(null, Hints))
             {
-                hashCode ^= Hints.GetHashCode();
+                hashCode += Hints.GetHashCode();
             }
 
             // Set back the hash code value

--- a/RepoDb/RepoDb/Requests/DeleteRequest.cs
+++ b/RepoDb/RepoDb/Requests/DeleteRequest.cs
@@ -49,7 +49,7 @@ namespace RepoDb.Requests
             // Get the properties hash codes
             if (Where != null)
             {
-                hashCode ^= Where.GetHashCode();
+                hashCode += Where.GetHashCode();
             }
 
             // Set back the hash code value

--- a/RepoDb/RepoDb/Requests/InlineInsertRequest.cs
+++ b/RepoDb/RepoDb/Requests/InlineInsertRequest.cs
@@ -52,7 +52,7 @@ namespace RepoDb.Requests
             {
                 foreach (var field in Fields)
                 {
-                    hashCode ^= field.GetHashCode();
+                    hashCode += field.GetHashCode();
                 }
             }
 

--- a/RepoDb/RepoDb/Requests/InlineMergeRequest.cs
+++ b/RepoDb/RepoDb/Requests/InlineMergeRequest.cs
@@ -60,7 +60,7 @@ namespace RepoDb.Requests
             {
                 foreach (var field in Fields)
                 {
-                    hashCode ^= field.GetHashCode();
+                    hashCode += field.GetHashCode();
                 }
             }
 
@@ -69,7 +69,7 @@ namespace RepoDb.Requests
             {
                 foreach (var field in Qualifiers)
                 {
-                    hashCode ^= field.GetHashCode();
+                    hashCode += field.GetHashCode();
                 }
             }
 

--- a/RepoDb/RepoDb/Requests/InlineUpdateRequest.cs
+++ b/RepoDb/RepoDb/Requests/InlineUpdateRequest.cs
@@ -58,7 +58,7 @@ namespace RepoDb.Requests
             // Get the expression hashcode
             if (Where != null)
             {
-                hashCode ^= Where.GetHashCode();
+                hashCode += Where.GetHashCode();
             }
 
             // Get the qualifier fields
@@ -66,7 +66,7 @@ namespace RepoDb.Requests
             {
                 foreach (var field in Fields)
                 {
-                    hashCode ^= field.GetHashCode();
+                    hashCode += field.GetHashCode();
                 }
             }
 

--- a/RepoDb/RepoDb/Requests/MergeRequest.cs
+++ b/RepoDb/RepoDb/Requests/MergeRequest.cs
@@ -52,7 +52,7 @@ namespace RepoDb.Requests
             {
                 foreach (var field in Qualifiers)
                 {
-                    hashCode ^= field.GetHashCode();
+                    hashCode += field.GetHashCode();
                 }
             }
 

--- a/RepoDb/RepoDb/Requests/QueryMultipleRequest.cs
+++ b/RepoDb/RepoDb/Requests/QueryMultipleRequest.cs
@@ -79,13 +79,13 @@ namespace RepoDb.Requests
             // Add the index
             if (!ReferenceEquals(null, Index))
             {
-                hashCode ^= Index.GetHashCode();
+                hashCode += Index.GetHashCode();
             }
 
             // Add the expression
             if (!ReferenceEquals(null, Where))
             {
-                hashCode ^= Where.GetHashCode();
+                hashCode += Where.GetHashCode();
             }
 
             // Add the order fields
@@ -93,20 +93,20 @@ namespace RepoDb.Requests
             {
                 foreach (var orderField in OrderBy)
                 {
-                    hashCode ^= orderField.GetHashCode();
+                    hashCode += orderField.GetHashCode();
                 }
             }
 
             // Add the filter
             if (!ReferenceEquals(null, Top))
             {
-                hashCode ^= Top.GetHashCode();
+                hashCode += Top.GetHashCode();
             }
 
             // Add the hints
             if (!ReferenceEquals(null, Hints))
             {
-                hashCode ^= Hints.GetHashCode();
+                hashCode += Hints.GetHashCode();
             }
 
             // Set back the hash code value

--- a/RepoDb/RepoDb/Requests/QueryRequest.cs
+++ b/RepoDb/RepoDb/Requests/QueryRequest.cs
@@ -72,7 +72,7 @@ namespace RepoDb.Requests
             // Add the expression
             if (!ReferenceEquals(null, Where))
             {
-                hashCode ^= Where.GetHashCode();
+                hashCode += Where.GetHashCode();
             }
 
             // Add the order fields
@@ -80,20 +80,20 @@ namespace RepoDb.Requests
             {
                 foreach (var orderField in OrderBy)
                 {
-                    hashCode ^= orderField.GetHashCode();
+                    hashCode += orderField.GetHashCode();
                 }
             }
 
             // Add the filter
             if (!ReferenceEquals(null, Top))
             {
-                hashCode ^= Top.GetHashCode();
+                hashCode += Top.GetHashCode();
             }
 
             // Add the hints
             if (!ReferenceEquals(null, Hints))
             {
-                hashCode ^= Hints.GetHashCode();
+                hashCode += Hints.GetHashCode();
             }
 
             // Set back the hash code value

--- a/RepoDb/RepoDb/Requests/UpdateRequest.cs
+++ b/RepoDb/RepoDb/Requests/UpdateRequest.cs
@@ -49,7 +49,7 @@ namespace RepoDb.Requests
             // Get the properties hash codes
             if (Where != null)
             {
-                hashCode ^= Where.GetHashCode();
+                hashCode += Where.GetHashCode();
             }
 
             // Set back the hash code value


### PR DESCRIPTION
Reverts mikependon/RepoDb#119 - build is failing on my development environment. The collisions are happening because of XOR. Wonder why the AppVeyor has succeed before even I committed the changes.