### PR TITLE
fix #650 TypeExtension.IsPlainType seems to misjudge the string property

### DIFF
--- a/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Extensions/DbCommandExtensionsTest.cs
+++ b/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Extensions/DbCommandExtensionsTest.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data.SqlClient;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RepoDb.Extensions;
 using RepoDb.Interfaces;
 using RepoDb.UnitTests.CustomObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace RepoDb.UnitTests.Extensions
 {
@@ -200,5 +200,16 @@ namespace RepoDb.UnitTests.Extensions
         #endregion
 
         #endregion
+
+        [TestMethod]
+        public void TestIsPlainTypeForAnoynmousType()
+        {
+            var type = (new { Property = "ABC" }).GetType();
+            Assert.IsTrue(type.IsPlainType());
+            Assert.IsTrue(type.IsAnonymousType());
+            Assert.IsFalse(type.IsQueryObjectType());
+            Assert.IsFalse(type.IsDictionaryStringObject());
+            Assert.IsFalse(type.GetEnumerableClassProperties().Any());
+        }
     }
 }

--- a/RepoDb.Core/RepoDb/Extensions/TypeExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/TypeExtension.cs
@@ -75,7 +75,7 @@ namespace RepoDb.Extensions
         /// </summary>
         /// <param name="type">The current type.</param>
         /// <returns>Returns true if the current type is a plain class type.</returns>
-        public static bool IsPlainType(this Type type) =>
+        internal static bool IsPlainType(this Type type) =>
             (IsClassType(type) || IsAnonymousType(type)) &&
             IsQueryObjectType(type) != true &&
             IsDictionaryStringObject(type) != true &&
@@ -86,7 +86,7 @@ namespace RepoDb.Extensions
         /// </summary>
         /// <param name="type">The curren type.</param>
         /// <returns>Returns true if the current type is of type <see cref="QueryField"/> or <see cref="QueryGroup"/>.</returns>
-        public static bool IsQueryObjectType(this Type type) =>
+        internal static bool IsQueryObjectType(this Type type) =>
             type == StaticType.QueryField || type == StaticType.QueryGroup;
 
         /// <summary>
@@ -102,9 +102,16 @@ namespace RepoDb.Extensions
         /// </summary>
         /// <param name="type">The current type.</param>
         /// <returns>The list of the enumerable <see cref="ClassProperty"/> objects.</returns>
-        public static IEnumerable<ClassProperty> GetEnumerableClassProperties(this Type type) =>
-            PropertyCache.Get(type).Where(classProperty =>
-                StaticType.IEnumerable.IsAssignableFrom(classProperty.PropertyInfo.PropertyType));
+        internal static IEnumerable<ClassProperty> GetEnumerableClassProperties(this Type type) =>
+            PropertyCache.Get(type).Where(classProperty => 
+            {
+                var propType = classProperty.PropertyInfo.PropertyType;
+                return
+                    propType != StaticType.String &&
+                    propType != StaticType.CharArray &&
+                    propType != StaticType.ByteArray &&
+                    StaticType.IEnumerable.IsAssignableFrom(propType);
+            });
 
         /// <summary>
         /// Converts all properties of the type into an array of <see cref="ClassProperty"/> objects.

--- a/RepoDb.Core/RepoDb/RepoDb.csproj
+++ b/RepoDb.Core/RepoDb/RepoDb.csproj
@@ -96,5 +96,11 @@
     </None>
     <None Include="..\.editorconfig" Link=".editorconfig" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>RepoDb.UnitTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
fix for #650

in addition, 
revert `IsPlainType`, `IsQueryObjectType`, and `GetEnumerableClassProperties` to internal.
instead, set InternalsVisibleToAttribute("RepoDb.UnitTests") for unit testing.
