### PR TITLE
Fix duplicate type check for StaticType.Byte in ClientTypeToDbTypeResolver

### DIFF
--- a/RepoDb.Core/RepoDb/Resolvers/ClientTypeToDbTypeResolver.cs
+++ b/RepoDb.Core/RepoDb/Resolvers/ClientTypeToDbTypeResolver.cs
@@ -109,10 +109,6 @@ namespace RepoDb.Resolvers
             {
                 return DbType.Time;
             }
-            else if (type == StaticType.Byte)
-            {
-                return DbType.Byte;
-            }
             else if (type == StaticType.Guid)
             {
                 return DbType.Guid;


### PR DESCRIPTION
This PR removes an unreachable duplicate check for `StaticType.Byte` in the `ClientTypeToDbTypeResolver.Resolve()` method.

**Issue:** The conditional chain had two identical checks for `StaticType.Byte`:
- First check at line 42 (reachable, correctly returns `DbType.Byte`)
- Second check at line 87 (unreachable dead code)

**Fix:** Removed the duplicate `else if (type == StaticType.Byte)` block at line 87, which was never executed due to the earlier check in the conditional chain.

**Impact:** No functional change - this only removes dead code that was never reached. The behavior remains identical.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.