### PR TITLE
Fixed bug with keep identity flag in BulkInsert and BulkMerge operations

### DIFF
--- a/RepoDb.Extensions/RepoDb.SqlServer.BulkOperations/RepoDb.SqlServer.BulkOperations/Base/BulkInsert.cs
+++ b/RepoDb.Extensions/RepoDb.SqlServer.BulkOperations/RepoDb.SqlServer.BulkOperations/Base/BulkInsert.cs
@@ -127,7 +127,8 @@ namespace RepoDb
                         identityDbField?.AsField(),
                         hints,
                         dbSetting,
-                        withPseudoExecution);
+                        withPseudoExecution,
+                        options.HasFlag(SqlBulkCopyOptions.KeepIdentity));
 
                     // Execute the SQL
                     using (var reader = (DbDataReader)connection.ExecuteReader(sql, commandTimeout: bulkCopyTimeout, transaction: transaction))
@@ -372,7 +373,8 @@ namespace RepoDb
                             identityDbField?.AsField(),
                             hints,
                             dbSetting,
-                            withPseudoExecution);
+                            withPseudoExecution,
+                            options.HasFlag(SqlBulkCopyOptions.KeepIdentity));
 
                         // Identify the column
                         var column = dataTable.Columns[identityDbField.Name];
@@ -532,7 +534,8 @@ namespace RepoDb
                         identityDbField?.AsField(),
                         hints,
                         dbSetting,
-                        withPseudoExecution);
+                        withPseudoExecution,
+                        options.HasFlag(SqlBulkCopyOptions.KeepIdentity));
 
                     // Execute the SQL
                     using (var reader = (DbDataReader)(await connection.ExecuteReaderAsync(sql, commandTimeout: bulkCopyTimeout, transaction: transaction, cancellationToken: cancellationToken)))
@@ -782,7 +785,8 @@ namespace RepoDb
                             identityDbField?.AsField(),
                             hints,
                             dbSetting,
-                            withPseudoExecution);
+                            withPseudoExecution,
+                            options.HasFlag(SqlBulkCopyOptions.KeepIdentity));
 
                         // Identify the column
                         var column = dataTable.Columns[identityDbField.Name];

--- a/RepoDb.Extensions/RepoDb.SqlServer.BulkOperations/RepoDb.SqlServer.BulkOperations/Base/BulkMerge.cs
+++ b/RepoDb.Extensions/RepoDb.SqlServer.BulkOperations/RepoDb.SqlServer.BulkOperations/Base/BulkMerge.cs
@@ -163,7 +163,8 @@ namespace RepoDb
                     identityDbField?.AsField(),
                     hints,
                     dbSetting,
-                    isReturnIdentity.GetValueOrDefault());
+                    isReturnIdentity.GetValueOrDefault(),
+                    options.HasFlag(SqlBulkCopyOptions.KeepIdentity));
 
                 // Identity if the identity is to return
                 if (hasOrderingColumn != true || TypeCache.Get(entityType).IsAnonymousType())
@@ -340,7 +341,8 @@ namespace RepoDb
                     identityDbField?.AsField(),
                     hints,
                     dbSetting,
-                    false);
+                    false,
+                    options.HasFlag(SqlBulkCopyOptions.KeepIdentity));
                 result = connection.ExecuteNonQuery(sql, commandTimeout: bulkCopyTimeout, transaction: transaction);
 
                 // Drop the table after used
@@ -511,7 +513,8 @@ namespace RepoDb
                     identityDbField?.AsField(),
                     hints,
                     dbSetting,
-                    isReturnIdentity.GetValueOrDefault());
+                    isReturnIdentity.GetValueOrDefault(),
+                    options.HasFlag(SqlBulkCopyOptions.KeepIdentity));
 
                 // Identity if the identity is to return
                 var column = identityDbField is not null ? dataTable.Columns[identityDbField.Name] : null;
@@ -706,7 +709,8 @@ namespace RepoDb
                     identityDbField?.AsField(),
                     hints,
                     dbSetting,
-                    isReturnIdentity.GetValueOrDefault());
+                    isReturnIdentity.GetValueOrDefault(),
+                    options.HasFlag(SqlBulkCopyOptions.KeepIdentity));
 
                 // Identity if the identity is to return
                 if (hasOrderingColumn != true || TypeCache.Get(entityType).IsAnonymousType())
@@ -885,7 +889,8 @@ namespace RepoDb
                     identityDbField?.AsField(),
                     hints,
                     dbSetting,
-                    false);
+                    false,
+                    options.HasFlag(SqlBulkCopyOptions.KeepIdentity));
                 result = await connection.ExecuteNonQueryAsync(sql, commandTimeout: bulkCopyTimeout, transaction: transaction, cancellationToken: cancellationToken);
 
                 // Drop the table after used
@@ -1059,7 +1064,8 @@ namespace RepoDb
                     identityDbField?.AsField(),
                     hints,
                     dbSetting,
-                    isReturnIdentity.GetValueOrDefault());
+                    isReturnIdentity.GetValueOrDefault(),
+                    options.HasFlag(SqlBulkCopyOptions.KeepIdentity));
 
                 // Identity if the identity is to return
                 var column = identityDbField is not null ? dataTable.Columns[identityDbField.Name] : null;


### PR DESCRIPTION
Hi @mikependon,
I've prepared a PR for #1037, although I don't know if it's ready for production. Better test and/or edit it before merging it into your branch. I tested my use case and it worked so I hope it's ok.
I also modified the BulkInsert operation in the same way as BulkMerge, although BulkInsert seems to be more complicated (with all those pseudo tables) so it definitely needs some testing :)