### PR TITLE
 Issue 1159 - Bug: Exception "A transaction is already in progress; nested/concurrent transactions aren't supported." when using TransactionScope with PostgreSQL bulk operations #1159 

### DIFF
--- a/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations/Extensions/NpgsqlWrapper.cs
+++ b/RepoDb.Extensions/RepoDb.PostgreSql.BulkOperations/RepoDb.PostgreSql.BulkOperations/Extensions/NpgsqlWrapper.cs
@@ -334,7 +334,7 @@ namespace RepoDb
         {
             // Variables
             var result = default(TResult);
-            var hasTransaction = transaction != null;
+            var hasTransaction = (transaction == null || Transaction.Current != null);
 
             // Open
             await connection.EnsureOpenAsync(cancellationToken);


### PR DESCRIPTION
PR for fixing bug of throwing exception when using TransactionScope for async bulk operations https://github.com/mikependon/RepoDB/issues/1159