### PR TITLE
Removed unnecessary calls the methode GetHashCode

### DIFF
--- a/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Equalities/FieldEqualityTest.cs
+++ b/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Equalities/FieldEqualityTest.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections;
 using System.Collections.Generic;
+using Moq;
 
 namespace RepoDb.UnitTests.Equalities
 {
@@ -130,6 +131,73 @@ namespace RepoDb.UnitTests.Equalities
 
             // Assert
             Assert.IsTrue(equal);
+        }
+
+        [TestMethod]
+        public void TestFieldGetHashCodeInvocationOnCheckNotNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<Field>("FieldName");
+
+            // Act
+            if (mockOfFiled.Object != null){}
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Never);
+        }
+        
+        [TestMethod]
+        public void TestFieldGetHashCodeInvocationOnCheckNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<Field>("FieldName");
+
+            // Act
+            if (mockOfFiled.Object == null){}
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Never);
+        }
+        
+        [TestMethod]
+        public void TestFieldGetHashCodeInvocationOnEqualsNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<Field>("FieldName");
+
+            // Act
+            mockOfFiled.Object.Equals(null);
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Never);
+        }
+
+        [TestMethod]
+        public void TestFieldGetHashCodeInvocationOnEqualsNotNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<Field>("FieldName");
+            var otherFiled = new Field("FieldName");
+
+            // Act
+            mockOfFiled.Object.Equals(otherFiled);
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Once);
+        }
+        
+        [TestMethod]
+        public void TestFieldGetHashCodeInvocationOnEqualityNotNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<Field>("FieldName");
+            var otherFiled = new Field("FieldName");
+
+            // Act
+            if (mockOfFiled.Object == otherFiled) {}
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Once);
         }
     }
 }

--- a/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Equalities/OrderFieldEqualityTest.cs
+++ b/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Equalities/OrderFieldEqualityTest.cs
@@ -2,6 +2,7 @@
 using RepoDb.Enumerations;
 using System.Collections;
 using System.Collections.Generic;
+using Moq;
 
 namespace RepoDb.UnitTests.Equalities
 {
@@ -153,6 +154,73 @@ namespace RepoDb.UnitTests.Equalities
 
             // Assert
             Assert.IsFalse(equal);
+        }
+        
+        [TestMethod]
+        public void TestOrderFieldGetHashCodeInvocationOnCheckNotNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<OrderField>("OrderFieldName", Order.Ascending);
+
+            // Act
+            if (mockOfFiled.Object != null){}
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Never);
+        }
+        
+        [TestMethod]
+        public void TestOrderFieldGetHashCodeInvocationOnCheckNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<OrderField>("OrderFieldName", Order.Ascending);
+
+            // Act
+            if (mockOfFiled.Object == null){}
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Never);
+        }
+        
+        [TestMethod]
+        public void TestOrderFieldGetHashCodeInvocationOnEqualsNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<OrderField>("OrderFieldName", Order.Ascending);
+
+            // Act
+            mockOfFiled.Object.Equals(null);
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Never);
+        }
+
+        [TestMethod]
+        public void TestOrderFieldGetHashCodeInvocationOnEqualsNotNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<OrderField>("OrderFieldName", Order.Ascending);
+            var otherFiled = new OrderField("OrderFieldName", Order.Ascending);
+
+            // Act
+            mockOfFiled.Object.Equals(otherFiled);
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Once);
+        }
+        
+        [TestMethod]
+        public void TestOrderFieldGetHashCodeInvocationOnEqualityNotNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<OrderField>("OrderFieldName", Order.Ascending);
+            var otherFiled = new OrderField("OrderFieldName", Order.Ascending);
+
+            // Act
+            if (mockOfFiled.Object == otherFiled) {}
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Once);
         }
     }
 }

--- a/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Equalities/QueryFieldEqualityTest.cs
+++ b/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/Equalities/QueryFieldEqualityTest.cs
@@ -2,6 +2,7 @@
 using RepoDb.Enumerations;
 using System.Collections;
 using System.Collections.Generic;
+using Moq;
 
 namespace RepoDb.UnitTests.Equalities
 {
@@ -108,6 +109,73 @@ namespace RepoDb.UnitTests.Equalities
 
             // Assert
             Assert.IsTrue(equal);
+        }
+        
+        [TestMethod]
+        public void TestQueryFieldGetHashCodeInvocationOnCheckNotNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<QueryField>("QueryFieldName", Operation.Equal, "Value1");
+
+            // Act
+            if (mockOfFiled.Object != null){}
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Never);
+        }
+        
+        [TestMethod]
+        public void TestQueryFieldGetHashCodeInvocationOnCheckNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<QueryField>("QueryFieldName", Operation.Equal, "Value1");
+
+            // Act
+            if (mockOfFiled.Object == null){}
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Never);
+        }
+        
+        [TestMethod]
+        public void TestQueryFieldGetHashCodeInvocationOnEqualsNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<QueryField>("QueryFieldName", Operation.Equal, "Value1");
+
+            // Act
+            mockOfFiled.Object.Equals(null);
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Never);
+        }
+
+        [TestMethod]
+        public void TestQueryFieldGetHashCodeInvocationOnEqualsNotNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<QueryField>("QueryFieldName", Operation.Equal, "Value1");
+            var otherFiled = new QueryField("QueryFieldName", Operation.Equal, "Value1");
+
+            // Act
+            mockOfFiled.Object.Equals(otherFiled);
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Once);
+        }
+        
+        [TestMethod]
+        public void TestQueryFieldGetHashCodeInvocationOnEqualityNotNull()
+        {
+            // Prepare
+            var mockOfFiled = new Mock<QueryField>("QueryFieldName", Operation.Equal, "Value1");
+            var otherFiled = new QueryField("QueryFieldName", Operation.Equal, "Value1");
+
+            // Act
+            if (mockOfFiled.Object == otherFiled) {}
+            
+            // Assert
+            mockOfFiled.Verify(x => x.GetHashCode(), Times.Once);
         }
     }
 }

--- a/RepoDb.Core/RepoDb/DbField.cs
+++ b/RepoDb.Core/RepoDb/DbField.cs
@@ -163,16 +163,24 @@ namespace RepoDb
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="DbField"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(DbField other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(DbField other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="DbField"/> objects.
@@ -187,7 +195,7 @@ namespace RepoDb
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/DbSettings/BaseDbSetting.cs
+++ b/RepoDb.Core/RepoDb/DbSettings/BaseDbSetting.cs
@@ -175,16 +175,24 @@ namespace RepoDb.DbSettings
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="BaseDbSetting"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(BaseDbSetting other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(BaseDbSetting other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="BaseDbSetting"/> objects.
@@ -199,7 +207,7 @@ namespace RepoDb.DbSettings
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/DirectionalQueryField.cs
+++ b/RepoDb.Core/RepoDb/DirectionalQueryField.cs
@@ -182,16 +182,24 @@ namespace RepoDb
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="DirectionalQueryField"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(DirectionalQueryField other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(DirectionalQueryField other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="DirectionalQueryField"/> objects.
@@ -206,7 +214,7 @@ namespace RepoDb
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Field.cs
+++ b/RepoDb.Core/RepoDb/Field.cs
@@ -294,16 +294,24 @@ namespace RepoDb
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="Field"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(Field other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(Field other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="Field"/> objects.
@@ -318,7 +326,7 @@ namespace RepoDb
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/OrderField.cs
+++ b/RepoDb.Core/RepoDb/OrderField.cs
@@ -192,16 +192,24 @@ namespace RepoDb
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="OrderField"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(OrderField other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(OrderField other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="OrderField"/> objects.
@@ -216,7 +224,7 @@ namespace RepoDb
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Parameter.cs
+++ b/RepoDb.Core/RepoDb/Parameter.cs
@@ -129,16 +129,24 @@ namespace RepoDb
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="Parameter"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(Parameter other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(Parameter other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="Parameter"/> objects.
@@ -153,7 +161,7 @@ namespace RepoDb
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/QueryField.cs
+++ b/RepoDb.Core/RepoDb/QueryField.cs
@@ -250,16 +250,24 @@ namespace RepoDb
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="QueryField"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(QueryField other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(QueryField other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="QueryField"/> objects.
@@ -274,7 +282,7 @@ namespace RepoDb
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/QueryGroup.cs
+++ b/RepoDb.Core/RepoDb/QueryGroup.cs
@@ -815,16 +815,24 @@ namespace RepoDb
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="QueryGroup"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(QueryGroup other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(QueryGroup other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="QueryGroup"/> objects.
@@ -839,7 +847,7 @@ namespace RepoDb
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/AverageAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/AverageAllRequest.cs
@@ -108,16 +108,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="AverageAllRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(AverageAllRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(AverageAllRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="AverageAllRequest"/> objects.
@@ -132,7 +140,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/AverageRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/AverageRequest.cs
@@ -125,16 +125,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="AverageRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(AverageRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(AverageRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="AverageRequest"/> objects.
@@ -149,7 +157,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/BatchQueryRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/BatchQueryRequest.cs
@@ -178,16 +178,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="BatchQueryRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(BatchQueryRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(BatchQueryRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="BatchQueryRequest"/> objects.
@@ -202,7 +210,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/CountAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/CountAllRequest.cs
@@ -91,16 +91,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="CountAllRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(CountAllRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(CountAllRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="CountAllRequest"/> objects.
@@ -115,7 +123,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/CountRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/CountRequest.cs
@@ -108,16 +108,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="CountRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(CountRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(CountRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="CountRequest"/> objects.
@@ -132,7 +140,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/DeleteAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/DeleteAllRequest.cs
@@ -91,16 +91,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="DeleteAllRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(DeleteAllRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(DeleteAllRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="DeleteAllRequest"/> objects.
@@ -115,7 +123,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/DeleteRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/DeleteRequest.cs
@@ -108,16 +108,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="DeleteRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(DeleteRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(DeleteRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="DeleteRequest"/> objects.
@@ -132,7 +140,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/ExistsRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/ExistsRequest.cs
@@ -108,16 +108,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="ExistsRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(ExistsRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(ExistsRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="ExistsRequest"/> objects.
@@ -132,7 +140,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/InsertAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/InsertAllRequest.cs
@@ -130,16 +130,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="InsertAllRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(InsertAllRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(InsertAllRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="InsertAllRequest"/> objects.
@@ -154,7 +162,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/InsertRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/InsertRequest.cs
@@ -113,16 +113,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="InsertRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(InsertRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(InsertRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="InsertRequest"/> objects.
@@ -137,7 +145,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/MaxAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/MaxAllRequest.cs
@@ -108,16 +108,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="MaxAllRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(MaxAllRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(MaxAllRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="MaxAllRequest"/> objects.
@@ -132,7 +140,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/MaxRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/MaxRequest.cs
@@ -125,16 +125,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="MaxRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(MaxRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(MaxRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="MaxRequest"/> objects.
@@ -149,7 +157,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/MergeAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/MergeAllRequest.cs
@@ -150,16 +150,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="MergeAllRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(MergeAllRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(MergeAllRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="MergeAllRequest"/> objects.
@@ -174,7 +182,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/MergeRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/MergeRequest.cs
@@ -133,16 +133,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="MergeRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(MergeRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(MergeRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="MergeRequest"/> objects.
@@ -156,7 +164,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/MinAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/MinAllRequest.cs
@@ -108,16 +108,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="MinAllRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(MinAllRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(MinAllRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="MinAllRequest"/> objects.
@@ -132,7 +140,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/MinRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/MinRequest.cs
@@ -125,16 +125,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="MinRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(MinRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(MinRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="MinRequest"/> objects.
@@ -149,7 +157,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/QueryAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/QueryAllRequest.cs
@@ -133,16 +133,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="QueryAllRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(QueryAllRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(QueryAllRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="QueryAllRequest"/> objects.
@@ -157,7 +165,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/QueryMultipleRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/QueryMultipleRequest.cs
@@ -184,16 +184,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="QueryMultipleRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(QueryMultipleRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(QueryMultipleRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="QueryMultipleRequest"/> objects.
@@ -207,7 +215,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/QueryRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/QueryRequest.cs
@@ -167,16 +167,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="QueryRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(QueryRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(QueryRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="QueryRequest"/> objects.
@@ -191,7 +199,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/SumAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/SumAllRequest.cs
@@ -108,16 +108,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="SumAllRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(SumAllRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(SumAllRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="SumAllRequest"/> objects.
@@ -132,7 +140,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/SumRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/SumRequest.cs
@@ -125,16 +125,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="SumRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(SumRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(SumRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="SumRequest"/> objects.
@@ -148,7 +156,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/TruncateRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/TruncateRequest.cs
@@ -73,16 +73,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="TruncateRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(TruncateRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(TruncateRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="TruncateRequest"/> objects.
@@ -97,7 +105,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/UpdateAllRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/UpdateAllRequest.cs
@@ -150,16 +150,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="UpdateAllRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(UpdateAllRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(UpdateAllRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="UpdateAllRequest"/> objects.
@@ -174,7 +182,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/Requests/UpdateRequest.cs
+++ b/RepoDb.Core/RepoDb/Requests/UpdateRequest.cs
@@ -130,16 +130,24 @@ namespace RepoDb.Requests
         /// </summary>
         /// <param name="obj">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equals.</returns>
-        public override bool Equals(object obj) =>
-            obj?.GetHashCode() == GetHashCode();
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            
+            return obj.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the <see cref="UpdateRequest"/> object equality against the given target object.
         /// </summary>
         /// <param name="other">The object to be compared to the current object.</param>
         /// <returns>True if the instances are equal.</returns>
-        public bool Equals(UpdateRequest other) =>
-            other?.GetHashCode() == GetHashCode();
+        public bool Equals(UpdateRequest other)
+        {
+            if (other is null) return false;
+            
+            return other.GetHashCode() == GetHashCode();
+        }
 
         /// <summary>
         /// Compares the equality of the two <see cref="UpdateRequest"/> objects.
@@ -154,7 +162,7 @@ namespace RepoDb.Requests
             {
                 return objB is null;
             }
-            return objB?.GetHashCode() == objA.GetHashCode();
+            return objA.Equals(objB);
         }
 
         /// <summary>


### PR DESCRIPTION
In the code like this: https://github.com/mikependon/RepoDB/blob/c715c11d51e1b531d9589f636536f4d15aef8dc8/RepoDb.Core/RepoDb/Operations/DbConnection/Query.cs#L2177 The current logic call calculation HashCode

![изображение](https://user-images.githubusercontent.com/880792/120100715-d4640f00-c14a-11eb-9995-58c66989c7c1.png)

Now checking for the null is more correct, because objB is also being checked for the null.
