### PR TITLE
Added more cases for benchmarks

### DIFF
--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/Configurations/BenchmarkConfig.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/Configurations/BenchmarkConfig.cs
@@ -22,8 +22,8 @@ namespace RepoDb.Benchmarks.Configurations
             AddColumn(StatisticColumn.StdDev);
             AddColumn(StatisticColumn.Error);
             AddColumn(BaselineRatioColumn.RatioMean);
-            AddColumn(StatisticColumn.Max);
             AddColumn(StatisticColumn.Min);
+            AddColumn(StatisticColumn.Max);
 
             AddColumnProvider(DefaultColumnProviders.Metrics);
 

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/DapperBenchmarks.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/DapperBenchmarks.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Data;
 using System.Data.SqlClient;
-using System.Threading.Tasks;
+using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Dapper;
 using RepoDb.Benchmarks.Models;
@@ -16,22 +16,31 @@ namespace RepoDb.Benchmarks.SqlServer
         public void Setup() => BaseSetup();
 
         [Benchmark]
-        public async Task<Person> FirstAsync()
+        public Person QueryFirst()
         {
             using IDbConnection connection = new SqlConnection(DatabaseHelper.ConnectionString);
             connection.Open();
 
-            return await connection.QueryFirstOrDefaultAsync<Person>("select * from Person where Id = @Id",
-                new {Id = CurrentId});
+            var param = new
+            {
+                Id = CurrentId
+            };
+
+            return connection.QueryFirst<Person>("select * from Person where Id = @Id", param);
         }
 
         [Benchmark]
-        public Person First()
+        public Person QueryLinqFirst()
         {
             using IDbConnection connection = new SqlConnection(DatabaseHelper.ConnectionString);
             connection.Open();
 
-            return connection.QueryFirstOrDefault<Person>("select * from Person where Id = @Id", new {Id = CurrentId});
+            var param = new
+            {
+                Id = CurrentId
+            };
+
+            return connection.Query<Person>("select * from Person where Id = @Id", param, buffered: true).First();
         }
     }
 }

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/EFCoreBenchmarks .cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/EFCoreBenchmarks .cs
@@ -1,6 +1,5 @@
 ﻿using System.ComponentModel;
 using System.Linq;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.EntityFrameworkCore;
 using RepoDb.Benchmarks.Models;
@@ -15,19 +14,27 @@ namespace RepoDb.Benchmarks.SqlServer
         public void Setup() => BaseSetup();
 
         [Benchmark]
-        public async Task<Person> FirstAsync()
-        {
-            await using var context = new EFCoreContext(DatabaseHelper.ConnectionString);
-
-            return await context.Persons.FirstAsync(x => x.Id == CurrentId);
-        }
-
-        [Benchmark]
         public Person First()
         {
             using var context = new EFCoreContext(DatabaseHelper.ConnectionString);
 
             return context.Persons.First(x => x.Id == CurrentId);
+        }
+
+        [Benchmark]
+        public Person NoTrackingFirst()
+        {
+            using var context = new EFCoreContext(DatabaseHelper.ConnectionString);
+
+            return context.Persons.AsNoTracking().First(x => x.Id == CurrentId);
+        }
+
+        [Benchmark]
+        public Person FromSqlRawFirst()
+        {
+            using var context = new EFCoreContext(DatabaseHelper.ConnectionString);
+
+            return context.Persons.FromSqlRaw("select * from Person where Id = {0}", CurrentId).First();
         }
     }
 }

--- a/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/RepoDbBenchmarks.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks/SqlServer/RepoDbBenchmarks.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
-using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using RepoDb.Benchmarks.Models;
 using RepoDb.Benchmarks.SqlServer.Setup;
@@ -23,20 +22,45 @@ namespace RepoDb.Benchmarks.SqlServer
         }
 
         [Benchmark]
-        public async Task<Person> FirstAsync()
-        {
-            using IDbConnection connection = await new SqlConnection(DatabaseHelper.ConnectionString).EnsureOpenAsync();
-            var person = await connection.QueryAsync<Person>(x => x.Id == CurrentId);
-
-            return person.First();
-        }
-
-        [Benchmark]
-        public Person First()
+        public Person QueryLinqFirst()
         {
             using IDbConnection connection = new SqlConnection(DatabaseHelper.ConnectionString).EnsureOpen();
 
             return connection.Query<Person>(x => x.Id == CurrentId).First();
+        }
+
+        [Benchmark]
+        public Person QueryDynamicFirst()
+        {
+            using IDbConnection connection = new SqlConnection(DatabaseHelper.ConnectionString).EnsureOpen();
+
+            return connection.Query<Person>(new { Id = CurrentId }).First();
+        }
+
+        [Benchmark]
+        public Person QueryObjectsFirst()
+        {
+            using IDbConnection connection = new SqlConnection(DatabaseHelper.ConnectionString).EnsureOpen();
+
+            QueryField[] where =
+            {
+                new QueryField(nameof(Person.Id), CurrentId)
+            };
+
+            return connection.Query<Person>(where).First();
+        }
+
+        [Benchmark]
+        public Person ExecuteQueryFirst()
+        {
+            using IDbConnection connection = new SqlConnection(DatabaseHelper.ConnectionString).EnsureOpen();
+
+            var param = new
+            {
+                Id = CurrentId
+            };
+
+            return connection.ExecuteQuery<Person>("select * from Person where Id = @Id", param).First();
         }
     }
 }


### PR DESCRIPTION
And now we have...

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.17134.1304 (1803/April2018Update/Redstone4)
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=5.0.100-preview.7.20366.6
  [Host]   : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
  ShortRun : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT


```
|              ORM |              Method |     Mean |   StdDev |    Error |      Min |      Max |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
|----------------- |-------------------- |---------:|---------:|---------:|---------:|---------:|--------:|-------:|------:|----------:|
|    Dapper 2.0.35 |          QueryFirst | 110.0 μs |  3.92 μs |  5.93 μs | 103.0 μs | 116.2 μs |  1.1250 | 0.3750 |     - |   4.64 KB |
|    Dapper 2.0.35 |      QueryLinqFirst | 117.2 μs |  4.41 μs |  7.41 μs | 110.0 μs | 122.9 μs |  1.1250 | 0.3750 |     - |   4.94 KB |
|           RepoDb |   ExecuteQueryFirst | 126.1 μs |  3.81 μs |  6.41 μs | 118.1 μs | 130.4 μs |  1.2500 | 0.2500 |     - |   5.44 KB |
|           RepoDb |   QueryObjectsFirst | 131.5 μs |  5.81 μs |  8.79 μs | 124.1 μs | 138.5 μs |  1.7500 | 0.5000 |     - |   7.53 KB |
|           RepoDb |   QueryDynamicFirst | 137.4 μs | 16.54 μs | 27.79 μs | 122.7 μs | 172.6 μs |  1.7500 | 0.5000 |     - |   7.58 KB |
|           RepoDb |      QueryLinqFirst | 148.6 μs |  4.29 μs |  6.49 μs | 143.3 μs | 156.9 μs |  2.0000 | 0.5000 |     - |   8.71 KB |
| NHibernate 5.3.2 | CreateSQLQueryFirst | 228.9 μs | 19.40 μs | 29.33 μs | 210.3 μs | 261.5 μs | 10.5000 | 0.5000 |     - |  43.98 KB |
|     EFCore 3.1.7 |     FromSqlRawFirst | 309.9 μs | 11.65 μs | 19.58 μs | 298.2 μs | 332.8 μs |  9.0000 | 0.5000 |     - |  37.33 KB |
|     EFCore 3.1.7 |     NoTrackingFirst | 552.8 μs | 31.73 μs | 47.97 μs | 513.8 μs | 604.9 μs |  9.0000 | 1.0000 |     - |  39.38 KB |
|     EFCore 3.1.7 |               First | 572.2 μs | 25.17 μs | 42.29 μs | 527.4 μs | 617.6 μs |  9.0000 | 1.0000 |     - |  38.97 KB |
| NHibernate 5.3.2 |          QueryFirst | 781.6 μs | 32.29 μs | 61.73 μs | 737.8 μs | 843.5 μs | 10.0000 | 2.0000 |     - |  47.49 KB |
