### PR TITLE
Cache for mapped property names

### DIFF
--- a/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Configurations/BenchmarkConfig.cs
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Configurations/BenchmarkConfig.cs
@@ -29,7 +29,7 @@ namespace RepoDb.Benchmarks.PostgreSql.Configurations
             AddColumnProvider(DefaultColumnProviders.Metrics);
 
             var job = Job.ShortRun
-                .WithRuntime(CoreRuntime.Core50)
+                .WithRuntime(CoreRuntime.Core31)
                 .WithLaunchCount(DefaultConstants.DefaultLaunchCount)
                 .WithWarmupCount(DefaultConstants.DefaultWarmupCount)
                 .WithUnrollFactor(DefaultConstants.DefaultUnrollFactor)

--- a/RepoDb.Core/RepoDb/Cachers/MappedPropertyCache.cs
+++ b/RepoDb.Core/RepoDb/Cachers/MappedPropertyCache.cs
@@ -1,0 +1,104 @@
+﻿using RepoDb.Extensions;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RepoDb
+{
+    /// <summary>
+    /// A class that is being used to cache the mapped properties of the data entity.
+    /// </summary>
+    public static class MappedPropertyCache
+    {
+        private static readonly ConcurrentDictionary<int, Dictionary<string, ClassProperty>> mappedCache = new();
+
+        #region Methods
+
+        /// <summary>
+        /// Gets the cached <see cref="ClassProperty"/> object of the data entity (via property name).
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the data entity.</typeparam>
+        /// <param name="propertyName">The mapped name of the property.</param>
+        /// <returns>The instance of cached <see cref="ClassProperty"/> object.</returns>
+        public static ClassProperty Get<TEntity>(string propertyName)
+            where TEntity : class =>
+            Get(typeof(TEntity), propertyName);
+
+        /// <summary>
+        /// Gets the cached <see cref="ClassProperty"/> object of the data entity (via property name).
+        /// </summary>
+        /// <param name="entityType">The type of the data entity.</param>
+        /// <param name="propertyName">The mapped name of the property.</param>
+        /// <returns>The instance of cached <see cref="ClassProperty"/> object.</returns>
+        public static ClassProperty Get(Type entityType, string propertyName)
+        {
+            // Validate the presence
+            ThrowNullReferenceException(propertyName, "PropertyName");
+            
+            ClassProperty classProperty = null;
+            Get(entityType)?.TryGetValue(propertyName, out classProperty);
+            
+            // Return the value
+            return classProperty;
+        }
+
+        private static Dictionary<string, ClassProperty> Get(Type entityType)
+        {
+            if (entityType?.IsClassType() != true)
+            {
+                return null;
+            }
+
+            // Variables
+            var key = GenerateHashCode(entityType);
+
+            // Try get the value
+            if (mappedCache.TryGetValue(key, out var properties) == false)
+            {
+                properties = PropertyCache.Get(entityType)
+                    .ToDictionary(p => p.GetMappedName(), p => p, StringComparer.OrdinalIgnoreCase);
+                
+                mappedCache.TryAdd(key, properties);
+            }
+
+            // Return the value
+            return properties;
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Flushes all the existing cached enumerable of <see cref="ClassProperty"/> objects.
+        /// </summary>
+        public static void Flush() =>
+            mappedCache.Clear();
+
+        /// <summary>
+        /// Generates a hashcode for caching.
+        /// </summary>
+        /// <param name="type">The type of the data entity.</param>
+        /// <returns>The generated hashcode.</returns>
+        private static int GenerateHashCode(Type type) =>
+            TypeExtension.GenerateHashCode(type);
+
+        /// <summary>
+        /// Validates the target object presence.
+        /// </summary>
+        /// <typeparam name="T">The type of the object.</typeparam>
+        /// <param name="obj">The object to be checked.</param>
+        /// <param name="argument">The name of the argument.</param>
+        private static void ThrowNullReferenceException<T>(T obj,
+            string argument)
+        {
+            if (obj == null)
+            {
+                throw new NullReferenceException($"The argument '{argument}' cannot be null.");
+            }
+        }
+
+        #endregion
+    }
+}

--- a/RepoDb.Core/RepoDb/Cachers/PropertyCache.cs
+++ b/RepoDb.Core/RepoDb/Cachers/PropertyCache.cs
@@ -47,7 +47,7 @@ namespace RepoDb
         {
             // Validate the presence
             ThrowNullReferenceException(propertyName, "PropertyName");
-            
+
             // Return the value
             return Get(entityType)?
                 .FirstOrDefault(p =>
@@ -74,7 +74,7 @@ namespace RepoDb
         {
             // Validate the presence
             ThrowNullReferenceException(field, "Field");
-            
+
             // Return the value
             return Get(entityType)?
                 .FirstOrDefault(p =>
@@ -118,7 +118,7 @@ namespace RepoDb
             {
                 return null;
             }
-            
+
             // Variables
             var key = GenerateHashCode(entityType);
 

--- a/RepoDb.Core/RepoDb/Extensions/TypeExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/TypeExtension.cs
@@ -142,7 +142,7 @@ namespace RepoDb.Extensions
         /// <param name="mappedName">The name of the property mapping.</param>
         /// <returns>The instance of <see cref="ClassProperty"/>.</returns>
         internal static ClassProperty GetMappedProperty(this Type type, string mappedName) =>
-            PropertyCache.Get(type, mappedName);
+            MappedPropertyCache.Get(type, mappedName);
 
         /// <summary>
         /// Returns the list of the interface types being implemented by the current type.

--- a/RepoDb.Core/RepoDb/Extensions/TypeExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/TypeExtension.cs
@@ -141,9 +141,8 @@ namespace RepoDb.Extensions
         /// <param name="type">The current type.</param>
         /// <param name="mappedName">The name of the property mapping.</param>
         /// <returns>The instance of <see cref="ClassProperty"/>.</returns>
-        internal static ClassProperty GetMappedProperty(this Type type,
-            string mappedName) =>
-            PropertyCache.Get(type)?.FirstOrDefault(p => string.Equals(p.GetMappedName(), mappedName, StringComparison.OrdinalIgnoreCase));
+        internal static ClassProperty GetMappedProperty(this Type type, string mappedName) =>
+            PropertyCache.Get(type, mappedName);
 
         /// <summary>
         /// Returns the list of the interface types being implemented by the current type.

--- a/RepoDb.Core/RepoDb/QueryField/ParseExpression.cs
+++ b/RepoDb.Core/RepoDb/QueryField/ParseExpression.cs
@@ -21,7 +21,7 @@ namespace RepoDb
             where TEntity : class
         {
             // Failing at some point - for base interfaces
-            var property = PropertyCache.Get<TEntity>(field.Name);
+            var property = MappedPropertyCache.Get<TEntity>(field.Name);
 
             // Matches to the actual class properties
             if (property == null)
@@ -481,7 +481,7 @@ namespace RepoDb
             var name = PropertyMappedNameCache.Get(propertyInfo);
 
             // Failing at some point - for base interfaces
-            var property = PropertyCache.Get<TEntity>(name);
+            var property = MappedPropertyCache.Get<TEntity>(name);
 
             // Matches to the actual class properties
             if (property == null)

--- a/RepoDb.Core/RepoDb/QueryField/ParseExpression.cs
+++ b/RepoDb.Core/RepoDb/QueryField/ParseExpression.cs
@@ -20,17 +20,13 @@ namespace RepoDb
         private static ClassProperty GetTargetProperty<TEntity>(Field field)
             where TEntity : class
         {
-            var properties = PropertyCache.Get<TEntity>();
-
             // Failing at some point - for base interfaces
-            var property = properties
-                .FirstOrDefault(p =>
-                    string.Equals(p.GetMappedName(), field.Name, StringComparison.OrdinalIgnoreCase));
+            var property = PropertyCache.Get<TEntity>(field.Name);
 
             // Matches to the actual class properties
             if (property == null)
             {
-                property = properties
+                property = PropertyCache.Get<TEntity>()
                     .FirstOrDefault(p =>
                         string.Equals(p.PropertyInfo.Name, field.Name, StringComparison.OrdinalIgnoreCase));
             }
@@ -482,18 +478,15 @@ namespace RepoDb
             }
 
             // Variables
-            var properties = PropertyCache.Get<TEntity>();
             var name = PropertyMappedNameCache.Get(propertyInfo);
 
             // Failing at some point - for base interfaces
-            var property = properties
-                .FirstOrDefault(p =>
-                    string.Equals(p.GetMappedName(), name, StringComparison.OrdinalIgnoreCase));
+            var property = PropertyCache.Get<TEntity>(name);
 
             // Matches to the actual class properties
             if (property == null)
             {
-                property = properties
+                property = PropertyCache.Get<TEntity>()
                     .FirstOrDefault(p =>
                         string.Equals(p.PropertyInfo.Name, name, StringComparison.OrdinalIgnoreCase));
             }


### PR DESCRIPTION
The cache in PropertyCache has been extended to work with case insensitive mappedNames. This made it possible to reduce the search for properties and allocation of memory.

![изображение](https://user-images.githubusercontent.com/880792/117661338-e9323000-b1a6-11eb-89e0-3e87011d2d85.png)
