### PR TITLE
Using Converter.EnumDefaultDatabaseType instead of DbType.String

### DIFF
--- a/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
@@ -265,7 +265,7 @@ namespace RepoDb.Extensions
                 // Specialized enum
                 if (dbType == null && isEnum.HasValue && isEnum.Value == true)
                 {
-                    dbType = DbType.String;
+                    dbType = Converter.EnumDefaultDatabaseType;
                 }
 
                 // Add the parameter
@@ -337,7 +337,7 @@ namespace RepoDb.Extensions
                 // Specialized enum
                 if (dbType == null && isEnum.HasValue && isEnum.Value == true)
                 {
-                    dbType = DbType.String;
+                    dbType = Converter.EnumDefaultDatabaseType;
                 }
 
                 // Add the parameter
@@ -466,7 +466,7 @@ namespace RepoDb.Extensions
             // Specialized enum
             if (dbType == null && isEnum.HasValue && isEnum == true)
             {
-                dbType = DbType.String;
+                dbType = Converter.EnumDefaultDatabaseType;
             }
 
             // Add the parameter
@@ -522,7 +522,7 @@ namespace RepoDb.Extensions
                     // Specialized enum
                     if (dbType == null && isEnum.HasValue && isEnum.Value == true)
                     {
-                        dbType = DbType.String;
+                        dbType = Converter.EnumDefaultDatabaseType;
                     }
 
                     // Create
@@ -591,11 +591,11 @@ namespace RepoDb.Extensions
                 // Specialized enum
                 if (leftDbType == null && isLeftEnum.HasValue && isLeftEnum.Value == true)
                 {
-                    leftDbType = DbType.String;
+                    leftDbType = Converter.EnumDefaultDatabaseType;
                 }
                 if (rightDbType == null && isRightEnum.HasValue && isRightEnum.Value == true)
                 {
-                    rightDbType = DbType.String;
+                    rightDbType = Converter.EnumDefaultDatabaseType;
                 }
 
                 // Add

--- a/RepoDb.Core/RepoDb/Reflection/Compiler/PlainTypeToDbParameters.cs
+++ b/RepoDb.Core/RepoDb/Reflection/Compiler/PlainTypeToDbParameters.cs
@@ -48,7 +48,7 @@ namespace RepoDb.Reflection
                 var dbType = classProperty.GetDbType();
                 if (dbType == null && classProperty.PropertyInfo.PropertyType.IsEnum)
                 {
-                    dbType = DbType.String;
+                    dbType = Converter.EnumDefaultDatabaseType;
                 }
                 var dbTypeExpression = dbType == null ? GetNullableTypeExpression(StaticType.DbType) :
                     ConvertExpressionToNullableExpression(Expression.Constant(dbType), StaticType.DbType);


### PR DESCRIPTION
This fixes #667 

Instead of hardcoding the default enum conversion to DbType.String this uses the static property Converter.EnumDefaultDatabaseType so it is possible to change the default value.
