### PR TITLE
Follow the #690 review suggestion to make adjustments

### DIFF
--- a/RepoDb.Core/RepoDb/Reflection/Compiler/Compiler.cs
+++ b/RepoDb.Core/RepoDb/Reflection/Compiler/Compiler.cs
@@ -1547,7 +1547,8 @@ namespace RepoDb.Reflection
             return Expression.Call(parameterVariableExpression, GetDbParameterValueSetMethod(), expression);
         }
 
-        private static DbType? GetDbType(ClassProperty classProperty, Type dbFieldType)
+        private static DbType? GetDbType(ClassProperty classProperty, 
+            Type dbFieldType)
         {
             var dbType = classProperty?.GetDbType();
             if (dbType == null)


### PR DESCRIPTION
Adjusted, please confirm.

In addition,
In `CreateParameters(...,IDictionary<string, object> ...)` and `CreateParameters(...,QueryField ...)`, 
although I also want to change to a single line, the following parts are a bit confused, so I will not adjust it first.

```csharp
// DbType
var dbType = (valueType != null? clientTypeToDbTypeResolver.Resolve(valueType): null) ??
    classProperty?.GetDbType() ??
    value?.GetType()?.GetDbType();
```
According to the previous logic, valueType and value?.GetType() should always be equal.
Why is the priority of `clientTypeToDbTypeResolver` higher than `value?.GetType()?.GetDbType()` ?
