### PR TITLE
Mitigate thread race conditions & hashcode collision risks

### DIFF
--- a/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/RepoDb.Benchmarks.PostgreSql.csproj
+++ b/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/RepoDb.Benchmarks.PostgreSql.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="linq2db.PostgreSQL" Version="4.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
     <PackageReference Include="NHibernate" Version="5.4.0" />
-    <PackageReference Include="Npgsql" Version="7.0.0" />
+    <PackageReference Include="Npgsql" Version="7.0.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
   </ItemGroup>
 

--- a/RepoDb.Core/RepoDb/Cachers/DbFieldCache.cs
+++ b/RepoDb.Core/RepoDb/Cachers/DbFieldCache.cs
@@ -1,4 +1,5 @@
-﻿using RepoDb.Exceptions;
+﻿using System;
+using RepoDb.Exceptions;
 using System.Collections.Concurrent;
 using System.Data;
 using System.Threading;
@@ -88,13 +89,13 @@ namespace RepoDb
             // Note: For SqlConnection, the ConnectionString is changing if the (Integrated Security=False). Actually for this isolation, the database name is enough.
             if (!string.IsNullOrWhiteSpace(connection.Database))
             {
-                key += connection.Database.GetHashCode();
+                key = HashCode.Combine(key, connection.Database.GetHashCode());
             }
 
             // Add the hashcode of the table name
             if (string.IsNullOrWhiteSpace(tableName) == false)
             {
-                key += tableName.GetHashCode();
+                key = HashCode.Combine(key, tableName.GetHashCode());
             }
 
             // Try get the value
@@ -177,13 +178,13 @@ namespace RepoDb
             // Note: For SqlConnection, the ConnectionString is changing if the (Integrated Security=False). Actually for this isolation, the database name is enough.
             if (!string.IsNullOrWhiteSpace(connection.Database))
             {
-                key += connection.Database.GetHashCode();
+                key = HashCode.Combine(key, connection.Database.GetHashCode());
             }
 
             // Add the hashcode of the table name
             if (string.IsNullOrWhiteSpace(tableName) == false)
             {
-                key += tableName.GetHashCode();
+                key = HashCode.Combine(key, tableName.GetHashCode());
             }
 
             // Try get the value

--- a/RepoDb.Core/RepoDb/Extensions/TypeExtension.cs
+++ b/RepoDb.Core/RepoDb/Extensions/TypeExtension.cs
@@ -241,7 +241,7 @@ namespace RepoDb.Extensions
         /// <returns>The generated hashcode.</returns>
         public static int GenerateHashCode(Type entityType,
             PropertyInfo propertyInfo) =>
-            entityType.GetHashCode() + propertyInfo.GenerateCustomizedHashCode(entityType);
+            HashCode.Combine(entityType.GetHashCode(), propertyInfo.GenerateCustomizedHashCode(entityType));
 
         /// <summary>
         /// A helper method to return the instance of <see cref="PropertyInfo"/> object based on name.

--- a/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations/Compiler.cs
+++ b/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations/Compiler.cs
@@ -732,8 +732,12 @@ namespace RepoDb.PostgreSql.BulkOperations
             public static Func<TEntity, object[], TResult> GetFunc(string methodName,
                 Type[] types)
             {
-                var key = methodName.GetHashCode() + types?.Sum(e => e.GetHashCode());
-                if (cache.TryGetValue(key.Value, out var func) == false)
+                var key = HashCode.Combine(methodName.GetHashCode());
+                for (int i = 0; i < types.Length; i++)
+                {
+                    key = HashCode.Combine(key, types[i].GetHashCode());
+                }
+                if (cache.TryGetValue(key, out var func) == false)
                 {
                     var typeOfEntity = typeof(TEntity);
                     var method = typeOfEntity.GetMethod(methodName, types);
@@ -756,7 +760,7 @@ namespace RepoDb.PostgreSql.BulkOperations
                             .Compile();
                     }
 
-                    cache.TryAdd(key.Value, func);
+                    cache.TryAdd(key, func);
                 }
                 return func;
             }
@@ -796,8 +800,12 @@ namespace RepoDb.PostgreSql.BulkOperations
             public static Action<TEntity, object[]> GetFunc(string methodName,
                 Type[] types)
             {
-                var key = methodName.GetHashCode() + types?.Sum(e => e.GetHashCode());
-                if (cache.TryGetValue(key.Value, out var func) == false)
+                var key = HashCode.Combine(methodName.GetHashCode());
+                for (int i = 0; i < types.Length; i++)
+                {
+                    key = HashCode.Combine(key, types[i].GetHashCode());
+                }
+                if (cache.TryGetValue(key, out var func) == false)
                 {
                     var typeOfEntity = typeof(TEntity);
                     var method = typeOfEntity.GetMethod(methodName, types);
@@ -820,7 +828,7 @@ namespace RepoDb.PostgreSql.BulkOperations
                             .Compile();
                     }
 
-                    cache.TryAdd(key.Value, func);
+                    cache.TryAdd(key, func);
                 }
                 return func;
             }


### PR DESCRIPTION
We have been seeing intermittent instances of this issue happening https://github.com/mikependon/RepoDB/issues/1133

It has taken a lot of debugging and stepping through in order to isolate the potential issue, but we've observed no recurrence of the errors since applying this patch locally and are therefore submitting a PR.

We are in a TimescaleDb / Postgresql 15 environment and are using RepoDb for its binary protocol support for bulk operations.

## Findings

### Race conditions

When creating db commands during both reads and inserts, the `ClassProperty.GetPropertyHandler<TPropertyHandler>()` is executed. The returned property handler is used to modify db commands such that their type matches what the database engine expects, and the value of the parameters is converted using the property handler. Quite elegant and also explains why at first we could find no use of Npgsql's TypeMapper system in the Postgresql-specific projects!

However, the code as-is can cause a null return for properties that do have a property handler. 

Consider 2 threads:

One enters `GetPropertyHandler<TPropertyHandler>()`, where `propertyHandlerWasSet` is false, so it proceeds to set `propertyHandlerWasSet = true` before it has obtained a reference to `PropertyHandlerCache.Get<TPropertyHandler>(GetDeclaringType(), PropertyInfo);`. A second thread entering `GetPropertyHandler<TPropertyHandler>()` at this point can then observe `propertyHandlerWasSet` to be `true`, causing the method to return null. When this method returns null, the db parameter is not modified, and leads to errors such as reported in the mentioned issue because the unconverted type is passed through to the database provider.

### Hashcode collisions

Furthermore in other areas we observed a chance for hashcode collisions when constructing cache keys, due to summing other hashcodes. Instead, this code has been converted to use `HashCode.Combine`.