### PR TITLE
Create benchmarks using BenchmarkDotNet

### DIFF
--- a/RepoDb.Benchmarks/RepoDb.Benchmarks.sln
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30320.27
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RepoDb.Benchmarks", "RepoDb.Benchmarks\RepoDb.Benchmarks.csproj", "{D5C8C45A-FD4A-4F72-8B60-EBFB771027F2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RepoDb.SqlServer", "..\RepoDb.SqlServer\RepoDb.SqlServer\RepoDb.SqlServer.csproj", "{6D196ABF-4A38-43C1-8D31-2C5CECC0F2AF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RepoDb", "..\RepoDb.Core\RepoDb\RepoDb.csproj", "{9313409F-467E-40D7-874E-9105BBDDFA53}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D5C8C45A-FD4A-4F72-8B60-EBFB771027F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5C8C45A-FD4A-4F72-8B60-EBFB771027F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5C8C45A-FD4A-4F72-8B60-EBFB771027F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5C8C45A-FD4A-4F72-8B60-EBFB771027F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D196ABF-4A38-43C1-8D31-2C5CECC0F2AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D196ABF-4A38-43C1-8D31-2C5CECC0F2AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D196ABF-4A38-43C1-8D31-2C5CECC0F2AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D196ABF-4A38-43C1-8D31-2C5CECC0F2AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9313409F-467E-40D7-874E-9105BBDDFA53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9313409F-467E-40D7-874E-9105BBDDFA53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9313409F-467E-40D7-874E-9105BBDDFA53}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9313409F-467E-40D7-874E-9105BBDDFA53}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5229CEA0-E4C0-482B-8BC3-FD9C540F583C}
+	EndGlobalSection
+EndGlobal

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/BenchmarkConfig.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/BenchmarkConfig.cs
@@ -1,0 +1,39 @@
+﻿using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Order;
+
+namespace RepoDb.Benchmarks
+{
+    public class BenchmarkConfig : ManualConfig
+    {
+        public BenchmarkConfig()
+        {
+            AddLogger(ConsoleLogger.Default);
+            AddExporter(MarkdownExporter.GitHub);
+            AddDiagnoser(MemoryDiagnoser.Default);
+
+            AddColumn(TargetMethodColumn.Method);
+            AddColumn(StatisticColumn.Mean);
+            AddColumn(StatisticColumn.StdDev);
+            AddColumn(StatisticColumn.Error);
+            AddColumn(BaselineRatioColumn.RatioMean);
+
+            AddColumnProvider(DefaultColumnProviders.Metrics);
+
+            var job = Job.ShortRun
+                .WithLaunchCount(1)
+                .WithWarmupCount(2)
+                .WithUnrollFactor(500)
+                .WithIterationCount(10);
+
+            AddJob(job);
+
+            Orderer = new DefaultOrderer(SummaryOrderPolicy.FastestToSlowest);
+            Options |= ConfigOptions.JoinSummary;
+        }
+    }
+}

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/Models/EFCoreContext.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/Models/EFCoreContext.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace RepoDb.Benchmarks.Models
+{
+    public class EFCoreContext : DbContext
+    {
+        private readonly string connectionString;
+
+        public EFCoreContext(string connectionString)
+        {
+            this.connectionString = connectionString;
+        }
+
+        public DbSet<Person> Persons { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseSqlServer(connectionString);
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Person>()
+                .ToTable("Person");
+        }
+    }
+}

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/Models/Person.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/Models/Person.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace RepoDb.Benchmarks.Models
+{
+    public class Person
+    {
+        public virtual long Id { get; set; }
+        public virtual string Name { get; set; }
+        public virtual int Age { get; set; }
+        public virtual DateTime CreatedDateUtc { get; set; }
+    }
+}

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/Models/PersonMap.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/Models/PersonMap.cs
@@ -1,0 +1,15 @@
+﻿using NHibernate.Mapping.ByCode.Conformist;
+
+namespace RepoDb.Benchmarks.Models
+{
+    public class PersonMap : ClassMapping<Person>
+    {
+        public PersonMap()
+        {
+            Id(x => x.Id);
+            Property(x => x.Name);
+            Property(x => x.Age);
+            Property(x => x.CreatedDateUtc);
+        }
+    }
+}

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/Program.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/Program.cs
@@ -1,0 +1,16 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace RepoDb.Benchmarks
+{
+    internal static class Program
+    {
+        private static void Main(string[] args)
+        {
+            var switcher = new BenchmarkSwitcher(typeof(BenchmarkConfig).Assembly);
+            switcher.RunAll(new BenchmarkConfig());
+
+            //For single run.
+            //switcher.Run(args, new BenchmarkConfig());
+        }
+    }
+}

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/RepoDb.Benchmarks.csproj
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/RepoDb.Benchmarks.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="Dapper" Version="2.0.35" />
+    <PackageReference Include="Dapper.Contrib" Version="2.0.35" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.6" />
+    <PackageReference Include="NHibernate" Version="5.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\RepoDb.SqlServer\RepoDb.SqlServer\RepoDb.SqlServer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/BaseBenchmark.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/BaseBenchmark.cs
@@ -1,0 +1,31 @@
+﻿using BenchmarkDotNet.Attributes;
+using RepoDb.Benchmarks.SqlServer.Setup;
+
+namespace RepoDb.Benchmarks.SqlServer
+{
+    public abstract class BaseBenchmark
+    {
+        protected int CurrentId;
+
+        protected void BaseSetup()
+        {
+            DatabaseHelper.Initialize(5000);
+        }
+
+        protected void IncreaseId()
+        {
+            CurrentId++;
+
+            if (CurrentId > 5000)
+            {
+                CurrentId = 1;
+            }
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            DatabaseHelper.Cleanup();
+        }
+    }
+}

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/DapperBenchmarks.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/DapperBenchmarks.cs
@@ -1,0 +1,42 @@
+﻿using System.Data;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Dapper;
+using RepoDb.Benchmarks.Models;
+using RepoDb.Benchmarks.SqlServer.Setup;
+
+namespace RepoDb.Benchmarks.SqlServer
+{
+    public class DapperBenchmarks : BaseBenchmark
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            BaseSetup();
+        }
+
+        [Benchmark(Description = "Dapper 2.0.35: FirstAsync")]
+        public async Task<Person> FirstAsync()
+        {
+            IncreaseId();
+
+            using IDbConnection connection = new SqlConnection(DatabaseHelper.ConnectionString);
+            connection.Open();
+
+            return await connection.QueryFirstOrDefaultAsync<Person>("select * from Person where Id = @Id",
+                new {Id = CurrentId});
+        }
+
+        [Benchmark(Description = "Dapper 2.0.35: First")]
+        public Person First()
+        {
+            IncreaseId();
+
+            using IDbConnection connection = new SqlConnection(DatabaseHelper.ConnectionString);
+            connection.Open();
+
+            return connection.QueryFirstOrDefault<Person>("select * from Person where Id = @Id", new {Id = CurrentId});
+        }
+    }
+}

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/EFCoreBenchmarks .cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/EFCoreBenchmarks .cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.EntityFrameworkCore;
+using RepoDb.Benchmarks.Models;
+using RepoDb.Benchmarks.SqlServer.Setup;
+
+namespace RepoDb.Benchmarks.SqlServer
+{
+    public class EFCoreBenchmarks : BaseBenchmark
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            BaseSetup();
+        }
+
+        [Benchmark(Description = "EFCore 3.1.6: FirstAsync")]
+        public async Task<Person> FirstAsync()
+        {
+            IncreaseId();
+
+            await using var context = new EFCoreContext(DatabaseHelper.ConnectionString);
+
+            return await context.Persons.FirstAsync(x => x.Id == CurrentId);
+        }
+
+        [Benchmark(Description = "EFCore 3.1.6: First")]
+        public Person First()
+        {
+            IncreaseId();
+
+            using var context = new EFCoreContext(DatabaseHelper.ConnectionString);
+
+            return context.Persons.First(x => x.Id == CurrentId);
+        }
+    }
+}

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/NHibernateBenchmarks.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/NHibernateBenchmarks.cs
@@ -1,0 +1,58 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using NHibernate;
+using NHibernate.Cfg;
+using NHibernate.Dialect;
+using NHibernate.Linq;
+using NHibernate.Mapping.ByCode;
+using RepoDb.Benchmarks.Models;
+using RepoDb.Benchmarks.SqlServer.Setup;
+
+namespace RepoDb.Benchmarks.SqlServer
+{
+    public class NHibernateBenchmarks : BaseBenchmark
+    {
+        private ISessionFactory sessionFactory;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            BaseSetup();
+
+            var configuration = new Configuration();
+            configuration.DataBaseIntegration(properties =>
+            {
+                properties.Dialect<MsSql2005Dialect>();
+                properties.ConnectionString = DatabaseHelper.ConnectionString;
+            });
+
+            var mapper = new ModelMapper();
+            mapper.AddMapping<PersonMap>();
+            var mapping = mapper.CompileMappingForAllExplicitlyAddedEntities();
+            configuration.AddMapping(mapping);
+
+            sessionFactory = configuration.BuildSessionFactory();
+        }
+
+        [Benchmark(Description = "NHibernate 5.3.1: FirstAsync")]
+        public async Task<Person> FirstAsync()
+        {
+            IncreaseId();
+
+            using IStatelessSession session = sessionFactory.OpenStatelessSession();
+
+            return await session.Query<Person>().FirstAsync(x => x.Id == CurrentId);
+        }
+
+        [Benchmark(Description = "NHibernate 5.3.1: First")]
+        public Person First()
+        {
+            IncreaseId();
+
+            using IStatelessSession session = sessionFactory.OpenStatelessSession();
+
+            return session.Query<Person>().First(x => x.Id == CurrentId);
+        }
+    }
+}

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/RepoDbBenchmarks.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/RepoDbBenchmarks.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using RepoDb.Benchmarks.Models;
+using RepoDb.Benchmarks.SqlServer.Setup;
+
+namespace RepoDb.Benchmarks.SqlServer
+{
+    public class RepoDbBenchmarks : BaseBenchmark
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            BaseSetup();
+
+            SqlServerBootstrap.Initialize();
+            TypeMapper.Add(typeof(DateTime), DbType.DateTime2, true);
+        }
+
+        [Benchmark(Description = "RepoDb: FirstAsync")]
+        public async Task<Person> FirstAsync()
+        {
+            IncreaseId();
+
+            using IDbConnection connection = await new SqlConnection(DatabaseHelper.ConnectionString).EnsureOpenAsync();
+            var person = await connection.QueryAsync<Person>(x => x.Id == CurrentId);
+
+            return person.First();
+        }
+
+        [Benchmark(Description = "RepoDb: First")]
+        public Person First()
+        {
+            IncreaseId();
+
+            using IDbConnection connection = new SqlConnection(DatabaseHelper.ConnectionString).EnsureOpen();
+
+            return connection.Query<Person>(x => x.Id == CurrentId).First();
+        }
+    }
+}

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/Setup/DatabaseHelper.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/Setup/DatabaseHelper.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using Microsoft.Data.SqlClient;
+
+namespace RepoDb.Benchmarks.SqlServer.Setup
+{
+    public static class DatabaseHelper
+    {
+        public static string ConnectionString { get; private set; }
+
+        public static void Initialize(int elementsCount)
+        {
+            var connectionString = Environment.GetEnvironmentVariable("REPODB_CONSTR", EnvironmentVariableTarget.Process);
+
+            ConnectionString = connectionString ?? @"Server=(local);Database=RepoDbTest;Integrated Security=False;User Id=michael;Password=Password123;";
+
+            CreateDatabase();
+            CreatePersonTable();
+            FillData(elementsCount);
+        }
+
+        private static void FillData(int elementsCount)
+        {
+            const string commandText = @"DECLARE @i INT = 1;
+	            WHILE @i <= @elementsCount
+                BEGIN
+                    INSERT INTO [dbo].[Person] (Name, Age, CreatedDateUtc) 
+                    VALUES (REPLICATE('x', 128), @i, GETDATE());
+                    Set @i = @i + 1;
+                END";
+
+            using var connection = new SqlConnection(ConnectionString);
+
+            var command = new SqlCommand(commandText, connection);
+            command.Parameters.AddWithValue("@elementsCount", elementsCount);
+
+            connection.Open();
+            command.ExecuteNonQuery();
+        }
+
+        public static void Cleanup()
+        {
+            const string commandText = "TRUNCATE TABLE [dbo].[Person];";
+
+            using var connection = new SqlConnection(ConnectionString);
+
+            connection.Open();
+            connection.ExecuteNonQuery(commandText);
+        }
+
+        private static void CreateDatabase()
+        {
+            const string commandText = @"IF (NOT EXISTS(SELECT * FROM sys.databases WHERE name = 'RepoDbTest'))
+                BEGIN
+	                CREATE DATABASE [RepoDbTest];
+                END";
+
+            using var connection = new SqlConnection(ConnectionString);
+
+            connection.Open();
+            connection.ExecuteNonQuery(commandText);
+        }
+
+        private static void CreatePersonTable()
+        {
+            const string commandText = @"IF (NOT EXISTS(SELECT * FROM sys.tables WHERE name = 'Person'))
+                BEGIN
+                    CREATE TABLE [dbo].[Person]
+                    (
+	                    [Id] [bigint] IDENTITY(1,1) NOT NULL,
+	                    [Name] [nvarchar](128) NOT NULL,
+	                    [Age] [int] NOT NULL,
+	                    [CreatedDateUtc] [datetime2](5) NOT NULL,
+	                    CONSTRAINT [CRIX_Person_Id] PRIMARY KEY CLUSTERED ([Id] ASC) ON [PRIMARY]
+                    )
+                    ON [PRIMARY];
+                END";
+
+            using var connection = new SqlConnection(ConnectionString);
+
+            connection.Open();
+            connection.ExecuteNonQuery(commandText);
+        }
+    }
+}


### PR DESCRIPTION
I think we can start writing performance tests.
These are the first results. And I think performance can be improved.

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.17134.1304 (1803/April2018Update/Redstone4)
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.302
  [Host]   : .NET Core 3.1.6 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.31603), X64 RyuJIT
  ShortRun : .NET Core 3.1.6 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.31603), X64 RyuJIT


```
|                         Method |     Mean |   StdDev |     Error |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------------------- |---------:|---------:|----------:|--------:|-------:|------:|----------:|
|         &#39;Dapper 2.0.35: First&#39; | 122.7 μs |  7.70 μs |  14.73 μs |  1.1250 | 0.3750 |     - |   4.64 KB |
|                &#39;RepoDb: First&#39; | 152.4 μs |  7.54 μs |  14.41 μs |  2.0000 | 0.5000 |     - |   8.71 KB |
|    &#39;Dapper 2.0.35: FirstAsync&#39; | 152.9 μs | 12.43 μs |  18.79 μs |  1.7500 | 0.5000 |     - |   7.55 KB |
|           &#39;RepoDb: FirstAsync&#39; | 197.2 μs |  9.09 μs |  15.27 μs |  2.7500 | 0.7500 |     - |   11.6 KB |
|          &#39;EFCore 3.1.6: First&#39; | 624.2 μs | 48.45 μs |  73.25 μs |  9.0000 | 1.0000 |     - |  38.97 KB |
|     &#39;EFCore 3.1.6: FirstAsync&#39; | 708.4 μs | 80.28 μs | 121.37 μs | 10.0000 | 1.0000 |     - |  42.93 KB |
|      &#39;NHibernate 5.3.1: First&#39; | 879.2 μs | 37.40 μs |  62.85 μs | 12.0000 | 2.0000 |     - |  49.24 KB |
| &#39;NHibernate 5.3.1: FirstAsync&#39; | 966.3 μs | 80.31 μs | 134.95 μs | 12.0000 | 2.0000 |     - |  52.53 KB |

