### PR TITLE
Update to MySqlConnector 1.0

### DIFF
--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/DbHelperTests.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/DbHelperTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/EnumTests.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/EnumTests.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Attributes;
 using RepoDb.Extensions;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/AverageAllTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/AverageAllTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 using System;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/AverageTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/AverageTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Enumerations;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/BatchQueryTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/BatchQueryTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Extensions;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/CountAllTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/CountAllTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 using System;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/CountTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/CountTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Enumerations;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/DeleteAllTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/DeleteAllTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 using System.Linq;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/DeleteTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/DeleteTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Enumerations;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/ExecuteNonQueryTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/ExecuteNonQueryTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 using System.Linq;
 

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/ExecuteQueryMultipleTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/ExecuteQueryMultipleTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Extensions;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/ExecuteQueryTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/ExecuteQueryTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Extensions;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/ExecuteReaderTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/ExecuteReaderTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Extensions;
 using RepoDb.Reflection;
 using RepoDb.MySqlConnector.IntegrationTests.Models;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/ExecuteScalarTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/ExecuteScalarTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 using System;
 using System.Linq;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/ExistsTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/ExistsTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Enumerations;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/InsertAllTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/InsertAllTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 using System.Linq;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/InsertTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/InsertTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 using System;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MaxAllTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MaxAllTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 using System;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MaxTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MaxTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Enumerations;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MergeAllTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MergeAllTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Extensions;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 using RepoDb.MySqlConnector.IntegrationTests.Models;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MergeTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MergeTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 using System;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MinAllTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MinAllTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 using System;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MinTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MinTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Enumerations;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/QueryAllTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/QueryAllTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Extensions;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/QueryMultipleTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/QueryMultipleTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Extensions;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/QueryTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/QueryTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Extensions;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/SumAllTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/SumAllTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 using System;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/SumTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/SumTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Enumerations;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/TruncateTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/TruncateTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/UpdateAllTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/UpdateAllTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Extensions;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/UpdateTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/UpdateTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;
 using System.Linq;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/RepoDb.MySqlConnector.IntegrationTests.csproj
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/RepoDb.MySqlConnector.IntegrationTests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="MySqlConnector" Version="0.66.0" />
+    <PackageReference Include="MySqlConnector" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Setup/Database.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Setup/Database.cs
@@ -1,5 +1,5 @@
 ﻿using RepoDb.MySqlConnector.IntegrationTests.Models;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using System;
 using System.Collections.Generic;
 

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/TransactionTests.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/TransactionTests.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Enumerations;
 using RepoDb.MySqlConnector.IntegrationTests.Models;
 using RepoDb.MySqlConnector.IntegrationTests.Setup;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/DbSettingTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/DbSettingTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace RepoDb.MySqlConnector.UnitTests
 {

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/MappingTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/MappingTest.cs
@@ -1,5 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace RepoDb.MySqlConnector.UnitTests
 {

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/QuotationTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/QuotationTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Extensions;
 
 namespace RepoDb.MySqlConnector.UnitTests

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/Resolvers/MySqlDbTypeToMySqlStringNameResolverTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/Resolvers/MySqlDbTypeToMySqlStringNameResolverTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Resolvers;
 
 namespace RepoDb.MySqlConnector.UnitTests.Resolvers

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/StatementBuilderTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/StatementBuilderTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using RepoDb.Enumerations;
 using RepoDb.Exceptions;
 using System;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector/Attributes/MySqlConnectorTypeMapAttribute.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector/Attributes/MySqlConnectorTypeMapAttribute.cs
@@ -1,4 +1,4 @@
-﻿using MySql.Data.MySqlClient;
+﻿using MySqlConnector;
 using System;
 
 namespace RepoDb.Attributes

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector/DbHelpers/MySqlConnectorDbHelper.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector/DbHelpers/MySqlConnectorDbHelper.cs
@@ -1,4 +1,4 @@
-﻿using MySql.Data.MySqlClient;
+﻿using MySqlConnector;
 using RepoDb.Extensions;
 using RepoDb.Interfaces;
 using RepoDb.Resolvers;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector/DbSettings/MySqlConnectorDbSetting.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector/DbSettings/MySqlConnectorDbSetting.cs
@@ -1,4 +1,4 @@
-﻿using MySql.Data.MySqlClient;
+﻿using MySqlConnector;
 using RepoDb.DbSettings;
 
 namespace RepoDb.MySqlConnector.DbSettings

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector/MySqlBootstrap.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector/MySqlBootstrap.cs
@@ -1,4 +1,4 @@
-﻿using MySql.Data.MySqlClient;
+﻿using MySqlConnector;
 using RepoDb.DbHelpers;
 using RepoDb.MySqlConnector.DbSettings;
 using RepoDb.StatementBuilders;

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector/RepoDb.MySqlConnector.csproj
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector/RepoDb.MySqlConnector.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySqlConnector" Version="0.66.0" />
+    <PackageReference Include="MySqlConnector" Version="1.0.0" />
     <PackageReference Include="RepoDb" Version="1.11.3" />
   </ItemGroup>
 

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector/Resolvers/MySqlConnectorDbTypeToMySqlStringNameResolver.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector/Resolvers/MySqlConnectorDbTypeToMySqlStringNameResolver.cs
@@ -1,4 +1,4 @@
-﻿using MySql.Data.MySqlClient;
+﻿using MySqlConnector;
 using RepoDb.Interfaces;
 using System.Data;
 

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector/StatementBuilders/MySqlConnectorStatementBuilder.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector/StatementBuilders/MySqlConnectorStatementBuilder.cs
@@ -1,4 +1,4 @@
-﻿using MySql.Data.MySqlClient;
+﻿using MySqlConnector;
 using RepoDb.Exceptions;
 using RepoDb.Extensions;
 using RepoDb.Interfaces;


### PR DESCRIPTION
MySqlConnector 1.0 will change the namespace of the library.

This PR shouldn't be merged until MySqlConnector 1.0 (stable) is released, but I'm opening it now to start the conversation.