### PR TITLE
Using ReadonlySpan instead of String

### DIFF
--- a/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/DbCommandExtension.cs
@@ -843,20 +843,31 @@ namespace RepoDb.Extensions
         private static DbField GetDbField(string fieldName,
             IEnumerable<DbField> dbFields)
         {
-            if (string.IsNullOrWhiteSpace(fieldName))
+            if (dbFields.IsNullOrEmpty()) return null;
+            
+            var fieldNameSpan = fieldName.AsSpan();
+            
+            if (fieldNameSpan.IsEmpty || fieldNameSpan.IsWhiteSpace())
             {
                 return null;
             }
-
-            var index = fieldName.IndexOf("_In_", StringComparison.OrdinalIgnoreCase);
+            
+            var index = fieldNameSpan.IndexOf("_In_".AsSpan(), StringComparison.OrdinalIgnoreCase);
 
             if (index >= 0)
             {
-                fieldName = fieldName.Substring(0, index);
+                fieldNameSpan = fieldNameSpan.Slice(0, index);
             }
 
-            return dbFields?.FirstOrDefault(df =>
-                string.Equals(df.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+            foreach (var dbField in dbFields)
+            {
+                if (dbField.Name.AsSpan().Equals(fieldNameSpan, StringComparison.OrdinalIgnoreCase))
+                {
+                    return dbField;
+                }
+            }
+            
+            return null;
         }
 
         /// <summary>

--- a/RepoDb.Core/RepoDb/RepoDb.csproj
+++ b/RepoDb.Core/RepoDb/RepoDb.csproj
@@ -36,6 +36,7 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+		<PackageReference Include="System.Memory" Version="4.5.5" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Calling Substring produces a copy of the extracted substring. By using AsSpan instead of Substring we can eliminate the unnecessary string allocation.

before:
![изображение](https://user-images.githubusercontent.com/880792/202779408-cd9fd36b-6091-460e-953c-eeb0148c9c03.png)

after:
![изображение](https://user-images.githubusercontent.com/880792/202779598-222b88c9-e84e-4270-8f89-3344e79a3be2.png)
