### PR TITLE
Typed method for ScopeIdentity

### DIFF
--- a/RepoDb.Core/RepoDb.Tests/RepoDb.IntegrationTests/DbHelperTest.cs
+++ b/RepoDb.Core/RepoDb.Tests/RepoDb.IntegrationTests/DbHelperTest.cs
@@ -197,17 +197,17 @@ namespace RepoDb.SqlServer.IntegrationTests
                 var helper = connection.GetDbHelper();
 
                 // Act
-                var insertResult = connection.Insert<IdentityTable>(table);
+                var insertResult = connection.Insert<IdentityTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = helper.GetScopeIdentity(connection, null);
+                var result = helper.GetScopeIdentity<long>(connection, null);
 
                 // Assert
-                Assert.AreEqual(insertResult, Convert.ToInt64(result));
+                Assert.AreEqual(insertResult, result);
             }
         }
 
@@ -225,17 +225,17 @@ namespace RepoDb.SqlServer.IntegrationTests
                 var helper = connection.GetDbHelper();
 
                 // Act
-                var insertResult = connection.Insert<IdentityTable>(table);
+                var insertResult = connection.Insert<IdentityTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = await helper.GetScopeIdentityAsync(connection, null);
+                var result = await helper.GetScopeIdentityAsync<long>(connection, null);
 
                 // Assert
-                Assert.AreEqual(insertResult, Convert.ToInt64(result));
+                Assert.AreEqual(insertResult, result);
             }
         }
 

--- a/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/CustomObjects/CustomDbHelper.cs
+++ b/RepoDb.Core/RepoDb.Tests/RepoDb.UnitTests/CustomObjects/CustomDbHelper.cs
@@ -34,17 +34,17 @@ namespace RepoDb.UnitTests.CustomObjects
             });
         }
 
-        public object GetScopeIdentity(IDbConnection connection,
+        public T GetScopeIdentity<T>(IDbConnection connection,
             IDbTransaction transaction = null)
         {
-            return 0;
+            return default;
         }
 
-        public Task<object> GetScopeIdentityAsync(IDbConnection connection,
+        public Task<T> GetScopeIdentityAsync<T>(IDbConnection connection,
             IDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
-            return Task.FromResult((object)0);
+            return Task.FromResult<T>(default);
         }
     }
 

--- a/RepoDb.Core/RepoDb/Interfaces/IDbHelper.cs
+++ b/RepoDb.Core/RepoDb/Interfaces/IDbHelper.cs
@@ -49,20 +49,22 @@ namespace RepoDb.Interfaces
         /// <summary>
         /// Gets the newly generated identity from the database.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        object GetScopeIdentity(IDbConnection connection,
+        T GetScopeIdentity<T>(IDbConnection connection,
             IDbTransaction transaction = null);
 
         /// <summary>
         /// Gets the newly generated identity from the database in an asynchronous way.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> object to be used during the asynchronous operation.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        Task<object> GetScopeIdentityAsync(IDbConnection connection,
+        Task<T> GetScopeIdentityAsync<T>(IDbConnection connection,
             IDbTransaction transaction = null,
             CancellationToken cancellationToken = default);
 

--- a/RepoDb.MySql/RepoDb.MySql.IntegrationTests/DbHelperTests.cs
+++ b/RepoDb.MySql/RepoDb.MySql.IntegrationTests/DbHelperTests.cs
@@ -196,14 +196,14 @@ namespace RepoDb.MySql.IntegrationTests
                 var table = Helper.CreateCompleteTables(1).First();
 
                 // Act
-                var insertResult = connection.Insert<CompleteTable>(table);
+                var insertResult = connection.Insert<CompleteTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = helper.GetScopeIdentity(connection, null);
+                var result = helper.GetScopeIdentity<long>(connection, null);
 
                 // Assert
                 Assert.AreEqual(insertResult, result);
@@ -224,14 +224,14 @@ namespace RepoDb.MySql.IntegrationTests
                 var table = Helper.CreateCompleteTables(1).First();
 
                 // Act
-                var insertResult = connection.Insert<CompleteTable>(table);
+                var insertResult = connection.Insert<CompleteTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = await helper.GetScopeIdentityAsync(connection, null);
+                var result = await helper.GetScopeIdentityAsync<long>(connection, null);
 
                 // Assert
                 Assert.AreEqual(insertResult, result);

--- a/RepoDb.MySql/RepoDb.MySql/DbHelpers/MySqlDbHelper.cs
+++ b/RepoDb.MySql/RepoDb.MySql/DbHelpers/MySqlDbHelper.cs
@@ -242,27 +242,29 @@ namespace RepoDb.DbHelpers
         /// <summary>
         /// Gets the newly generated identity from the database.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        public object GetScopeIdentity(IDbConnection connection,
+        public T GetScopeIdentity<T>(IDbConnection connection,
             IDbTransaction transaction = null)
         {
-            return connection.ExecuteScalar("SELECT LAST_INSERT_ID();", transaction: transaction);
+            return connection.ExecuteScalar<T>("SELECT LAST_INSERT_ID();", transaction: transaction);
         }
 
         /// <summary>
         /// Gets the newly generated identity from the database in an asynchronous way.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> object to be used during the asynchronous operation.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        public Task<object> GetScopeIdentityAsync(IDbConnection connection,
+        public Task<T> GetScopeIdentityAsync<T>(IDbConnection connection,
             IDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
-            return connection.ExecuteScalarAsync("SELECT LAST_INSERT_ID();", transaction: transaction,
+            return connection.ExecuteScalarAsync<T>("SELECT LAST_INSERT_ID();", transaction: transaction,
                 cancellationToken: cancellationToken);
         }
 

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/DbHelperTests.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/DbHelperTests.cs
@@ -196,14 +196,14 @@ namespace RepoDb.MySqlConnector.IntegrationTests
                 var table = Helper.CreateCompleteTables(1).First();
 
                 // Act
-                var insertResult = connection.Insert<CompleteTable>(table);
+                var insertResult = connection.Insert<CompleteTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = helper.GetScopeIdentity(connection, null);
+                var result = helper.GetScopeIdentity<long>(connection, null);
 
                 // Assert
                 Assert.AreEqual(insertResult, result);
@@ -224,14 +224,14 @@ namespace RepoDb.MySqlConnector.IntegrationTests
                 var table = Helper.CreateCompleteTables(1).First();
 
                 // Act
-                var insertResult = connection.Insert<CompleteTable>(table);
+                var insertResult = connection.Insert<CompleteTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = await helper.GetScopeIdentityAsync(connection, null);
+                var result = await helper.GetScopeIdentityAsync<long>(connection, null);
 
                 // Assert
                 Assert.AreEqual(insertResult, result);

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector/DbHelpers/MySqlConnectorDbHelper.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector/DbHelpers/MySqlConnectorDbHelper.cs
@@ -238,27 +238,29 @@ namespace RepoDb.DbHelpers
         /// <summary>
         /// Gets the newly generated identity from the database.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        public object GetScopeIdentity(IDbConnection connection,
+        public T GetScopeIdentity<T>(IDbConnection connection,
             IDbTransaction transaction = null)
         {
-            return connection.ExecuteScalar("SELECT LAST_INSERT_ID();", transaction: transaction);
+            return connection.ExecuteScalar<T>("SELECT LAST_INSERT_ID();", transaction: transaction);
         }
 
         /// <summary>
         /// Gets the newly generated identity from the database in an asynchronous way.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> object to be used during the asynchronous operation.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        public Task<object> GetScopeIdentityAsync(IDbConnection connection,
+        public Task<T> GetScopeIdentityAsync<T>(IDbConnection connection,
             IDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
-            return connection.ExecuteScalarAsync("SELECT LAST_INSERT_ID();", transaction: transaction,
+            return connection.ExecuteScalarAsync<T>("SELECT LAST_INSERT_ID();", transaction: transaction,
                 cancellationToken: cancellationToken);
         }
 

--- a/RepoDb.PostgreSql/RepoDb.PostgreSql.IntegrationTests/DbHelperTests.cs
+++ b/RepoDb.PostgreSql/RepoDb.PostgreSql.IntegrationTests/DbHelperTests.cs
@@ -196,14 +196,14 @@ namespace RepoDb.PostgreSql.IntegrationTests
                 var table = Helper.CreateCompleteTables(1).First();
 
                 // Act
-                var insertResult = connection.Insert<CompleteTable>(table);
+                var insertResult = connection.Insert<CompleteTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = helper.GetScopeIdentity(connection, null);
+                var result = helper.GetScopeIdentity<long>(connection, null);
 
                 // Assert
                 Assert.AreEqual(insertResult, result);
@@ -224,14 +224,14 @@ namespace RepoDb.PostgreSql.IntegrationTests
                 var table = Helper.CreateCompleteTables(1).First();
 
                 // Act
-                var insertResult = connection.Insert<CompleteTable>(table);
+                var insertResult = connection.Insert<CompleteTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = await helper.GetScopeIdentityAsync(connection, null);
+                var result = await helper.GetScopeIdentityAsync<long>(connection, null);
 
                 // Assert
                 Assert.AreEqual(insertResult, result);

--- a/RepoDb.PostgreSql/RepoDb.PostgreSql/DbHelpers/PostgreSqlDbHelper.cs
+++ b/RepoDb.PostgreSql/RepoDb.PostgreSql/DbHelpers/PostgreSqlDbHelper.cs
@@ -212,29 +212,31 @@ namespace RepoDb.DbHelpers
         /// <summary>
         /// Gets the newly generated identity from the database.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        public object GetScopeIdentity(IDbConnection connection,
+        public T GetScopeIdentity<T>(IDbConnection connection,
             IDbTransaction transaction = null)
         {
             // TODO: May fail with trigger?
-            return connection.ExecuteScalar("SELECT lastval();", transaction: transaction);
+            return connection.ExecuteScalar<T>("SELECT lastval();", transaction: transaction);
         }
 
         /// <summary>
         /// Gets the newly generated identity from the database in an asynchronous way.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> object to be used during the asynchronous operation.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        public Task<object> GetScopeIdentityAsync(IDbConnection connection,
+        public Task<T> GetScopeIdentityAsync<T>(IDbConnection connection,
             IDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             // TODO: May fail with trigger?
-            return connection.ExecuteScalarAsync("SELECT lastval();", transaction: transaction,
+            return connection.ExecuteScalarAsync<T>("SELECT lastval();", transaction: transaction,
                 cancellationToken: cancellationToken);
         }
 

--- a/RepoDb.SQLite.System/RepoDb.SQLite.System.IntegrationTests/DbHelperTests.cs
+++ b/RepoDb.SQLite.System/RepoDb.SQLite.System.IntegrationTests/DbHelperTests.cs
@@ -197,14 +197,14 @@ namespace RepoDb.SQLite.System.IntegrationTests
                 var table = Helper.CreateSdsCompleteTables(1).First();
 
                 // Act
-                var insertResult = connection.Insert<SdsCompleteTable>(table);
+                var insertResult = connection.Insert<SdsCompleteTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = helper.GetScopeIdentity(connection, null);
+                var result = helper.GetScopeIdentity<long>(connection, null);
 
                 // Assert
                 Assert.AreEqual(insertResult, result);
@@ -228,14 +228,14 @@ namespace RepoDb.SQLite.System.IntegrationTests
                 var table = Helper.CreateSdsCompleteTables(1).First();
 
                 // Act
-                var insertResult = connection.Insert<SdsCompleteTable>(table);
+                var insertResult = connection.Insert<SdsCompleteTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = await helper.GetScopeIdentityAsync(connection, null);
+                var result = await helper.GetScopeIdentityAsync<long>(connection, null);
 
                 // Assert
                 Assert.AreEqual(insertResult, result);

--- a/RepoDb.SQLite.System/RepoDb.SQLite.System/DbHelpers/SqLiteDbHelper.cs
+++ b/RepoDb.SQLite.System/RepoDb.SQLite.System/DbHelpers/SqLiteDbHelper.cs
@@ -302,27 +302,29 @@ namespace RepoDb.DbHelpers
         /// <summary>
         /// Gets the newly generated identity from the database.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        public object GetScopeIdentity(IDbConnection connection,
+        public T GetScopeIdentity<T>(IDbConnection connection,
             IDbTransaction transaction = null)
         {
-            return connection.ExecuteScalar("SELECT last_insert_rowid();", transaction: transaction);
+            return connection.ExecuteScalar<T>("SELECT last_insert_rowid();", transaction: transaction);
         }
 
         /// <summary>
         /// Gets the newly generated identity from the database in an asynchronous way.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> object to be used during the asynchronous operation.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        public Task<object> GetScopeIdentityAsync(IDbConnection connection,
+        public Task<T> GetScopeIdentityAsync<T>(IDbConnection connection,
             IDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
-            return connection.ExecuteScalarAsync("SELECT last_insert_rowid();", transaction: transaction,
+            return connection.ExecuteScalarAsync<T>("SELECT last_insert_rowid();", transaction: transaction,
                 cancellationToken: cancellationToken);
         }
 

--- a/RepoDb.SqlServer/RepoDb.SqlServer.IntegrationTests/DbHelperTest.cs
+++ b/RepoDb.SqlServer/RepoDb.SqlServer.IntegrationTests/DbHelperTest.cs
@@ -196,17 +196,17 @@ namespace RepoDb.SqlServer.IntegrationTests
                 var table = Helper.CreateCompleteTables(1).First();
 
                 // Act
-                var insertResult = connection.Insert<CompleteTable>(table);
+                var insertResult = connection.Insert<CompleteTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = helper.GetScopeIdentity(connection, null);
+                var result = helper.GetScopeIdentity<long>(connection, null);
 
                 // Assert
-                Assert.AreEqual(Convert.ToInt64(insertResult), Convert.ToInt64(result));
+                Assert.AreEqual(insertResult, result);
             }
         }
 
@@ -224,17 +224,17 @@ namespace RepoDb.SqlServer.IntegrationTests
                 var table = Helper.CreateCompleteTables(1).First();
 
                 // Act
-                var insertResult = connection.Insert<CompleteTable>(table);
+                var insertResult = connection.Insert<CompleteTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = await helper.GetScopeIdentityAsync(connection, null);
+                var result = await helper.GetScopeIdentityAsync<long>(connection, null);
 
                 // Assert
-                Assert.AreEqual(Convert.ToInt64(insertResult), Convert.ToInt64(result));
+                Assert.AreEqual(insertResult, result);
             }
         }
 

--- a/RepoDb.SqlServer/RepoDb.SqlServer/DbHelpers/SqlServerDbHelper.cs
+++ b/RepoDb.SqlServer/RepoDb.SqlServer/DbHelpers/SqlServerDbHelper.cs
@@ -224,28 +224,30 @@ namespace RepoDb.DbHelpers
         /// <summary>
         /// Gets the newly generated identity from the database.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        public object GetScopeIdentity(IDbConnection connection,
+        public T GetScopeIdentity<T>(IDbConnection connection,
             IDbTransaction transaction = null)
         {
-            return connection.ExecuteScalar("SELECT COALESCE(SCOPE_IDENTITY(), @@IDENTITY);",
+            return connection.ExecuteScalar<T>("SELECT COALESCE(SCOPE_IDENTITY(), @@IDENTITY);",
                 transaction: transaction);
         }
 
         /// <summary>
         /// Gets the newly generated identity from the database in an asynchronous way.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> object to be used during the asynchronous operation.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        public async Task<object> GetScopeIdentityAsync(IDbConnection connection,
+        public async Task<T> GetScopeIdentityAsync<T>(IDbConnection connection,
             IDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
-            return await connection.ExecuteScalarAsync("SELECT COALESCE(SCOPE_IDENTITY(), @@IDENTITY);",
+            return await connection.ExecuteScalarAsync<T>("SELECT COALESCE(SCOPE_IDENTITY(), @@IDENTITY);",
                 transaction: transaction,
                 cancellationToken: cancellationToken);
         }

--- a/RepoDb.Sqlite.Microsoft/RepoDb.Sqlite.Microsoft.IntegrationTests/DbHelperTests.cs
+++ b/RepoDb.Sqlite.Microsoft/RepoDb.Sqlite.Microsoft.IntegrationTests/DbHelperTests.cs
@@ -197,14 +197,14 @@ namespace RepoDb.Sqlite.Microsoft.IntegrationTests
                 var table = Helper.CreateMdsCompleteTables(1).First();
 
                 // Act
-                var insertResult = connection.Insert<MdsCompleteTable>(table);
+                var insertResult = connection.Insert<MdsCompleteTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = helper.GetScopeIdentity(connection, null);
+                var result = helper.GetScopeIdentity<long>(connection, null);
 
                 // Assert
                 Assert.AreEqual(insertResult, result);
@@ -228,14 +228,14 @@ namespace RepoDb.Sqlite.Microsoft.IntegrationTests
                 var table = Helper.CreateMdsCompleteTables(1).First();
 
                 // Act
-                var insertResult = connection.Insert<MdsCompleteTable>(table);
+                var insertResult = connection.Insert<MdsCompleteTable, long>(table);
 
                 // Assert
-                Assert.IsTrue(Convert.ToInt64(insertResult) > 0);
+                Assert.IsTrue(insertResult > 0);
                 Assert.IsTrue(table.Id > 0);
 
                 // Act
-                var result = await helper.GetScopeIdentityAsync(connection, null);
+                var result = await helper.GetScopeIdentityAsync<long>(connection, null);
 
                 // Assert
                 Assert.AreEqual(insertResult, result);

--- a/RepoDb.Sqlite.Microsoft/RepoDb.Sqlite.Microsoft/DbHelpers/SqLiteDbHelper.cs
+++ b/RepoDb.Sqlite.Microsoft/RepoDb.Sqlite.Microsoft/DbHelpers/SqLiteDbHelper.cs
@@ -302,27 +302,29 @@ namespace RepoDb.DbHelpers
         /// <summary>
         /// Gets the newly generated identity from the database.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        public object GetScopeIdentity(IDbConnection connection,
+        public T GetScopeIdentity<T>(IDbConnection connection,
             IDbTransaction transaction = null)
         {
-            return connection.ExecuteScalar("SELECT last_insert_rowid();", transaction: transaction);
+            return connection.ExecuteScalar<T>("SELECT last_insert_rowid();", transaction: transaction);
         }
 
         /// <summary>
         /// Gets the newly generated identity from the database in an asynchronous way.
         /// </summary>
+        /// <typeparam name="T">The type of newly generated identity.</typeparam>
         /// <param name="connection">The instance of the connection object.</param>
         /// <param name="transaction">The transaction object that is currently in used.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> object to be used during the asynchronous operation.</param>
         /// <returns>The newly generated identity from the database.</returns>
-        public Task<object> GetScopeIdentityAsync(IDbConnection connection,
+        public Task<T> GetScopeIdentityAsync<T>(IDbConnection connection,
             IDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
-            return connection.ExecuteScalarAsync("SELECT last_insert_rowid();", transaction: transaction,
+            return connection.ExecuteScalarAsync<T>("SELECT last_insert_rowid();", transaction: transaction,
                 cancellationToken: cancellationToken);
         }
 


### PR DESCRIPTION
This is a small breakingchange, but it avoids an unnecessary allocation