### PR TITLE
Generic Attribute for ClassHandler

### DIFF
--- a/RepoDb.Core/RepoDb/Attributes/ClassHandlerAttribute.cs
+++ b/RepoDb.Core/RepoDb/Attributes/ClassHandlerAttribute.cs
@@ -34,7 +34,7 @@ namespace RepoDb.Attributes
         /// 
         /// </summary>
         /// <param name="handlerType"></param>
-        private void Validate(Type handlerType)
+        private static void Validate(Type handlerType)
         {
             if (handlerType?.IsInterfacedTo(StaticType.IClassHandler) != true)
             {
@@ -44,4 +44,33 @@ namespace RepoDb.Attributes
 
         #endregion
     }
+    
+#if NET7_0_OR_GREATER
+    /// <summary>
+    /// An attribute that is used to define a handler for the property transformation.
+    /// </summary>
+    public class ClassHandlerAttribute<T> : Attribute
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="ClassHandlerAttribute{T}"/> class.
+        /// </summary>
+        public ClassHandlerAttribute() => Validate(typeof(T));
+
+        #region Methods
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="handlerType"></param>
+        private static void Validate(Type handlerType)
+        {
+            if (handlerType?.IsInterfacedTo(StaticType.IClassHandler) != true)
+            {
+                throw new InvalidTypeException($"Type '{handlerType.FullName}' must implement the '{StaticType.IClassHandler}' interface.");
+            }
+        }
+
+        #endregion
+    }
+#endif
 }


### PR DESCRIPTION
How about using generic attributes. For example for a ClassHandlerAttribute.

Then instead of:
```
[ClassHandler(typeof(PersonClassHandler))]
public class Person
{
	public long Id { get; set; }
	public string Name { get; set; }
}
```

we can use:
```
[ClassHandler<PersonClassHandler>]
public class Person
{
	public long Id { get; set; }
	public string Name { get; set; }
}
```

The only limitation is that this feature is only available for net 7 or greate.