### PR TITLE
rewrite sql where empty array parameter.

### DIFF
--- a/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Extensions/DbCommandExtensionsTest.cs
+++ b/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Extensions/DbCommandExtensionsTest.cs
@@ -243,11 +243,11 @@ where id in (@normalArray)
                 var expectedSql = @"
 select * from someTable
 where id in (@normalArray0, @normalArray1)
-  and id in ((select @emptyArray where 1 = 0))
+  and id in ((SELECT @emptyArray WHERE 1 = 0))
   and id in (@nullArray)
   and id in (@concat1ArrayA0, @concat1ArrayA1, @concat1ArrayB0, @concat1ArrayB1)
-  and id in ((select @concat2ArrayA where 1 = 0), @concat2ArrayB0, @concat2ArrayB1)
-  and id in ((select @concat3ArrayA where 1 = 0), (select @concat3ArrayB where 1 = 0))";
+  and id in ((SELECT @concat2ArrayA WHERE 1 = 0), @concat2ArrayB0, @concat2ArrayB1)
+  and id in ((SELECT @concat3ArrayA WHERE 1 = 0), (SELECT @concat3ArrayB WHERE 1 = 0))";
                 Assert.AreEqual(expectedSql, command.CommandText);
                 Assert.AreEqual(13, command.Parameters.Count);
                 Assert.AreEqual(5, command.Parameters["@normalArray0"].Value);

--- a/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Extensions/DbCommandExtensionsTest.cs
+++ b/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Extensions/DbCommandExtensionsTest.cs
@@ -225,6 +225,7 @@ namespace RepoDb.UnitTests.Extensions
 select * from someTable
 where id in (@normalArray)
   and id in (@emptyArray)
+  and id in (@nullArray)
   and id in (@concat1ArrayA, @concat1ArrayB)
   and id in (@concat2ArrayA, @concat2ArrayB)
   and id in (@concat3ArrayA, @concat3ArrayB)";
@@ -232,6 +233,7 @@ where id in (@normalArray)
                 {
                     normalArray = new[] { 5, 6 },
                     emptyArray = Array.Empty<int>(),
+                    nullArray = (IEnumerable<int>)null,
                     concat1ArrayA = new[] { 100, 101 }, concat1ArrayB = new[] { 102, 103 },
                     concat2ArrayA = Array.Empty<int>(), concat2ArrayB = new[] { 200, 201 },
                     concat3ArrayA = Array.Empty<int>(), concat3ArrayB = Array.Empty<int>()
@@ -242,14 +244,16 @@ where id in (@normalArray)
 select * from someTable
 where id in (@normalArray0, @normalArray1)
   and id in ((select @emptyArray where 1 = 0))
+  and id in (@nullArray)
   and id in (@concat1ArrayA0, @concat1ArrayA1, @concat1ArrayB0, @concat1ArrayB1)
   and id in ((select @concat2ArrayA where 1 = 0), @concat2ArrayB0, @concat2ArrayB1)
   and id in ((select @concat3ArrayA where 1 = 0), (select @concat3ArrayB where 1 = 0))";
                 Assert.AreEqual(expectedSql, command.CommandText);
-                Assert.AreEqual(12, command.Parameters.Count);
+                Assert.AreEqual(13, command.Parameters.Count);
                 Assert.AreEqual(5, command.Parameters["@normalArray0"].Value);
                 Assert.AreEqual(6, command.Parameters["@normalArray1"].Value);
                 Assert.AreEqual(DBNull.Value, command.Parameters["@emptyArray"].Value);
+                Assert.AreEqual(DBNull.Value, command.Parameters["@nullArray"].Value);
                 Assert.AreEqual(100, command.Parameters["@concat1ArrayA0"].Value);
                 Assert.AreEqual(101, command.Parameters["@concat1ArrayA1"].Value);
                 Assert.AreEqual(102, command.Parameters["@concat1ArrayB0"].Value);

--- a/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
@@ -121,10 +121,17 @@ namespace RepoDb.Extensions
         {
             var values = commandArrayParameter.Values.AsArray();
 
-            for (var i = 0; i < values.Length; i++)
+            if (values.Length == 0)
             {
-                var name = string.Concat(commandArrayParameter.ParameterName, i).AsParameter(dbSetting);
-                command.Parameters.Add(command.CreateParameter(name, values[i], null));
+                command.Parameters.Add(command.CreateParameter(commandArrayParameter.ParameterName.AsParameter(dbSetting), null, null));
+            }
+            else
+            {
+                for (var i = 0; i < values.Length; i++)
+                {
+                    var name = string.Concat(commandArrayParameter.ParameterName, i).AsParameter(dbSetting);
+                    command.Parameters.Add(command.CreateParameter(name, values[i], null));
+                }
             }
         }
 

--- a/RepoDb.Core/RepoDb/Extensions/DbConnectionExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/DbConnectionExtension.cs
@@ -3084,7 +3084,7 @@ namespace RepoDb
             if (items.Any() != true)
             {
                 var parameter = parameterName.AsParameter(dbSetting);
-                return commandText.Replace(parameter, string.Concat("(select ", parameter, " where 1 = 0)"));
+                return commandText.Replace(parameter, string.Concat("(SELECT ", parameter, " WHERE 1 = 0)"));
             }
 
             // Get the variables needed

--- a/RepoDb.Core/RepoDb/Extensions/DbConnectionExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/DbConnectionExtension.cs
@@ -3083,7 +3083,8 @@ namespace RepoDb
             var items = values is IEnumerable<object> ? (IEnumerable<object>)values : values.WithType<object>();
             if (items.Any() != true)
             {
-                return commandText;
+                var parameter = parameterName.AsParameter(dbSetting);
+                return commandText.Replace(parameter, string.Concat("(select ", parameter, " where 1 = 0)"));
             }
 
             // Get the variables needed


### PR DESCRIPTION
### Code
```csharp
var result = connection.ExecuteQuery("SELECT * FROM [sc].[IdentityTable] WHERE ColumnInt IN (@ColumnInt);", 
      new { ColumnInt = new int[0] });
```
### Exception
```
Microsoft.Data.SqlClient.SqlException
  HResult=0x80131904
  Message=Must declare the scalar variable "@ColumnInt"。
  Source=Core Microsoft SqlClient Data Provider
  StackTrace: 
   at Microsoft.Data.SqlClient.SqlConnection.OnError(SqlException exception, Boolean breakConnection, Action`1 wrapCloseInAction) in /_/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlConnection.cs:line 1858
```
### Command watch
command.CommandText = "SELECT * FROM [sc].[IdentityTable] WHERE ColumnInt IN (@ColumnInt);"
command.Parameters (count = 0)

### Revise
When the parameter is an empty set, replace @arg with (select @arg where 1 = 0). 
And set a DbNull parameter in command.Parameters.

### Example
```sql
-- @normal = new[] { 1, 2 }
-- @empty = @emptyA = @emptyB = new int[0]
where id in (@normal)		--> where id in (@normal0, @normal1)
where id in (@empty)		--> where id in ((select @empty where 1 = 0))
where id in (@empty, @normal)	--> where id in ((select @empty where 1 = 0), @normal0, @normal1)
where id in (@emptyA, @emptyB)	--> where id in ((select @emptyA where 1 = 0), (select @emptyB where 1 = 0))
```
