### PR TITLE
#1132 Bug: PostgreSQL BinaryBulkMerge not working when table has name "schema.table"

### DIFF
--- a/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations.IntegrationTests/Operations/BinaryBulkDeleteTest.cs
+++ b/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations.IntegrationTests/Operations/BinaryBulkDeleteTest.cs
@@ -4,6 +4,7 @@ using RepoDb.Enumerations.PostgreSql;
 using RepoDb.IntegrationTests.Setup;
 using RepoDb.PostgreSql.BulkOperations.IntegrationTests.Models;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace RepoDb.PostgreSql.BulkOperations.IntegrationTests.Operations
 {
@@ -57,6 +58,31 @@ namespace RepoDb.PostgreSql.BulkOperations.IntegrationTests.Operations
                 var countResult = connection.CountAll(tableName);
                 Assert.AreEqual(0, countResult);
             }
+        }
+        
+        [TestMethod]
+        public void TestBinaryBulkDeleteTableNameWithSchema()
+        {
+            using var connection = GetConnection();
+            
+            // Prepare
+            var entities = Helper.CreateBulkOperationLightIdentityTables(10, true);
+            var tableName = "public.BulkOperationIdentityTable";
+            
+            // Act
+            connection.BinaryBulkInsert(tableName,
+                entities: entities,
+                identityBehavior: BulkImportIdentityBehavior.KeepIdentity);
+
+            // Act
+            var result = connection.BinaryBulkDelete(tableName, entities);
+
+            // Assert
+            Assert.AreEqual(entities.Count, result);
+
+            // Assert
+            var countResult = connection.CountAll(tableName);
+            Assert.AreEqual(0, countResult);
         }
 
         [TestMethod]
@@ -1243,6 +1269,31 @@ namespace RepoDb.PostgreSql.BulkOperations.IntegrationTests.Operations
                 var countResult = connection.CountAll(tableName);
                 Assert.AreEqual(0, countResult);
             }
+        }
+        
+        [TestMethod]
+        public async Task TestBinaryBulkDeleteAsyncTableNameWithSchema()
+        {
+            await using var connection = GetConnection();
+            
+            // Prepare
+            var entities = Helper.CreateBulkOperationLightIdentityTables(10, true);
+            var tableName = "public.BulkOperationIdentityTable";
+            
+            // Act
+            await connection.BinaryBulkInsertAsync(tableName,
+                entities: entities,
+                identityBehavior: BulkImportIdentityBehavior.KeepIdentity);
+
+            // Act
+            var result = await connection.BinaryBulkDeleteAsync(tableName, entities);
+
+            // Assert
+            Assert.AreEqual(entities.Count, result);
+
+            // Assert
+            var countResult = await connection.CountAllAsync(tableName);
+            Assert.AreEqual(0, countResult);
         }
 
         [TestMethod]

--- a/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations.IntegrationTests/Operations/BinaryBulkInsertTest.cs
+++ b/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations.IntegrationTests/Operations/BinaryBulkInsertTest.cs
@@ -6,6 +6,7 @@ using RepoDb.PostgreSql.BulkOperations.IntegrationTests.Models;
 using System;
 using System.Data;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace RepoDb.PostgreSql.BulkOperations.IntegrationTests.Operations
 {
@@ -54,6 +55,27 @@ namespace RepoDb.PostgreSql.BulkOperations.IntegrationTests.Operations
                 var assertCount = Helper.AssertEntitiesEquality(entities, queryResult, (t1, t2) => entities.IndexOf(t1) == queryResult.IndexOf(t2));
                 Assert.AreEqual(entities.Count(), assertCount);
             }
+        }
+        
+        [TestMethod]
+        public void TestBinaryBulkInsertTableNameWithSchema()
+        {
+            using var connection = GetConnection();
+            
+            // Prepare
+            var entities = Helper.CreateBulkOperationLightIdentityTables(10, false);
+            var tableName = "public.BulkOperationIdentityTable";
+            
+            // Act
+            var result = connection.BinaryBulkInsert(tableName, entities);
+
+            // Assert
+            Assert.AreEqual(entities.Count, result);
+
+            // Assert
+            var queryResult = connection.QueryAll<BulkOperationLightIdentityTable>(tableName).ToList();
+            var assertCount = Helper.AssertEntitiesEquality(entities, queryResult, (t1, t2) => entities.IndexOf(t1) == queryResult.IndexOf(t2));
+            Assert.AreEqual(entities.Count, assertCount);
         }
 
         [TestMethod]
@@ -2023,6 +2045,27 @@ namespace RepoDb.PostgreSql.BulkOperations.IntegrationTests.Operations
             }
         }
 
+        [TestMethod]
+        public async Task TestBinaryBulkInsertAsyncTableNameWithSchema()
+        {
+            await using var connection = GetConnection();
+            
+            // Prepare
+            var entities = Helper.CreateBulkOperationLightIdentityTables(10, false);
+            var tableName = "public.BulkOperationIdentityTable";
+            
+            // Act
+            var result = await connection.BinaryBulkInsertAsync(tableName, entities);
+
+            // Assert
+            Assert.AreEqual(entities.Count, result);
+
+            // Assert
+            var queryResult = connection.QueryAll<BulkOperationLightIdentityTable>(tableName).ToList();
+            var assertCount = Helper.AssertEntitiesEquality(entities, queryResult, (t1, t2) => entities.IndexOf(t1) == queryResult.IndexOf(t2));
+            Assert.AreEqual(entities.Count, assertCount);
+        }
+        
         [TestMethod]
         public void TestBinaryBulkInsertAsyncWithIdentityValues()
         {

--- a/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations.IntegrationTests/Operations/BinaryBulkMergeTest.cs
+++ b/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations.IntegrationTests/Operations/BinaryBulkMergeTest.cs
@@ -6,6 +6,7 @@ using RepoDb.PostgreSql.BulkOperations.IntegrationTests.Models;
 using System;
 using System.Data;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace RepoDb.PostgreSql.BulkOperations.IntegrationTests.Operations
 {
@@ -54,6 +55,27 @@ namespace RepoDb.PostgreSql.BulkOperations.IntegrationTests.Operations
                 var assertCount = Helper.AssertEntitiesEquality(entities, queryResult, (t1, t2) => entities.IndexOf(t1) == queryResult.IndexOf(t2));
                 Assert.AreEqual(entities.Count(), assertCount);
             }
+        }
+        
+        [TestMethod]
+        public void TestBinaryBulkMergeTableNameWithSchema()
+        {
+            using var connection = GetConnection();
+            
+            // Prepare
+            var entities = Helper.CreateBulkOperationLightIdentityTables(10, false);
+            var tableName = "public.BulkOperationIdentityTable";
+            
+            // Act
+            var result = connection.BinaryBulkMerge(tableName, entities);
+
+            // Assert
+            Assert.AreEqual(entities.Count, result);
+
+            // Assert
+            var queryResult = connection.QueryAll<BulkOperationLightIdentityTable>(tableName).ToList();
+            var assertCount = Helper.AssertEntitiesEquality(entities, queryResult, (t1, t2) => entities.IndexOf(t1) == queryResult.IndexOf(t2));
+            Assert.AreEqual(entities.Count, assertCount);
         }
 
         [TestMethod]
@@ -2740,6 +2762,27 @@ namespace RepoDb.PostgreSql.BulkOperations.IntegrationTests.Operations
             }
         }
 
+        [TestMethod]
+        public async Task TestBinaryBulkMergeAsyncTableNameWithSchema()
+        {
+            await using var connection = GetConnection();
+            
+            // Prepare
+            var entities = Helper.CreateBulkOperationLightIdentityTables(10, false);
+            var tableName = "public.BulkOperationIdentityTable";
+            
+            // Act
+            var result = await connection.BinaryBulkMergeAsync(tableName, entities);
+
+            // Assert
+            Assert.AreEqual(entities.Count, result);
+
+            // Assert
+            var queryResult = connection.QueryAll<BulkOperationLightIdentityTable>(tableName).ToList();
+            var assertCount = Helper.AssertEntitiesEquality(entities, queryResult, (t1, t2) => entities.IndexOf(t1) == queryResult.IndexOf(t2));
+            Assert.AreEqual(entities.Count, assertCount);
+        }
+        
         [TestMethod]
         public void TestBinaryBulkMergeAsyncWithBatchSize()
         {

--- a/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations.IntegrationTests/Operations/BinaryBulkUpdateTest.cs
+++ b/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations.IntegrationTests/Operations/BinaryBulkUpdateTest.cs
@@ -4,6 +4,7 @@ using RepoDb.Enumerations.PostgreSql;
 using RepoDb.IntegrationTests.Setup;
 using RepoDb.PostgreSql.BulkOperations.IntegrationTests.Models;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace RepoDb.PostgreSql.BulkOperations.IntegrationTests.Operations
 {
@@ -62,6 +63,37 @@ namespace RepoDb.PostgreSql.BulkOperations.IntegrationTests.Operations
                 var assertCount = Helper.AssertEntitiesEquality(entities, queryResult, (t1, t2) => t1.Id == t2.Id, false);
                 Assert.AreEqual(entities.Count(), assertCount);
             }
+        }
+        
+        [TestMethod]
+        public void TestBinaryBulkUpdateTableNameWithSchema()
+        {
+            using var connection = GetConnection();
+            
+            // Prepare
+            var createdEntities = Helper.CreateBulkOperationLightIdentityTables(10, true);
+            var tableName = "public.BulkOperationIdentityTable";
+            
+            // Act
+            connection.BinaryBulkInsert(tableName,
+                entities: createdEntities,
+                identityBehavior: BulkImportIdentityBehavior.KeepIdentity);
+
+            // Prepare
+            var updatedEntities = Helper.UpdateBulkOperationLightIdentityTables(createdEntities);
+
+            // Act
+            var result = connection.BinaryBulkUpdate(tableName, updatedEntities);
+
+            // Assert
+            Assert.AreEqual(updatedEntities.Count, result);
+
+            // Assert
+            var queryResult = connection.QueryAll<BulkOperationLightIdentityTable>(tableName).ToList();
+            Assert.AreEqual(10, queryResult.Count);
+            
+            var assertCount = Helper.AssertEntitiesEquality(updatedEntities, queryResult, (t1, t2) => t1.Id == t2.Id, false);
+            Assert.AreEqual(expected: updatedEntities.Count, assertCount);
         }
 
         [TestMethod]
@@ -1693,6 +1725,37 @@ namespace RepoDb.PostgreSql.BulkOperations.IntegrationTests.Operations
                 var assertCount = Helper.AssertEntitiesEquality(entities, queryResult, (t1, t2) => t1.Id == t2.Id, false);
                 Assert.AreEqual(entities.Count(), assertCount);
             }
+        }
+        
+        [TestMethod]
+        public async Task TestBinaryBulkUpdateAsyncTableNameWithSchema()
+        {
+            await using var connection = GetConnection();
+            
+            // Prepare
+            var createdEntities = Helper.CreateBulkOperationLightIdentityTables(10, true);
+            var tableName = "public.BulkOperationIdentityTable";
+            
+            // Act
+            await connection.BinaryBulkInsertAsync(tableName,
+                entities: createdEntities,
+                identityBehavior: BulkImportIdentityBehavior.KeepIdentity);
+
+            // Prepare
+            var updatedEntities = Helper.UpdateBulkOperationLightIdentityTables(createdEntities);
+
+            // Act
+            var result = await connection.BinaryBulkUpdateAsync(tableName, updatedEntities);
+
+            // Assert
+            Assert.AreEqual(updatedEntities.Count, result);
+
+            // Assert
+            var queryResult = connection.QueryAll<BulkOperationLightIdentityTable>(tableName).ToList();
+            Assert.AreEqual(10, queryResult.Count);
+            
+            var assertCount = Helper.AssertEntitiesEquality(updatedEntities, queryResult, (t1, t2) => t1.Id == t2.Id, false);
+            Assert.AreEqual(expected: updatedEntities.Count, assertCount);
         }
 
         [TestMethod]

--- a/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations/Extensions/NpgsqlText.cs
+++ b/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations/Extensions/NpgsqlText.cs
@@ -1162,7 +1162,7 @@ SET ""Identity"" = EXCLUDED.""Identity"";";
         /// <returns></returns>
         private static string GetBinaryBulkInsertPseudoTableName(string tableName,
             IDbSetting dbSetting) =>
-            $"_RepoDb_BinaryBulkInsert_{tableName.AsUnquoted(true, dbSetting)}";
+            $"_RepoDb_BinaryBulkInsert_{tableName.AsUnquoted(true, dbSetting).AsAlphaNumeric()}";
 
         /// <summary>
         /// 
@@ -1172,7 +1172,7 @@ SET ""Identity"" = EXCLUDED.""Identity"";";
         /// <returns></returns>
         private static string GetBinaryBulkMergePseudoTableName(string tableName,
             IDbSetting dbSetting) =>
-            $"_RepoDb_BinaryBulkMerge_{tableName.AsUnquoted(true, dbSetting)}";
+            $"_RepoDb_BinaryBulkMerge_{tableName.AsUnquoted(true, dbSetting).AsAlphaNumeric()}";
 
         /// <summary>
         /// 
@@ -1182,7 +1182,7 @@ SET ""Identity"" = EXCLUDED.""Identity"";";
         /// <returns></returns>
         private static string GetBinaryBulkUpdatePseudoTableName(string tableName,
             IDbSetting dbSetting) =>
-            $"_RepoDb_BinaryBulkUpdate_{tableName.AsUnquoted(true, dbSetting)}";
+            $"_RepoDb_BinaryBulkUpdate_{tableName.AsUnquoted(true, dbSetting).AsAlphaNumeric()}";
 
         /// <summary>
         /// 
@@ -1192,7 +1192,7 @@ SET ""Identity"" = EXCLUDED.""Identity"";";
         /// <returns></returns>
         private static string GetBinaryBulkDeletePseudoTableName(string tableName,
             IDbSetting dbSetting) =>
-            $"_RepoDb_BinaryBulkDelete_{tableName.AsUnquoted(true, dbSetting)}";
+            $"_RepoDb_BinaryBulkDelete_{tableName.AsUnquoted(true, dbSetting).AsAlphaNumeric()}";
 
         /// <summary>
         /// 


### PR DESCRIPTION
When we call bulk methods for tables with schema, we get result **_RepoDb_BinaryBulkMerge_schema.table** in this line https://github.com/mikependon/RepoDB/blob/3dc60f117dcddc9cade2d2071570c93599530f97/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations/Extensions/NpgsqlText.cs#L1175

So, when trying to use this name, we call the AsQuoted method https://github.com/mikependon/RepoDB/blob/74ced7851a8256460170c0429ab391e705f8b0b2/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations/Extensions/NpgsqlPseudoTable.cs#L357 and get new table with schema **"_RepoDb_BinaryBulkMerge_schema"."table"**

To avoid this I added call the _AsAlphaNumeric_ method.