### PR TITLE
Optimized the method GetCustomAttribute

### DIFF
--- a/RepoDb.Core/RepoDb/ClassProperty.cs
+++ b/RepoDb.Core/RepoDb/ClassProperty.cs
@@ -130,7 +130,7 @@ namespace RepoDb
                 return identityAttribute;
             }
             isIdentityAttributeWasSet = true;
-            return identityAttribute = PropertyInfo.GetCustomAttribute(StaticType.IdentityAttribute) as IdentityAttribute;
+            return identityAttribute = PropertyInfo.GetCustomAttribute<IdentityAttribute>();
         }
 
         /*
@@ -150,7 +150,7 @@ namespace RepoDb
                 return typeMapAttribute;
             }
             isTypeMapAttributeWasSet = true;
-            return typeMapAttribute = PropertyInfo.GetCustomAttribute(StaticType.TypeMapAttribute) as TypeMapAttribute;
+            return typeMapAttribute = PropertyInfo.GetCustomAttribute<TypeMapAttribute>();
         }
 
         /*
@@ -170,8 +170,8 @@ namespace RepoDb
                 return propertyValueAttribute;
             }
             isDbTypeAttributeWasSet = true;
-            return propertyValueAttribute = (PropertyInfo.GetCustomAttribute(StaticType.DbTypeAttribute) ??
-                PropertyInfo.GetCustomAttribute(StaticType.TypeMapAttribute)) as DbTypeAttribute ??
+            return propertyValueAttribute = (PropertyInfo.GetCustomAttribute<DbTypeAttribute>() ??
+                PropertyInfo.GetCustomAttribute<TypeMapAttribute>()) ??
                 (GetPropertyValueAttributes()
                     .Where(
                         e => string.Equals(nameof(IDbDataParameter.ParameterName), e.PropertyName, StringComparison.OrdinalIgnoreCase))
@@ -195,7 +195,7 @@ namespace RepoDb
                 return propertyHandlerAttribute;
             }
             isPropertyHandlerAttributeWasSet = true;
-            return propertyHandlerAttribute = PropertyInfo.GetCustomAttribute(StaticType.PropertyHandlerAttribute) as PropertyHandlerAttribute;
+            return propertyHandlerAttribute = PropertyInfo.GetCustomAttribute<PropertyHandlerAttribute>();
         }
 
         /*

--- a/RepoDb.Core/RepoDb/Extensions/EnumerableExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/EnumerableExtension.cs
@@ -94,17 +94,22 @@ namespace RepoDb.Extensions
 
 #if NETSTANDARD2_0
         /// <summary>
-        /// 
+        /// CCreates a new <see cref="HashSet{T}"/> from an <see cref="IEnumerable{T}"/>.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="source"></param>
-        /// <param name="comparer"></param>
-        /// <returns></returns>
-        internal static HashSet<T> ToHashSet<T>(this IEnumerable<T> source,
-            IEqualityComparer<T> comparer)
-        {
-            return new(source, comparer);
-        }
+        /// <typeparam name="T">The type of the elements.</typeparam>
+        /// <param name="source">The actual enumerable instance.</param>
+        /// <param name="comparer">An <see cref="IEqualityComparer{T}"/> to compare keys.</param>
+        /// <returns>The created <see cref="HashSet{T}"/> object.</returns>
+        internal static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer) => 
+            new(source, comparer);
+
+        /// <summary>
+        /// Creates a new <see cref="HashSet{T}"/> from an <see cref="IEnumerable{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements=.</typeparam>
+        /// <param name="source">The actual enumerable instance.</param>
+        /// <returns>The created <see cref="HashSet{T}"/> object.</returns>
+        internal static HashSet<T> ToHashSet<T>(this IEnumerable<T> source) => new(source);
 #endif
     }
 }

--- a/RepoDb.Core/RepoDb/Extensions/PropertyInfoExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/PropertyInfoExtension.cs
@@ -24,20 +24,7 @@ namespace RepoDb.Extensions
         /// <returns>The custom attribute.</returns>
         public static T GetCustomAttribute<T>(this PropertyInfo property)
             where T : Attribute =>
-            (T)GetCustomAttribute(property, typeof(T));
-
-        /// <summary>
-        /// Gets a custom attribute defined on the property.
-        /// </summary>
-        /// <param name="property">The property of where the custom attribute is defined.</param>
-        /// <param name="type">The custom attribute that is defined into the property.</param>
-        /// <returns>The custom attribute.</returns>
-        public static Attribute GetCustomAttribute(this PropertyInfo property,
-            Type type)
-        {
-            var attributes = property.GetCustomAttributes(type, false).WithType<Attribute>();
-            return attributes?.FirstOrDefault(a => a.GetType() == type);
-        }
+            property.GetCustomAttribute<T>(false);
 
         /// <summary>
         /// Gets the mapped name of the property.
@@ -56,9 +43,9 @@ namespace RepoDb.Extensions
         internal static string GetMappedName(this PropertyInfo property,
             Type declaringType)
         {
-            var mappedName = ((MapAttribute)GetCustomAttribute(property, StaticType.MapAttribute))?.Name ??
-                ((ColumnAttribute)GetCustomAttribute(property, StaticType.ColumnAttribute))?.Name ??
-                ((NameAttribute)GetCustomAttribute(property, StaticType.NameAttribute))?.Name;
+            var mappedName = GetCustomAttribute<MapAttribute>(property)?.Name ??
+                GetCustomAttribute<ColumnAttribute>(property)?.Name ??
+                GetCustomAttribute<NameAttribute>(property)?.Name;
 
             return mappedName ??
                 PropertyMapper.Get(declaringType, property) ??
@@ -220,11 +207,8 @@ namespace RepoDb.Extensions
             Type declaringType)
         {
             var customAttributes = property?
-                .GetCustomAttributes()?
-                .Where(e =>
-                    StaticType.PropertyValueAttribute.IsAssignableFrom(e.GetType()))
-                .Select(e =>
-                    (PropertyValueAttribute)e);
+                .GetCustomAttributes<PropertyValueAttribute>()
+                .ToHashSet();
 
             var mappedAttributes = PropertyValueAttributeMapper
                 .Get((declaringType ?? property?.DeclaringType), property)?


### PR DESCRIPTION
The method GetCustomAttribute worked with a collection, although there is an implementation for a single call.
It also allowed fixed double-casting.