### PR TITLE
Bugfix: TDbConnection handling

### DIFF
--- a/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Mappers/DbHelperMapperTest.cs
+++ b/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Mappers/DbHelperMapperTest.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RepoDb.UnitTests.CustomObjects;
+
+namespace RepoDb.UnitTests.Mappers
+{
+    [TestClass]
+    public partial class DbHelperMapperTest
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            Cleanup();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            DbHelperMapper.Clear();
+        }
+
+        #region Methods
+
+        [TestMethod]
+        public void TestDbHelperMapperMappingViaGeneric()
+        {
+            // Setup
+            var dbHelper = new CustomDbHelper();
+            DbHelperMapper.Add<CustomDbConnection>(dbHelper, true);
+
+            // Act
+            var actual = DbHelperMapper.Get<CustomDbConnection>();
+
+            // Assert
+            Assert.AreSame(dbHelper, actual);
+        }
+
+        [TestMethod]
+        public void TestDbHelperMapperMappingCanBeRemovedViaGeneric()
+        {
+            // Setup
+            var dbHelper = new CustomDbHelper();
+            DbHelperMapper.Add<CustomDbConnection>(dbHelper, true);
+
+            // Act
+            DbHelperMapper.Remove<CustomDbConnection>();
+
+            // Assert
+            var actual = DbHelperMapper.Get<CustomDbConnection>();
+            Assert.IsNull(actual);
+        }
+
+        #endregion
+    }
+}

--- a/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Mappers/DbSettingMapperTest.cs
+++ b/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Mappers/DbSettingMapperTest.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RepoDb.UnitTests.CustomObjects;
+
+namespace RepoDb.UnitTests.Mappers
+{
+    [TestClass]
+    public partial class DbSettingMapperTest
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            Cleanup();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            DbSettingMapper.Clear();
+        }
+
+        #region Methods
+
+        [TestMethod]
+        public void TestDbSettingMapperMappingViaGeneric()
+        {
+            // Setup
+            var dbSetting = new CustomDbSetting();
+            DbSettingMapper.Add<CustomDbConnection>(dbSetting, true);
+
+            // Act
+            var actual = DbSettingMapper.Get<CustomDbConnection>();
+
+            // Assert
+            Assert.AreSame(dbSetting, actual);
+        }
+
+        [TestMethod]
+        public void TestDbSettingMapperMappingCanBeRemovedViaGeneric()
+        {
+            // Setup
+            var dbSetting = new CustomDbSetting();
+            DbSettingMapper.Add<CustomDbConnection>(dbSetting, true);
+
+            // Act
+            DbSettingMapper.Remove<CustomDbConnection>();
+
+            // Assert
+            var actual = DbSettingMapper.Get<CustomDbConnection>();
+            Assert.IsNull(actual);
+        }
+
+        #endregion
+    }
+}

--- a/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Mappers/StatementBuilderMapperTest.cs
+++ b/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Mappers/StatementBuilderMapperTest.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RepoDb.UnitTests.CustomObjects;
+
+namespace RepoDb.UnitTests.Mappers
+{
+    [TestClass]
+    public partial class StatementBuilderMapperTest
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            Cleanup();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            StatementBuilderMapper.Clear();
+        }
+
+        #region Methods
+
+        [TestMethod]
+        public void TestStatementBuilderMapperMappingViaGeneric()
+        {
+            // Setup
+            var statementBuilder = new CustomStatementBuilder();
+            StatementBuilderMapper.Add<CustomDbConnection>(statementBuilder, true);
+
+            // Act
+            var actual = StatementBuilderMapper.Get<CustomDbConnection>();
+
+            // Assert
+            Assert.AreSame(statementBuilder, actual);
+        }
+
+        [TestMethod]
+        public void TestStatementBuilderMapperMappingCanBeRemovedViaGeneric()
+        {
+            // Setup
+            var statementBuilder = new CustomStatementBuilder();
+            StatementBuilderMapper.Add<CustomDbConnection>(statementBuilder, true);
+
+            // Act
+            StatementBuilderMapper.Remove<CustomDbConnection>();
+
+            // Assert
+            var actual = StatementBuilderMapper.Get<CustomDbConnection>();
+            Assert.IsNull(actual);
+        }
+
+        #endregion
+    }
+}

--- a/RepoDb.Core/RepoDb/Mappers/DbHelperMapper.cs
+++ b/RepoDb.Core/RepoDb/Mappers/DbHelperMapper.cs
@@ -33,7 +33,7 @@ namespace RepoDb
         public static void Add<TDbConnection>(IDbHelper dbHelper,
             bool @override)
             where TDbConnection : DbConnection =>
-            Add(StaticType.DbConnection, dbHelper, @override);
+            Add(typeof(TDbConnection), dbHelper, @override);
 
         /// <summary>
         /// Adds a mapping between the type of <see cref="DbConnection"/> and an instance of <see cref="IDbHelper"/> object.
@@ -112,7 +112,7 @@ namespace RepoDb
         /// <typeparam name="TDbConnection">The type of <see cref="DbConnection"/>.</typeparam>
         public static void Remove<TDbConnection>()
             where TDbConnection : DbConnection =>
-            Remove(StaticType.DbConnection);
+            Remove(typeof(TDbConnection));
 
         /// <summary>
         /// Removes the mapping between the type of <see cref="DbConnection"/> and an instance of <see cref="IDbHelper"/> object.

--- a/RepoDb.Core/RepoDb/Mappers/DbSettingMapper.cs
+++ b/RepoDb.Core/RepoDb/Mappers/DbSettingMapper.cs
@@ -33,7 +33,7 @@ namespace RepoDb
         public static void Add<TDbConnection>(IDbSetting dbSetting,
             bool @override)
             where TDbConnection : DbConnection =>
-            Add(StaticType.DbConnection, dbSetting, @override);
+            Add(typeof(TDbConnection), dbSetting, @override);
 
         /// <summary>
         /// Adds a mapping between the type of <see cref="DbConnection"/> and an instance of <see cref="IDbSetting"/> object.
@@ -112,7 +112,7 @@ namespace RepoDb
         /// <typeparam name="TDbConnection">The type of <see cref="DbConnection"/>.</typeparam>
         public static void Remove<TDbConnection>()
             where TDbConnection : DbConnection =>
-            Remove(StaticType.DbConnection);
+            Remove(typeof(TDbConnection));
 
         /// <summary>
         /// Removes the mapping between the type of <see cref="DbConnection"/> and an instance of <see cref="IDbSetting"/> object.

--- a/RepoDb.Core/RepoDb/Mappers/StatementBuilderMapper.cs
+++ b/RepoDb.Core/RepoDb/Mappers/StatementBuilderMapper.cs
@@ -37,7 +37,7 @@ namespace RepoDb
         public static void Add<TDbConnection>(IStatementBuilder statementBuilder,
             bool @override)
             where TDbConnection : DbConnection =>
-            Add(StaticType.DbConnection, statementBuilder, @override);
+            Add(typeof(TDbConnection), statementBuilder, @override);
 
         /// <summary>
         /// Adds a mapping between the type of <see cref="DbConnection"/> and an instance of <see cref="IStatementBuilder"/> object.
@@ -116,7 +116,7 @@ namespace RepoDb
         /// <typeparam name="TDbConnection">The type of <see cref="DbConnection"/>.</typeparam>
         public static void Remove<TDbConnection>()
             where TDbConnection : DbConnection =>
-            Remove(StaticType.DbConnection);
+            Remove(typeof(TDbConnection));
 
         /// <summary>
         /// Removes an existing mapping between the type of <see cref="DbConnection"/> and an instance of <see cref="IStatementBuilder"/> object.


### PR DESCRIPTION
Use `typeof(TDbConnection)` for `Add` and `Remove` generic overloads.
Changes involve: `DbHelperMapper`, `DbSettingMapper`, `StatementBuilderMapper`.

Resolves #756.