### PR TITLE
GetHashCode for own type

### DIFF
--- a/RepoDb.Core/RepoDb.Tests/RepoDb.IntegrationTests/EnumPropertyTest.cs
+++ b/RepoDb.Core/RepoDb.Tests/RepoDb.IntegrationTests/EnumPropertyTest.cs
@@ -2272,6 +2272,8 @@ namespace RepoDb.IntegrationTests
         public void TestEnumGetFromStringWithPropertyHandler()
         {
             EnsureCustomedMappingEnumPropertyHandler<CustomedStringEnum>(customedStringEnumHandler);
+            EnsureCustomedMappingEnumPropertyHandler<CustomedStringEnum?>(customedStringEnumHandler);
+            
             using (var connection = new SqlConnection(Database.ConnectionStringForRepoDb))
             {
                 var enumValue = connection.ExecuteQuery<CustomedStringEnum>("select 'Special-B'").First();
@@ -2308,6 +2310,8 @@ namespace RepoDb.IntegrationTests
         public void TestEnumGetFromDecimalWithPropertyHandler()
         {
             EnsureCustomedMappingEnumPropertyHandler<CustomedDecimalEnum>(customedDecimalEnumHandler);
+            EnsureCustomedMappingEnumPropertyHandler<CustomedDecimalEnum?>(customedDecimalEnumHandler);
+            
             using (var connection = new SqlConnection(Database.ConnectionStringForRepoDb))
             {
                 var enumValue = connection.ExecuteQuery<CustomedDecimalEnum>("select convert(decimal(8,3), 6.2)").First();

--- a/RepoDb.Core/RepoDb/Extensions/TypeExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/TypeExtension.cs
@@ -215,7 +215,7 @@ namespace RepoDb.Extensions
         /// <param name="type">The type of the data entity.</param>
         /// <returns>The generated hashcode.</returns>
         internal static int GenerateHashCode(Type type) =>
-            type.GetUnderlyingType().GetHashCode();
+            type.GetHashCode();
 
         /// <summary>
         /// Generates a hashcode for caching.
@@ -225,7 +225,7 @@ namespace RepoDb.Extensions
         /// <returns>The generated hashcode.</returns>
         internal static int GenerateHashCode(Type entityType,
             PropertyInfo propertyInfo) =>
-            entityType.GetUnderlyingType().GetHashCode() + propertyInfo.GenerateCustomizedHashCode(entityType);
+            entityType.GetHashCode() + propertyInfo.GenerateCustomizedHashCode(entityType);
 
         /// <summary>
         /// A helper method to return the instance of <see cref="PropertyInfo"/> object based on name.


### PR DESCRIPTION
I think that it is not entirely correct to use the method GetUnderlyingType to calculate the hashcode.

In the example, you can see that A is equal to C, but this can lead to collisions when using two different types in fact.

![изображение](https://user-images.githubusercontent.com/880792/128232594-07198b80-3e2f-4046-af5a-840231c48758.png)
