### PR TITLE
Bug: Incorrect syntax near the keyword 'WITH' BulkMergeAsync

### DIFF
--- a/RepoDb.Extensions/RepoDb.SqlServer.BulkOperations/RepoDb.SqlServer.BulkOperations/SqlConnectionExtension.cs
+++ b/RepoDb.Extensions/RepoDb.SqlServer.BulkOperations/RepoDb.SqlServer.BulkOperations/SqlConnectionExtension.cs
@@ -523,8 +523,8 @@ namespace RepoDb
                 // MERGE T USING S
                 .Merge()
                 .TableNameFrom(tableName, dbSetting)
-                .As("T")
                 .HintsFrom(hints)
+                .As("T")
                 .Using()
                 .OpenParen()
                 .Select()


### PR DESCRIPTION
Fixes https://github.com/mikependon/RepoDB/issues/640

@mike_pendon
SQL Server with Alias + Hints Syntax:

- INSERT, DELETE, UPDATE has an identical syntax (i.e.: SELECT * FROM Table T WITH (NOLOCK)).

- MERGE has different syntax (MERGE INTO Table WITH (TABLOCK) T).

You cannot just switch that, otherwise you will get a syntax error. 
@SQLServer