### PR TITLE
Using strings for Concat

### DIFF
--- a/RepoDb.Core/RepoDb/Contexts/Providers/InsertAllExecutionContextProvider.cs
+++ b/RepoDb.Core/RepoDb/Contexts/Providers/InsertAllExecutionContextProvider.cs
@@ -38,7 +38,7 @@ namespace RepoDb.Contexts.Providers
                 ";",
                 fields?.Select(f => f.Name).Join(","),
                 ";",
-                batchSize,
+                batchSize.ToString(),
                 ";",
                 hints);
         }

--- a/RepoDb.Core/RepoDb/Contexts/Providers/MergeAllExecutionContextProvider.cs
+++ b/RepoDb.Core/RepoDb/Contexts/Providers/MergeAllExecutionContextProvider.cs
@@ -42,7 +42,7 @@ namespace RepoDb.Contexts.Providers
                 ";",
                 fields?.Select(f => f.Name).Join(","),
                 ";",
-                batchSize,
+                batchSize.ToString(),
                 ";",
                 hints);
         }

--- a/RepoDb.Core/RepoDb/Contexts/Providers/UpdateAllExecutionContextProvider.cs
+++ b/RepoDb.Core/RepoDb/Contexts/Providers/UpdateAllExecutionContextProvider.cs
@@ -42,7 +42,7 @@ namespace RepoDb.Contexts.Providers
                 ";",
                 fields?.Select(f => f.Name).Join(","),
                 ";",
-                batchSize,
+                batchSize.ToString(),
                 ";",
                 hints);
         }

--- a/RepoDb.Core/RepoDb/Contexts/Providers/UpdateExecutionContextProvider.cs
+++ b/RepoDb.Core/RepoDb/Contexts/Providers/UpdateExecutionContextProvider.cs
@@ -39,7 +39,7 @@ namespace RepoDb.Contexts.Providers
                 ";",
                 hints,
                 ";",
-                where?.GetHashCode());
+                where?.GetHashCode().ToString());
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/DbField.cs
+++ b/RepoDb.Core/RepoDb/DbField.cs
@@ -112,7 +112,7 @@ namespace RepoDb
         /// </summary>
         /// <returns>The string that represents the instance of this <see cref="DbField"/> object.</returns>
         public override string ToString() =>
-            string.Concat(Name, ", ", IsPrimary.ToString(), " (", hashCode, ")");
+            string.Concat(Name, ", ", IsPrimary.ToString(), " (", hashCode.ToString(), ")");
 
         #endregion
 

--- a/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
@@ -139,7 +139,7 @@ namespace RepoDb.Extensions
             {
                 for (var i = 0; i < values.Length; i++)
                 {
-                    var name = string.Concat(commandArrayParameter.ParameterName, i).AsParameter(dbSetting);
+                    var name = string.Concat(commandArrayParameter.ParameterName, i.ToString()).AsParameter(dbSetting);
                     command.Parameters.Add(command.CreateParameter(name, values[i], null));
                 }
             }
@@ -512,7 +512,7 @@ namespace RepoDb.Extensions
             {
                 for (var i = 0; i < values.Count; i++)
                 {
-                    var name = string.Concat(queryField.Parameter.Name, "_In_", i);
+                    var name = string.Concat(queryField.Parameter.Name, "_In_", i.ToString());
                     command.Parameters.Add(CreateParameter(command, name, values[i], null, dbField, null, null));
                 }
             }

--- a/RepoDb.Core/RepoDb/Extensions/DbConnectionExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/DbConnectionExtension.cs
@@ -2692,7 +2692,7 @@ namespace RepoDb
 
             // Get the variables needed
             var parameters = values.Select((_, index) =>
-                string.Concat(parameterName, index).AsParameter(dbSetting));
+                string.Concat(parameterName, index.ToString()).AsParameter(dbSetting));
 
             // Replace the target parameter
             return commandText.Replace(parameterName.AsParameter(dbSetting), parameters.Join(", "));
@@ -3217,7 +3217,7 @@ namespace RepoDb
 
             // Get the variables needed
             var parameters = items.Select((_, index) =>
-                string.Concat(parameterName, index).AsParameter(dbSetting));
+                string.Concat(parameterName, index.ToString()).AsParameter(dbSetting));
 
             // Replace the target parameter
             return commandText.Replace(parameterName.AsParameter(dbSetting), parameters.Join(", "));

--- a/RepoDb.Core/RepoDb/Extensions/QueryFieldExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/QueryFieldExtension.cs
@@ -93,7 +93,7 @@ namespace RepoDb.Extensions
             var values = enumerable
                 .OfType<object>()
                 .Select((_, valueIndex) =>
-                    string.Concat(queryField.Parameter.Name.AsParameter(index, dbSetting), "_In_", valueIndex))
+                    string.Concat(queryField.Parameter.Name.AsParameter(index, dbSetting), "_In_", valueIndex.ToString()))
                 .Join(", ");
             return string.Concat("(", values, ")");
         }

--- a/RepoDb.Core/RepoDb/Extensions/StringExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/StringExtension.cs
@@ -295,7 +295,7 @@ namespace RepoDb.Extensions
                     (value.StartsWith(dbSetting.ParameterPrefix) ? value.Substring(1) : value)
                         .AsUnquoted(true, dbSetting).AsAlphaNumeric());
             }
-            return index > 0 ? string.Concat(value, "_", index) : value;
+            return index > 0 ? string.Concat(value, "_", index.ToString()) : value;
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Field.cs
+++ b/RepoDb.Core/RepoDb/Field.cs
@@ -65,7 +65,7 @@ namespace RepoDb
         /// </summary>
         /// <returns>The string value equivalent to the name of the field.</returns>
         public override string ToString() =>
-            string.Concat(Name, ", ", Type?.FullName, " (", hashCode, ")");
+            string.Concat(Name, ", ", Type?.FullName, " (", hashCode.ToString(), ")");
 
 
         #endregion

--- a/RepoDb.Core/RepoDb/Parameter.cs
+++ b/RepoDb.Core/RepoDb/Parameter.cs
@@ -103,7 +103,7 @@ namespace RepoDb
         /// </summary>
         /// <returns></returns>
         public override string ToString() =>
-            string.Concat(Name, " (", Value, ")");
+            string.Concat(Name, " (", Value.ToString(), ")");
 
         #endregion
 

--- a/RepoDb.Core/RepoDb/QueryGroup.cs
+++ b/RepoDb.Core/RepoDb/QueryGroup.cs
@@ -618,7 +618,7 @@ namespace RepoDb
                     if (firstQueryField.Field.Equals(secondQueryField.Field))
                     {
                         var fieldValue = secondQueryField.Parameter;
-                        fieldValue.SetName(string.Concat(secondQueryField.Parameter.Name, "_", fieldIndex));
+                        fieldValue.SetName(string.Concat(secondQueryField.Parameter.Name, "_", fieldIndex.ToString()));
                     }
                 }
                 secondList.RemoveAll(qf => qf.Field.Equals(firstQueryField.Field));

--- a/RepoDb.Core/RepoDb/QueryGroup/AsMappedObject.cs
+++ b/RepoDb.Core/RepoDb/QueryGroup/AsMappedObject.cs
@@ -148,7 +148,7 @@ namespace RepoDb
 
             for (var i = 0; i < values.Count; i++)
             {
-                var parameterName = string.Concat(queryField.Parameter.Name, "_In_", i);
+                var parameterName = string.Concat(queryField.Parameter.Name, "_In_", i.ToString());
                 if (dictionary.ContainsKey(parameterName))
                 {
                     continue;

--- a/RepoDb.Core/RepoDb/Reflection/Compiler/Compiler.cs
+++ b/RepoDb.Core/RepoDb/Reflection/Compiler/Compiler.cs
@@ -1637,7 +1637,7 @@ namespace RepoDb.Reflection
         {
             var dbParameterParameterNameSetMethod = StaticType.DbParameter.GetProperty("ParameterName").SetMethod;
             var parameterName = dbField.Name.AsUnquoted(true, dbSetting).AsAlphaNumeric();
-            parameterName = entityIndex > 0 ? string.Concat(dbSetting.ParameterPrefix, parameterName, "_", entityIndex) :
+            parameterName = entityIndex > 0 ? string.Concat(dbSetting.ParameterPrefix, parameterName, "_", entityIndex.ToString()) :
                 string.Concat(dbSetting.ParameterPrefix, parameterName);
             return Expression.Call(parameterVariableExpression, dbParameterParameterNameSetMethod,
                 Expression.Constant(parameterName));

--- a/RepoDb.Core/RepoDb/Reflection/Compiler/DbCommandToProperty.cs
+++ b/RepoDb.Core/RepoDb/Reflection/Compiler/DbCommandToProperty.cs
@@ -45,7 +45,7 @@ namespace RepoDb.Reflection
             var name = parameterName ?? propertyName;
             var parameters = Expression.Property(dbCommandParameterExpression, dbCommandParametersProperty);
             var parameter = Expression.Call(parameters, dbParameterCollectionIndexerMethod,
-                Expression.Constant(index > 0 ? string.Concat(name, "_", index) : name));
+                Expression.Constant(index > 0 ? string.Concat(name, "_", index.ToString()) : name));
 
             // Assign the Parameter.Value into DataEntity.Property
             var value = Expression.Property(parameter, dbParameterValueProperty);

--- a/RepoDb.Core/RepoDb/Reflection/FunctionCache.cs
+++ b/RepoDb.Core/RepoDb/Reflection/FunctionCache.cs
@@ -31,7 +31,7 @@ namespace RepoDb
             for (var ordinal = 0; ordinal < reader.FieldCount; ordinal++)
             {
                 // The spatial data type is null.
-                hashCode += string.Concat(reader.GetName(ordinal), "-", ordinal).GetHashCode() +
+                hashCode += string.Concat(reader.GetName(ordinal), "-", ordinal.ToString()).GetHashCode() +
                     (reader.GetFieldType(ordinal)?.GetHashCode()).GetValueOrDefault();
             }
             return hashCode;


### PR DESCRIPTION
![изображение](https://user-images.githubusercontent.com/880792/118398933-60fad180-b663-11eb-8e33-2fc78c3d1d54.png)

To avoid allocations need to use the method
`public static string Concat (string? str0, string? str1, ...`
instead of
`public static string Concat (object? arg0, object? arg1, ...`

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i5-9300H CPU 2.40GHz, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=6.0.100-preview.3.21202.5
  [Host]                  : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT
  MediumRun-.NET Core 3.1 : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT

Job=MediumRun-.NET Core 3.1  Runtime=.NET Core 3.1  IterationCount=15  
LaunchCount=2  WarmupCount=10  

```
|          Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| ConcatOfStrings | 39.78 ns | 3.453 ns | 4.841 ns | 0.0076 |     - |     - |      32 B |
| ConcatOfObjects | 53.62 ns | 4.601 ns | 6.450 ns | 0.0134 |     - |     - |      56 B |

```csharp
    [MemoryDiagnoser]
    [MediumRunJob(RuntimeMoniker.NetCoreApp31)]
    public class Program
    {
        private string _firstStringParam = "1";
        private string _secondStringParam = "2";
        private int _thirdIntParam = 3;
        
        [Benchmark]
        public string ConcatOfStrings()
        {
            return string.Concat(_firstStringParam, _secondStringParam, _thirdIntParam.ToString());
        }
    
        [Benchmark]
        public string ConcatOfObjects()
        {
            return string.Concat(_firstStringParam, _secondStringParam, _thirdIntParam);
        }
    
        private static void Main() => BenchmarkRunner.Run<Program>();
    }
```