### PR TITLE
fix null parameter being mistaken for the string type

### DIFF
--- a/RepoDb.Core/RepoDb.Tests/RepoDb.IntegrationTests/ExecuteParameterTest.cs
+++ b/RepoDb.Core/RepoDb.Tests/RepoDb.IntegrationTests/ExecuteParameterTest.cs
@@ -202,6 +202,19 @@ namespace RepoDb.IntegrationTests
             }
         }
 
+        [TestMethod]
+        public void TestSqlConnectionExecuteQueryWithParameterAsNullDecimal()
+        {
+            using (var connection = new SqlConnection(Database.ConnectionStringForRepoDb).EnsureOpen())
+            {
+                // Act Query
+                var data = connection.ExecuteQuery<decimal?>("select @value", new { value = (decimal?)null }).First();
+
+                // Assert
+                Assert.IsNull(data);
+            }
+        }
+
         #endregion
 
         #region ExecuteQueryAsync

--- a/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
@@ -268,6 +268,12 @@ namespace RepoDb.Extensions
                     dbType = Converter.EnumDefaultDatabaseType;
                 }
 
+                // DbType fallback
+                if (dbType == null)
+                {
+                    dbType = TypeMapper.GetFallback(classProperty.PropertyInfo.PropertyType);
+                }
+
                 // Add the parameter
                 command.Parameters.Add(command.CreateParameter(name, value, dbType));
             }
@@ -338,6 +344,12 @@ namespace RepoDb.Extensions
                 if (dbType == null && isEnum.HasValue && isEnum.Value == true)
                 {
                     dbType = Converter.EnumDefaultDatabaseType;
+                }
+
+                // DbType fallback
+                if (dbType == null)
+                {
+                    dbType = TypeMapper.GetFallback(classProperty.PropertyInfo.PropertyType);
                 }
 
                 // Add the parameter
@@ -467,6 +479,12 @@ namespace RepoDb.Extensions
             if (dbType == null && isEnum.HasValue && isEnum == true)
             {
                 dbType = Converter.EnumDefaultDatabaseType;
+            }
+
+            // DbType fallback
+            if (dbType == null)
+            {
+                dbType = TypeMapper.GetFallback(classProperty.PropertyInfo.PropertyType);
             }
 
             // Add the parameter

--- a/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
@@ -268,12 +268,6 @@ namespace RepoDb.Extensions
                     dbType = Converter.EnumDefaultDatabaseType;
                 }
 
-                // DbType fallback
-                if (dbType == null)
-                {
-                    dbType = TypeMapper.GetFallback(classProperty.PropertyInfo.PropertyType);
-                }
-
                 // Add the parameter
                 command.Parameters.Add(command.CreateParameter(name, value, dbType));
             }
@@ -344,12 +338,6 @@ namespace RepoDb.Extensions
                 if (dbType == null && isEnum.HasValue && isEnum.Value == true)
                 {
                     dbType = Converter.EnumDefaultDatabaseType;
-                }
-
-                // DbType fallback
-                if (dbType == null)
-                {
-                    dbType = TypeMapper.GetFallback(classProperty.PropertyInfo.PropertyType);
                 }
 
                 // Add the parameter
@@ -479,12 +467,6 @@ namespace RepoDb.Extensions
             if (dbType == null && isEnum.HasValue && isEnum == true)
             {
                 dbType = Converter.EnumDefaultDatabaseType;
-            }
-
-            // DbType fallback
-            if (dbType == null)
-            {
-                dbType = TypeMapper.GetFallback(classProperty.PropertyInfo.PropertyType);
             }
 
             // Add the parameter

--- a/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
@@ -262,6 +262,12 @@ namespace RepoDb.Extensions
                     classProperty.GetDbType() ??
                     value?.GetType()?.GetDbType();
 
+                // Try get fallback dbType by classProperty to avoid being mistaken as string when value is null.
+                if (dbType == null && classProperty != null)
+                {
+                    dbType = clientTypeToDbTypeResolver.Resolve(classProperty.PropertyInfo.PropertyType);
+                }
+
                 // Specialized enum
                 if (dbType == null && isEnum.HasValue && isEnum.Value == true)
                 {
@@ -333,6 +339,12 @@ namespace RepoDb.Extensions
                 var dbType = (valueType != null ? clientTypeToDbTypeResolver.Resolve(valueType) : null) ??
                     classProperty?.GetDbType() ??
                     value?.GetType()?.GetDbType();
+
+                // Try get fallback dbType by classProperty to avoid being mistaken as string when value is null.
+                if (dbType == null && classProperty != null)
+                {
+                    dbType = clientTypeToDbTypeResolver.Resolve(classProperty.PropertyInfo.PropertyType);
+                }
 
                 // Specialized enum
                 if (dbType == null && isEnum.HasValue && isEnum.Value == true)
@@ -462,6 +474,12 @@ namespace RepoDb.Extensions
             var dbType = (valueType != null ? clientTypeToDbTypeResolver.Resolve(valueType) : null) ??
                 classProperty?.GetDbType() ??
                 value?.GetType()?.GetDbType();
+
+            // Try get fallback dbType by classProperty to avoid being mistaken as string when value is null.
+            if (dbType == null && classProperty != null)
+            {
+                dbType = clientTypeToDbTypeResolver.Resolve(classProperty.PropertyInfo.PropertyType);
+            }
 
             // Specialized enum
             if (dbType == null && isEnum.HasValue && isEnum == true)

--- a/RepoDb.Core/RepoDb/Mappers/TypeMapper.cs
+++ b/RepoDb.Core/RepoDb/Mappers/TypeMapper.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Data;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using RepoDb.Exceptions;
@@ -16,6 +19,28 @@ namespace RepoDb
         #region Privates
 
         private static readonly ConcurrentDictionary<int, DbType?> maps = new ConcurrentDictionary<int, DbType?>();
+
+        private static readonly ReadOnlyDictionary<int, DbType> fallbackMaps = new ReadOnlyDictionary<int, DbType>(new Dictionary<Type, DbType>
+        {
+            [typeof(byte)] = DbType.Byte,
+            [typeof(sbyte)] = DbType.SByte,
+            [typeof(short)] = DbType.Int16,
+            [typeof(ushort)] = DbType.UInt16,
+            [typeof(int)] = DbType.Int32,
+            [typeof(uint)] = DbType.UInt32,
+            [typeof(long)] = DbType.Int64,
+            [typeof(ulong)] = DbType.UInt64,
+            [typeof(float)] = DbType.Single,
+            [typeof(double)] = DbType.Double,
+            [typeof(decimal)] = DbType.Decimal,
+            [typeof(bool)] = DbType.Boolean,
+            [typeof(string)] = DbType.String,
+            [typeof(char)] = DbType.StringFixedLength,
+            [typeof(Guid)] = DbType.Guid,
+            [typeof(DateTime)] = DbType.DateTime,
+            [typeof(DateTimeOffset)] = DbType.DateTimeOffset,
+            [typeof(TimeSpan)] = DbType.Time,
+        }.ToDictionary(n => TypeExtension.GenerateHashCode(n.Key), n => n.Value));
 
         #endregion
 
@@ -483,6 +508,14 @@ namespace RepoDb
                 throw new NullReferenceException($"The argument '{argument}' cannot be null.");
             }
         }
+
+        /// <summary>
+        /// Type Level: Gets the fallback mapped <see cref="DbType"/> object of the .NET CLR type.
+        /// </summary>
+        /// <param name="type">The .NET CLR type used for mapping.</param>
+        /// <returns>The instance of the fallback mapped <see cref="DbType"/> object.</returns>
+        internal static DbType? GetFallback(Type type)
+            => fallbackMaps.TryGetValue(TypeExtension.GenerateHashCode(type), out var dbType) ? dbType : (DbType?)null;
 
         #endregion
     }

--- a/RepoDb.Core/RepoDb/Mappers/TypeMapper.cs
+++ b/RepoDb.Core/RepoDb/Mappers/TypeMapper.cs
@@ -20,28 +20,6 @@ namespace RepoDb
 
         private static readonly ConcurrentDictionary<int, DbType?> maps = new ConcurrentDictionary<int, DbType?>();
 
-        private static readonly ReadOnlyDictionary<int, DbType> fallbackMaps = new ReadOnlyDictionary<int, DbType>(new Dictionary<Type, DbType>
-        {
-            [typeof(byte)] = DbType.Byte,
-            [typeof(sbyte)] = DbType.SByte,
-            [typeof(short)] = DbType.Int16,
-            [typeof(ushort)] = DbType.UInt16,
-            [typeof(int)] = DbType.Int32,
-            [typeof(uint)] = DbType.UInt32,
-            [typeof(long)] = DbType.Int64,
-            [typeof(ulong)] = DbType.UInt64,
-            [typeof(float)] = DbType.Single,
-            [typeof(double)] = DbType.Double,
-            [typeof(decimal)] = DbType.Decimal,
-            [typeof(bool)] = DbType.Boolean,
-            [typeof(string)] = DbType.String,
-            [typeof(char)] = DbType.StringFixedLength,
-            [typeof(Guid)] = DbType.Guid,
-            [typeof(DateTime)] = DbType.DateTime,
-            [typeof(DateTimeOffset)] = DbType.DateTimeOffset,
-            [typeof(TimeSpan)] = DbType.Time,
-        }.ToDictionary(n => TypeExtension.GenerateHashCode(n.Key), n => n.Value));
-
         #endregion
 
         #region Type Level
@@ -508,14 +486,6 @@ namespace RepoDb
                 throw new NullReferenceException($"The argument '{argument}' cannot be null.");
             }
         }
-
-        /// <summary>
-        /// Type Level: Gets the fallback mapped <see cref="DbType"/> object of the .NET CLR type.
-        /// </summary>
-        /// <param name="type">The .NET CLR type used for mapping.</param>
-        /// <returns>The instance of the fallback mapped <see cref="DbType"/> object.</returns>
-        internal static DbType? GetFallback(Type type)
-            => fallbackMaps.TryGetValue(TypeExtension.GenerateHashCode(type), out var dbType) ? dbType : (DbType?)null;
 
         #endregion
     }

--- a/RepoDb.Core/RepoDb/Reflection/Compiler/Compiler.cs
+++ b/RepoDb.Core/RepoDb/Reflection/Compiler/Compiler.cs
@@ -1547,6 +1547,17 @@ namespace RepoDb.Reflection
             return Expression.Call(parameterVariableExpression, GetDbParameterValueSetMethod(), expression);
         }
 
+        private static DbType? GetDbType(ClassProperty classProperty, Type dbFieldType)
+        {
+            var dbType = classProperty?.GetDbType();
+            if (dbType == null)
+            {
+                var underlyingType = dbFieldType?.GetUnderlyingType();
+                dbType = TypeMapper.Get(underlyingType) ?? new ClientTypeToDbTypeResolver().Resolve(underlyingType);
+            }
+            return dbType;
+        }
+
         /// <summary>
         /// 
         /// </summary>
@@ -1557,14 +1568,7 @@ namespace RepoDb.Reflection
         internal static MethodCallExpression GetDbParameterDbTypeAssignmentExpression(ParameterExpression parameterVariableExpression,
             ClassProperty classProperty,
             DbField dbField)
-        {
-            var underlyingType = dbField.Type?.GetUnderlyingType();
-            var dbType = classProperty?.GetDbType() ?? TypeMapper.Get(underlyingType) ??
-                new ClientTypeToDbTypeResolver().Resolve(underlyingType);
-
-            // Return the expression
-            return GetDbParameterDbTypeAssignmentExpression(parameterVariableExpression, dbType);
-        }
+            => GetDbParameterDbTypeAssignmentExpression(parameterVariableExpression, GetDbType(classProperty, dbField.Type));
 
         /// <summary>
         /// 
@@ -1574,13 +1578,7 @@ namespace RepoDb.Reflection
         /// <returns></returns>
         internal static MethodCallExpression GetDbParameterDbTypeAssignmentExpression(ParameterExpression parameterVariableExpression,
             DbField dbField)
-        {
-            var underlyingType = dbField.Type?.GetUnderlyingType();
-            var dbType = TypeMapper.Get(underlyingType) ?? new ClientTypeToDbTypeResolver().Resolve(underlyingType);
-
-            // Return the expression
-            return GetDbParameterDbTypeAssignmentExpression(parameterVariableExpression, dbType);
-        }
+            => GetDbParameterDbTypeAssignmentExpression(parameterVariableExpression, GetDbType(null, dbField.Type));
 
         /// <summary>
         /// 

--- a/RepoDb.Core/RepoDb/Reflection/Compiler/PlainTypeToDbParameters.cs
+++ b/RepoDb.Core/RepoDb/Reflection/Compiler/PlainTypeToDbParameters.cs
@@ -55,21 +55,13 @@ namespace RepoDb.Reflection
                         dbField.Type.GetUnderlyingType());
                 }
 
-                // DbType
-                var dbType = (DbType?)null;
-                if (handlerSetType == null)
+                // DbType. PropertyHandler first
+                var dbType = handlerSetType != null ?
+                    GetDbType(null, handlerSetType) :
+                    GetDbType(entityProperty ?? paramProperty, (entityProperty ?? paramProperty).PropertyInfo.PropertyType);
+                if (dbType == null && paramProperty.PropertyInfo.PropertyType.IsEnum)
                 {
-                    dbType = (entityProperty ?? paramProperty).GetDbType();
-                    if (dbType == null && paramProperty.PropertyInfo.PropertyType.IsEnum)
-                    {
-                        dbType = Converter.EnumDefaultDatabaseType;
-                    }
-                }
-
-                // DbType fallback
-                if (dbType == null)
-                {
-                    dbType = TypeMapper.GetFallback(handlerSetType ?? paramProperty.PropertyInfo.PropertyType);
+                    dbType = Converter.EnumDefaultDatabaseType;
                 }
 
                 var dbTypeExpression = dbType == null ? GetNullableTypeExpression(StaticType.DbType) :

--- a/RepoDb.Core/RepoDb/Reflection/Compiler/PlainTypeToDbParameters.cs
+++ b/RepoDb.Core/RepoDb/Reflection/Compiler/PlainTypeToDbParameters.cs
@@ -66,6 +66,12 @@ namespace RepoDb.Reflection
                     }
                 }
 
+                // DbType fallback
+                if (dbType == null)
+                {
+                    dbType = TypeMapper.GetFallback(handlerSetType ?? paramProperty.PropertyInfo.PropertyType);
+                }
+
                 var dbTypeExpression = dbType == null ? GetNullableTypeExpression(StaticType.DbType) :
                     ConvertExpressionToNullableExpression(Expression.Constant(dbType), StaticType.DbType);
 


### PR DESCRIPTION
Always try to set the DbType of the pameter to avoid the null value being mistaken for the string type.

### code
```csharp
var data = connection.ExecuteQuery<decimal?>("select @value", new { value = (decimal?)null }).First();
```
### exception
```
System.InvalidOperationException
  HResult=0x80131509
  Message=No coercion operator is defined between types 'System.String' and 'System.Nullable`1[System.Decimal]'.
  Source=System.Linq.Expressions
  StackTrace: 
   at System.Linq.Expressions.Expression.GetUserDefinedCoercionOrThrow(ExpressionType coercionType, Expression expression, Type convertToType)
   at System.Linq.Expressions.Expression.Convert(Expression expression, Type type, MethodInfo method)
   at System.Linq.Expressions.Expression.Convert(Expression expression, Type type)
   at RepoDb.Reflection.Compiler.ConvertExpressionToTypeExpression(Expression expression, Type toType) in D:\Code-git\RepoDB\RepoDb.Core\RepoDb\Reflection\Compiler\Compiler.cs:line 574
```

### analysis
Expression generated by `Compiler.GetPlainTypeToDbParametersCompiledFunction` is 
```csharp
DbCommand.CreateParameter("name", value, new Nullable<DbType>());
```
When the third parameter is not specified and the value is null, sql server will treat the parameter as a string.
So DbDataReader.GetFieldType(n) will return DbType.String, the read Expression will use DbDataReader.GetString(n), and then the string will be converted to the return type decimal and an error will occur.

So this PR is mainly to set Parameter.DbType as much as possible to avoid misjudgment of the type when it is null.

If you have any questions, please let me know, and I will modify it as soon as possible.

thank
