### PR TITLE
Honour cache expiration from ctor if not passed explicitly

### DIFF
--- a/RepoDb.Core/RepoDb/BaseRepository.cs
+++ b/RepoDb.Core/RepoDb/BaseRepository.cs
@@ -316,14 +316,14 @@ namespace RepoDb
             object param = null,
             CommandType? commandType = null,
             string cacheKey = null,
-            int? cacheItemExpiration = Constant.DefaultCacheItemExpirationInMinutes,
+            int? cacheItemExpiration = null,
             IDbTransaction transaction = null)
         {
             return DbRepository.ExecuteQuery<TEntity>(commandText: commandText,
                 param: param,
                 commandType: commandType,
                 cacheKey: cacheKey,
-                cacheItemExpiration: cacheItemExpiration,
+                cacheItemExpiration: cacheItemExpiration ?? CacheItemExpiration,
                 transaction: transaction);
         }
 
@@ -354,7 +354,7 @@ namespace RepoDb
             object param = null,
             CommandType? commandType = null,
             string cacheKey = null,
-            int? cacheItemExpiration = Constant.DefaultCacheItemExpirationInMinutes,
+            int? cacheItemExpiration = null,
             IDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
@@ -362,7 +362,7 @@ namespace RepoDb
                 param: param,
                 commandType: commandType,
                 cacheKey: cacheKey,
-                cacheItemExpiration: cacheItemExpiration,
+                cacheItemExpiration: cacheItemExpiration ?? CacheItemExpiration,
                 transaction: transaction,
                 cancellationToken: cancellationToken);
         }

--- a/RepoDb.Core/RepoDb/DbRepository.cs
+++ b/RepoDb.Core/RepoDb/DbRepository.cs
@@ -368,7 +368,7 @@ namespace RepoDb
             object param = null,
             CommandType? commandType = null,
             string cacheKey = null,
-            int? cacheItemExpiration = Constant.DefaultCacheItemExpirationInMinutes,
+            int? cacheItemExpiration = null,
             IDbTransaction transaction = null)
         {
             // Create a connection
@@ -381,7 +381,7 @@ namespace RepoDb
                     param: param,
                     commandType: commandType,
                     cacheKey: cacheKey,
-                    cacheItemExpiration: cacheItemExpiration,
+                    cacheItemExpiration: cacheItemExpiration ?? CacheItemExpiration,
                     commandTimeout: CommandTimeout,
                     transaction: transaction,
                     cache: Cache);
@@ -420,7 +420,7 @@ namespace RepoDb
             object param = null,
             CommandType? commandType = null,
             string cacheKey = null,
-            int? cacheItemExpiration = Constant.DefaultCacheItemExpirationInMinutes,
+            int? cacheItemExpiration = null,
             IDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
@@ -434,7 +434,7 @@ namespace RepoDb
                     param: param,
                     commandType: commandType,
                     cacheKey: cacheKey,
-                    cacheItemExpiration: cacheItemExpiration,
+                    cacheItemExpiration: cacheItemExpiration ?? CacheItemExpiration,
                     commandTimeout: CommandTimeout,
                     transaction: transaction,
                     cache: Cache,
@@ -474,7 +474,7 @@ namespace RepoDb
             object param = null,
             CommandType? commandType = null,
             string cacheKey = null,
-            int? cacheItemExpiration = Constant.DefaultCacheItemExpirationInMinutes,
+            int? cacheItemExpiration = null,
             IDbTransaction transaction = null)
             where TEntity : class
         {
@@ -488,7 +488,7 @@ namespace RepoDb
                     param: param,
                     commandType: commandType,
                     cacheKey: cacheKey,
-                    cacheItemExpiration: cacheItemExpiration,
+                    cacheItemExpiration: cacheItemExpiration ?? CacheItemExpiration,
                     commandTimeout: CommandTimeout,
                     transaction: transaction,
                     cache: Cache);
@@ -528,7 +528,7 @@ namespace RepoDb
             object param = null,
             CommandType? commandType = null,
             string cacheKey = null,
-            int? cacheItemExpiration = Constant.DefaultCacheItemExpirationInMinutes,
+            int? cacheItemExpiration = null,
             IDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
@@ -543,7 +543,7 @@ namespace RepoDb
                     param: param,
                     commandType: commandType,
                     cacheKey: cacheKey,
-                    cacheItemExpiration: cacheItemExpiration,
+                    cacheItemExpiration: cacheItemExpiration ?? CacheItemExpiration,
                     commandTimeout: CommandTimeout,
                     transaction: transaction,
                     cache: Cache,


### PR DESCRIPTION
This bug in behaviour just recently bit us on the project. The default `DbRepository<T>` doesn't honour the value passed in its ctor consistently across all its methods. While most of them do make use of it, there is a set of methods in which signatures contain a possibility to overload the cache expiration with a default value of 180 minutes and without taking into account the value set on the object.

Suggested changes alter the signature to make use of the `null` default parameter to maintain the ability of custom override and use the value set on the object as the fall-back one (it would still be 180 if it's not configured otherwise in the ctor call)