### PR TITLE
GetHashCode without Sting.Concat

### DIFF
--- a/RepoDb.Core/RepoDb/QueryField.cs
+++ b/RepoDb.Core/RepoDb/QueryField.cs
@@ -239,7 +239,7 @@ namespace RepoDb
             // The string representation affects the collision
             // var objA = QueryGroup.Parse<EntityClass>(c => c.Id == 1 && c.Value != 1);
             // var objB = QueryGroup.Parse<EntityClass>(c => c.Id != 1 && c.Value == 1);
-            hashCode += string.Concat(Field.Name, Operation.GetText()).GetHashCode();
+            hashCode += HashCode.Combine(Field.Name, Operation.GetText());
 
             // Set and return the hashcode
             return (this.hashCode = hashCode).Value;

--- a/RepoDb.Core/RepoDb/Reflection/FunctionCache.cs
+++ b/RepoDb.Core/RepoDb/Reflection/FunctionCache.cs
@@ -23,17 +23,16 @@ namespace RepoDb
         /// <returns></returns>
         private static long GetReaderFieldsHashCode(DbDataReader reader)
         {
-            if (reader == null)
+            long hashCode = 0;
+            
+            if (reader is not null)
             {
-                return 0;
+                for (var ordinal = 0; ordinal < reader.FieldCount; ordinal++)
+                {
+                    hashCode += HashCode.Combine(reader.GetName(ordinal), ordinal, reader.GetFieldType(ordinal));
+                }
             }
-            var hashCode = (long)0;
-            for (var ordinal = 0; ordinal < reader.FieldCount; ordinal++)
-            {
-                // The spatial data type is null.
-                hashCode += string.Concat(reader.GetName(ordinal), "-", ordinal.ToString()).GetHashCode() +
-                    (reader.GetFieldType(ordinal)?.GetHashCode()).GetValueOrDefault();
-            }
+            
             return hashCode;
         }
 

--- a/RepoDb.Core/RepoDb/RepoDb.csproj
+++ b/RepoDb.Core/RepoDb/RepoDb.csproj
@@ -55,6 +55,10 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\LICENSE.txt">

--- a/RepoDb.Core/RepoDb/Requests/AverageAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/AverageAllRequest.cs
@@ -85,7 +85,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".AverageAll").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".AverageAll");
 
             // Add the field
             if (Field != null)

--- a/RepoDb.Core/RepoDb/Requests/AverageRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/AverageRequest.cs
@@ -96,7 +96,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".Average").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".Average");
 
             // Add the field
             if (Field != null)

--- a/RepoDb.Core/RepoDb/Requests/BatchQueryRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/BatchQueryRequest.cs
@@ -131,7 +131,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".BatchQuery").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".BatchQuery");
 
             // Add the fields
             if (Fields != null)

--- a/RepoDb.Core/RepoDb/Requests/CountAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/CountAllRequest.cs
@@ -74,7 +74,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".CountAll").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".CountAll");
 
             // Add the hints
             if (!string.IsNullOrWhiteSpace(Hints))

--- a/RepoDb.Core/RepoDb/Requests/CountRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/CountRequest.cs
@@ -85,7 +85,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".Count").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".Count");
 
             // Get the properties hash codes
             if (Where != null)

--- a/RepoDb.Core/RepoDb/Requests/DeleteAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/DeleteAllRequest.cs
@@ -74,7 +74,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".DeleteAll").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".DeleteAll");
 
             // Add the hints
             if (!string.IsNullOrWhiteSpace(Hints))

--- a/RepoDb.Core/RepoDb/Requests/DeleteRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/DeleteRequest.cs
@@ -85,7 +85,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".Delete").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".Delete");
 
             // Get the properties hash codes
             if (Where != null)

--- a/RepoDb.Core/RepoDb/Requests/ExistsRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/ExistsRequest.cs
@@ -85,7 +85,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".Exists").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".Exists");
 
             // Get the properties hash codes
             if (Where != null)

--- a/RepoDb.Core/RepoDb/Requests/InsertAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/InsertAllRequest.cs
@@ -98,7 +98,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".InsertAll").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".InsertAll");
 
             // Get the qualifier <see cref="Field"/> objects
             if (Fields != null)

--- a/RepoDb.Core/RepoDb/Requests/InsertRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/InsertRequest.cs
@@ -87,7 +87,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".Insert").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".Insert");
 
             // Get the qualifier <see cref="Field"/> objects
             if (Fields != null)

--- a/RepoDb.Core/RepoDb/Requests/MaxAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/MaxAllRequest.cs
@@ -85,7 +85,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".MaxAll").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".MaxAll");
 
             // Add the field
             if (Field != null)

--- a/RepoDb.Core/RepoDb/Requests/MaxRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/MaxRequest.cs
@@ -96,7 +96,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".Max").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".Max");
 
             // Add the field
             if (Field != null)

--- a/RepoDb.Core/RepoDb/Requests/MergeAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/MergeAllRequest.cs
@@ -109,7 +109,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".MergeAll").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".MergeAll");
 
             // Get the qualifier <see cref="Field"/> objects
             if (Fields != null)

--- a/RepoDb.Core/RepoDb/Requests/MergeRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/MergeRequest.cs
@@ -98,7 +98,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".Merge").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".Merge");
 
             // Get the qualifier <see cref="Field"/> objects
             if (Fields != null)

--- a/RepoDb.Core/RepoDb/Requests/MinAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/MinAllRequest.cs
@@ -85,7 +85,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".MinAll").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".MinAll");
 
             // Add the field
             if (Field != null)

--- a/RepoDb.Core/RepoDb/Requests/MinRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/MinRequest.cs
@@ -96,7 +96,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".Min").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".Min");
 
             // Add the field
             if (Field != null)

--- a/RepoDb.Core/RepoDb/Requests/QueryAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/QueryAllRequest.cs
@@ -98,7 +98,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".QueryAll").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".QueryAll");
 
             // Get the qualifier <see cref="Field"/> objects
             if (Fields != null)

--- a/RepoDb.Core/RepoDb/Requests/QueryMultipleRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/QueryMultipleRequest.cs
@@ -131,7 +131,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".QueryMultiple").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".QueryMultiple");
 
             // Add the index
             if (Index != null)

--- a/RepoDb.Core/RepoDb/Requests/QueryRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/QueryRequest.cs
@@ -120,7 +120,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".Query").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".Query");
 
             // Get the qualifier <see cref="Field"/> objects
             if (Fields != null)

--- a/RepoDb.Core/RepoDb/Requests/SumAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/SumAllRequest.cs
@@ -85,7 +85,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".SumAll").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".SumAll");
 
             // Add the field
             if (Field != null)

--- a/RepoDb.Core/RepoDb/Requests/SumRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/SumRequest.cs
@@ -96,7 +96,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".Sum").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".Sum");
 
             // Add the field
             if (Field != null)

--- a/RepoDb.Core/RepoDb/Requests/TruncateRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/TruncateRequest.cs
@@ -62,7 +62,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".Truncate").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".Truncate");
 
             // Set and return the hashcode
             return (this.hashCode = hashCode).Value;

--- a/RepoDb.Core/RepoDb/Requests/UpdateAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/UpdateAllRequest.cs
@@ -109,7 +109,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".UpdateAll").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".UpdateAll");
 
             // Get the fields
             if (Fields != null)

--- a/RepoDb.Core/RepoDb/Requests/UpdateRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/UpdateRequest.cs
@@ -98,7 +98,7 @@ namespace RepoDb.Requests
             }
 
             // Get first the entity hash code
-            var hashCode = string.Concat(Name, ".Update").GetHashCode();
+            var hashCode = HashCode.Combine(Name, ".Update");
 
             // Get the properties hash codes
             if (Where != null)


### PR DESCRIPTION
Using string.Concat when calculating hashCode leads to unnecessary allocations

![изображение](https://user-images.githubusercontent.com/880792/118543409-e9a96880-b75c-11eb-82f1-56851bf8a5df.png)

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i5-9300H CPU 2.40GHz, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=6.0.100-preview.3.21202.5
  [Host]                  : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT
  MediumRun-.NET Core 3.1 : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT

Job=MediumRun-.NET Core 3.1  Runtime=.NET Core 3.1  IterationCount=15  
LaunchCount=2  WarmupCount=10  

```
|               Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
|      HashCodeCombine | 13.03 ns | 0.123 ns | 0.185 ns |      - |     - |     - |         - |
| HashCodeStringConcat | 25.87 ns | 2.198 ns | 3.222 ns | 0.0095 |     - |     - |      40 B |

```csharp
    [MemoryDiagnoser]
    [MediumRunJob(RuntimeMoniker.NetCoreApp31)]
    public class Program
    {
        private string _firstStringParam = "1111";
        private string _secondStringParam = "22222";

        [Benchmark]
        public int HashCodeCombine()
        {
            return HashCode.Combine(_firstStringParam, _secondStringParam);
        }
    
        [Benchmark]
        public int HashCodeStringConcat()
        {
            return string.Concat(_firstStringParam, _secondStringParam).GetHashCode();
        }
    
        private static void Main() => BenchmarkRunner.Run<Program>();
    }
```