### PR TITLE
Support to RepoDb.Connector.MariaDb for RepoDb.MariaDb.BulkOperations #1271

### DIFF
--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/README.md
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/README.md
@@ -4,7 +4,7 @@
 
 # [RepoDb.MariaDb.BulkOperations](https://www.nuget.org/packages/RepoDb.MariaDb.BulkOperations)
 
-A high-performant extension library of RepoDB that does bulk operations towards a MariaDB database. It uses its own internal class `MariaDbBulkCopy` to load the data towards the database. It uses the `LOAD DATA LOCAL INFILE`-based implementation on top of `MySql.Data`'s `MySqlBulkLoader`.
+A high-performant extension library of RepoDB that does bulk operations towards a MariaDB database. It uses its own internal class `MariaDbBulkCopy` to load the data towards the database. It uses the `LOAD DATA LOCAL INFILE`-based implementation on top of `RepoDb.Connector.MariaDb`'s `MariaDbBulkLoader`.
 
 ## Important Pages
 
@@ -55,7 +55,7 @@ Every synchronous operation has a corresponding `Async` overload.
 Inserts a list of entities into the database in bulk. Returns the number of inserted rows.
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var customers = GetCustomers();
     var insertedRows = connection.BulkInsert<Customer>(customers);
@@ -65,7 +65,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Or via table-name:
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var customers = GetCustomers();
     var insertedRows = connection.BulkInsert("Customer", customers);
@@ -75,7 +75,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Or via a `DataTable`:
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var table = GetCustomersAsDataTable();
     var insertedRows = connection.BulkInsert("Customer", table);
@@ -85,7 +85,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Returning generated identities:
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var customers = GetCustomers(); // Id not set
     connection.BulkInsert<Customer>(customers, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -98,7 +98,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Upserts a list of entities in bulk — inserts new rows and updates existing ones based on the defined qualifiers. Returns the number of affected rows.
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var customers = GetCustomers();
     var mergedRows = connection.BulkMerge<Customer>(customers);
@@ -108,7 +108,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Or with qualifiers:
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var customers = GetCustomers();
     var mergedRows = connection.BulkMerge<Customer>(customers, qualifiers: e => new { e.LastName, e.DateOfBirth });
@@ -118,7 +118,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Or via table-name with qualifiers:
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var customers = GetCustomers();
     var mergedRows = connection.BulkMerge("Customer", customers, qualifiers: Field.From("LastName", "DateOfBirth"));
@@ -128,7 +128,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Or via a `DataTable`:
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var table = GetCustomersAsDataTable();
     var mergedRows = connection.BulkMerge("Customer", table);
@@ -140,7 +140,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Updates existing rows in the database in bulk, matched by the defined qualifiers. Returns the number of updated rows.
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var customers = GetCustomers();
     var rows = connection.BulkUpdate<Customer>(customers);
@@ -150,7 +150,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Or with qualifiers:
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var customers = GetCustomers();
     var rows = connection.BulkUpdate<Customer>(customers, qualifiers: e => new { e.LastName, e.DateOfBirth });
@@ -160,7 +160,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Or via a `DataTable`:
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var table = GetCustomersAsDataTable();
     var rows = connection.BulkUpdate("Customer", table);
@@ -172,7 +172,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Deletes existing rows from the database in bulk, matched by the defined qualifiers. Returns the number of deleted rows.
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var customers = GetCustomers();
     var deletedRows = connection.BulkDelete<Customer>(customers);
@@ -182,7 +182,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Or with qualifiers:
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var customers = GetCustomers();
     var deletedRows = connection.BulkDelete<Customer>(customers, qualifiers: e => new { e.LastName, e.DateOfBirth });
@@ -192,7 +192,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Or via a `DataTable`:
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var table = GetCustomersAsDataTable();
     var deletedRows = connection.BulkDelete("Customer", table);
@@ -204,7 +204,7 @@ using (var connection = new MySqlConnection(ConnectionString))
 Deletes existing rows from the database in bulk, matched by their primary (or identity) key value alone — no entities or `DataTable` involved, just the list of key values to remove. Returns the number of deleted rows.
 
 ```csharp
-using (var connection = new MySqlConnection(ConnectionString))
+using (var connection = new MariaDbConnection(ConnectionString))
 {
     var primaryKeys = new [] { 10045, 10046, 10047 };
     var deletedRows = connection.BulkDeleteByKey("Customer", primaryKeys);

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Helper.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Helper.cs
@@ -1,5 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Extensions;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations.IntegrationTests.Models;
@@ -17,7 +17,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests
     {
         static Helper()
         {
-            StatementBuilder = StatementBuilderMapper.Get<MySqlConnection>();
+            StatementBuilder = StatementBuilderMapper.Get<MariaDbConnection>();
             EpocDate = new DateTime(1970, 1, 1, 0, 0, 0);
         }
 

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Models/BulkOperationIdentityTable.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Models/BulkOperationIdentityTable.cs
@@ -3,8 +3,8 @@ using System;
 namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Models
 {
     /// <summary>
-    /// MariaDb has no native BOOLEAN column usable for parameter binding (MySqlDbType.Boolean is
-    /// documented as "Not Available in ODP.NET, Managed Driver"), so the SqlServer suite's BIT column
+    /// MariaDb has no native BOOLEAN column usable for parameter binding (MariaDbType has no Boolean
+    /// member either), so the SqlServer suite's BIT column
     /// is represented here as a NUMBER(1,0)-backed <see cref="byte"/>? instead of bool?. RowGuid is
     /// stored as RAW(16) and round-tripped via <c>MariaDbGuidToByteArrayPropertyHandler</c> (registered
     /// per-property in Setup/Database.cs), the same pattern used by RepoDb.MariaDb.IntegrationTests.

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Operations/BulkDeleteByKeyTest.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Operations/BulkDeleteByKeyTest.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.IntegrationTests.Setup;
@@ -8,7 +8,7 @@ using System.Linq;
 namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
 {
     [TestClass]
-    public class MySqlConnectionBulkDeleteByKeyOperationsTest
+    public class MariaDbConnectionBulkDeleteByKeyOperationsTest
     {
         [TestInitialize]
         public void Initialize()
@@ -26,12 +26,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region Sync
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteByKey()
+        public void TestMariaDbConnectionBulkDeleteByKey()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -55,12 +55,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteByKeyWithBatchSize()
+        public void TestMariaDbConnectionBulkDeleteByKeyWithBatchSize()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -85,12 +85,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteByKeyViaPhysicalTable()
+        public void TestMariaDbConnectionBulkDeleteByKeyViaPhysicalTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -119,12 +119,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region Async
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteByKeyAsync()
+        public void TestMariaDbConnectionBulkDeleteByKeyAsync()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -148,12 +148,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteByKeyAsyncWithBatchSize()
+        public void TestMariaDbConnectionBulkDeleteByKeyAsyncWithBatchSize()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -178,12 +178,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteByKeyAsyncViaPhysicalTable()
+        public void TestMariaDbConnectionBulkDeleteByKeyAsyncViaPhysicalTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Operations/BulkDeleteTest.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Operations/BulkDeleteTest.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Exceptions;
 using RepoDb.Extensions;
@@ -13,7 +13,7 @@ using RepoDb.MariaDb.BulkOperations.IntegrationTests.Models;
 namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
 {
     [TestClass]
-    public class MySqlConnectionBulkDeleteOperationsTest
+    public class MariaDbConnectionBulkDeleteOperationsTest
     {
         [TestInitialize]
         public void Initialize()
@@ -31,12 +31,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkDelete<TEntity>
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForEntities()
+        public void TestMariaDbConnectionBulkDeleteForEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -56,12 +56,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkDeleteForEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -82,12 +82,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkDeleteForEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -108,12 +108,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForEntitiesWithBatchSize()
+        public void TestMariaDbConnectionBulkDeleteForEntitiesWithBatchSize()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -134,12 +134,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForEntitiesOnEmptyTable()
+        public void TestMariaDbConnectionBulkDeleteForEntitiesOnEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkDeleteResult = connection.BulkDelete(tables);
@@ -150,7 +150,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkDeleteForEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -166,7 +166,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -186,12 +186,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForMappedEntities()
+        public void TestMariaDbConnectionBulkDeleteForMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -211,12 +211,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForMappedEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkDeleteForMappedEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -237,12 +237,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForMappedEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkDeleteForMappedEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -263,7 +263,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkDeleteForMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
@@ -279,7 +279,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedIdentityTable.ColumnIntMapped), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedIdentityTable.ColumnNVarCharMapped), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -299,19 +299,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForEntitiesDataTable()
+        public void TestMariaDbConnectionBulkDeleteForEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -321,7 +321,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table);
@@ -341,7 +341,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkDeleteForEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -359,13 +359,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -375,7 +375,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, null, DataRowState.Unchanged);
@@ -395,27 +395,27 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteForNullEntities()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteForNullEntities()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkDelete((IEnumerable<BulkOperationIdentityTable>)null));
             }
         }
 
         //[TestMethod, ExpectedException(typeof(EmptyException))]
-        //public void ThrowExceptionOnMySqlConnectionBulkDeleteForEmptyEntities()
+        //public void ThrowExceptionOnMariaDbConnectionBulkDeleteForEmptyEntities()
         //{
-        //    using (var connection = new MySqlConnection(Database.ConnectionString))
+        //    using (var connection = new MariaDbConnection(Database.ConnectionString))
         //    {
         //        connection.BulkDelete(Enumerable.Empty<BulkOperationIdentityTable>());
         //    }
         //}
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteForNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteForNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkDelete(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
                     (DataTable)null));
@@ -423,12 +423,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForEntitiesViaPrimaryKeys()
+        public void TestMariaDbConnectionBulkDeleteForEntitiesViaPrimaryKeys()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -455,12 +455,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkDelete<TEntity>(Extra Fields)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkDeleteForEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -480,7 +480,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkDeleteForEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
@@ -496,7 +496,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -520,12 +520,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkDelete(TableName)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForTableNameEntitiesViaPrimaryKeys()
+        public void TestMariaDbConnectionBulkDeleteForTableNameEntitiesViaPrimaryKeys()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -548,11 +548,11 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForTableNameExpandoObjects()
+        public void TestMariaDbConnectionBulkDeleteForTableNameExpandoObjects()
         {
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -575,9 +575,9 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForTableNameExpandoObjectsOnEmptyTable()
+        public void TestMariaDbConnectionBulkDeleteForTableNameExpandoObjectsOnEmptyTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 var entities = Helper.CreateBulkOperationExpandoObjectIdentityTables(10, true);
@@ -591,11 +591,11 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForTableNameAnonymousObjects()
+        public void TestMariaDbConnectionBulkDeleteForTableNameAnonymousObjects()
         {
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -618,9 +618,9 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForTableNameAnonymousObjectsOnEmptyTable()
+        public void TestMariaDbConnectionBulkDeleteForTableNameAnonymousObjectsOnEmptyTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 var entities = Helper.CreateBulkOperationAnonymousObjectIdentityTables(10, true);
@@ -634,12 +634,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForTableNameDataEntities()
+        public void TestMariaDbConnectionBulkDeleteForTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -659,12 +659,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForTableNameDataEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkDeleteForTableNameDataEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -686,12 +686,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkDeleteForTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -713,12 +713,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForTableNameDataEntitiesOnEmptyTable()
+        public void TestMariaDbConnectionBulkDeleteForTableNameDataEntitiesOnEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkDeleteResult = connection.BulkDelete(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables);
@@ -729,19 +729,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkDeleteForTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -751,7 +751,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table);
@@ -771,7 +771,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkDeleteForTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -789,13 +789,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -805,7 +805,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -828,19 +828,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteForTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteForTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -850,7 +850,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkDelete("InvalidTable", table));
@@ -861,19 +861,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteForTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteForTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -883,7 +883,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkDelete("MissingTable",
@@ -897,19 +897,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForTableNameDataTable()
+        public void TestMariaDbConnectionBulkDeleteForTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -919,7 +919,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table);
@@ -939,7 +939,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkDeleteForTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -957,13 +957,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -973,7 +973,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -996,19 +996,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteForTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteForTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1018,7 +1018,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkDelete("InvalidTable", table));
@@ -1029,19 +1029,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteForTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteForTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1051,7 +1051,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkDelete("MissingTable",
@@ -1069,12 +1069,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkDeleteAsync<TEntity>
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForEntitiesViaPrimaryKeys()
+        public void TestMariaDbConnectionBulkDeleteAsyncForEntitiesViaPrimaryKeys()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1097,12 +1097,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForEntities()
+        public void TestMariaDbConnectionBulkDeleteAsyncForEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1122,12 +1122,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkDeleteAsyncForEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1148,12 +1148,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1174,12 +1174,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForEntitiesWithBatchSize()
+        public void TestMariaDbConnectionBulkDeleteAsyncForEntitiesWithBatchSize()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1200,12 +1200,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForEntitiesOnEmptyTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForEntitiesOnEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkDeleteResult = connection.BulkDeleteAsync(tables).Result;
@@ -1216,7 +1216,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkDeleteAsyncForEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1232,7 +1232,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1252,12 +1252,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForMappedEntities()
+        public void TestMariaDbConnectionBulkDeleteAsyncForMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1277,12 +1277,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForMappedEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkDeleteAsyncForMappedEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1303,12 +1303,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForMappedEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForMappedEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1329,7 +1329,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkDeleteAsyncForMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
@@ -1345,7 +1345,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedIdentityTable.ColumnIntMapped), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedIdentityTable.ColumnNVarCharMapped), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1371,19 +1371,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForEntitiesDataTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1393,7 +1393,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table).Result;
@@ -1413,7 +1413,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkDeleteAsyncForEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1431,13 +1431,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1447,7 +1447,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -1470,18 +1470,18 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteAsyncForNullEntities()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteAsyncForNullEntities()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkDeleteAsync((IEnumerable<BulkOperationIdentityTable>)null).Wait());
             }
         }
 
         //[TestMethod, ExpectedException(typeof(AggregateException))]
-        //public void ThrowExceptionOnMySqlConnectionBulkDeleteAsyncForEmptyEntities()
+        //public void ThrowExceptionOnMariaDbConnectionBulkDeleteAsyncForEmptyEntities()
         //{
-        //    using (var connection = new MySqlConnection(Database.ConnectionString))
+        //    using (var connection = new MariaDbConnection(Database.ConnectionString))
         //    {
         //        connection.BulkDeleteAsync(Enumerable.Empty<BulkOperationIdentityTable>()).Wait();
         //    }
@@ -1490,9 +1490,9 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteAsyncForNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteAsyncForNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
                     (DataTable)null).Wait());
@@ -1504,12 +1504,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkDeleteAsync<TEntity>(Extra Fields)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkDeleteAsyncForEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1529,7 +1529,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkDeleteAsyncForEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
@@ -1546,7 +1546,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1570,12 +1570,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkDeleteAsync(TableName)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForTableNameEntitiesViaPrimaryKeys()
+        public void TestMariaDbConnectionBulkDeleteAsyncForTableNameEntitiesViaPrimaryKeys()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1598,13 +1598,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForTableNameExpandoObjects()
+        public void TestMariaDbConnectionBulkDeleteAsyncForTableNameExpandoObjects()
         {
-            // Setup - see TestMySqlConnectionBulkDeleteForTableNameAnonymousObjects for why
+            // Setup - see TestMariaDbConnectionBulkDeleteForTableNameAnonymousObjects for why
             // BulkOperationNonIdentityTable is used here instead of the IDENTITY table.
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1627,11 +1627,11 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForTableNameExpandoObjectsOnEmptyTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForTableNameExpandoObjectsOnEmptyTable()
         {
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 var entities = Helper.CreateBulkOperationExpandoObjectIdentityTables(10, true);
@@ -1645,11 +1645,11 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForTableNameAnonymousObjects()
+        public void TestMariaDbConnectionBulkDeleteAsyncForTableNameAnonymousObjects()
         {
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1672,11 +1672,11 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForTableNameAnonymousObjectsOnEmptyTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForTableNameAnonymousObjectsOnEmptyTable()
         {
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 var entities = Helper.CreateBulkOperationAnonymousObjectIdentityTables(10, true);
@@ -1690,12 +1690,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForTableNameDataEntities()
+        public void TestMariaDbConnectionBulkDeleteAsyncForTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1715,12 +1715,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForTableNameDataEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkDeleteAsyncForTableNameDataEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1742,12 +1742,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1779,12 +1779,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForTableNameDataEntitiesOnEmptyTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForTableNameDataEntitiesOnEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkDeleteResult = connection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables).Result;
@@ -1795,19 +1795,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForTableNameDataTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1817,7 +1817,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table).Result;
@@ -1837,7 +1837,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkDeleteAsyncForTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1855,13 +1855,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1871,7 +1871,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -1894,19 +1894,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteAsyncForTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteAsyncForTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1916,7 +1916,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkDeleteAsync("InvalidTable", table).Result);
@@ -1927,19 +1927,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteAsyncForTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteAsyncForTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1949,7 +1949,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkDeleteAsync("MissingTable",
@@ -1963,19 +1963,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1985,7 +1985,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table).Result;
@@ -2005,7 +2005,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkDeleteAsyncForTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -2023,13 +2023,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2039,7 +2039,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -2062,19 +2062,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteAsyncForTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteAsyncForTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2084,7 +2084,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkDeleteAsync("InvalidTable", table).Result);
@@ -2095,19 +2095,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteAsyncForTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteAsyncForTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2117,7 +2117,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkDeleteAsync("MissingTable",
@@ -2135,12 +2135,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region NonIdentityTable Mirrors
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityEntitiesViaPrimaryKeys()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityEntitiesViaPrimaryKeys()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2163,12 +2163,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityEntities()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2188,12 +2188,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2214,12 +2214,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2240,12 +2240,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityEntitiesWithBatchSize()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityEntitiesWithBatchSize()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2266,12 +2266,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityEntitiesOnEmptyTable()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityEntitiesOnEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkDeleteResult = connection.BulkDelete(tables);
@@ -2282,7 +2282,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -2298,7 +2298,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2318,12 +2318,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityMappedEntities()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2343,12 +2343,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityMappedEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityMappedEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2369,12 +2369,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityMappedEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityMappedEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2395,7 +2395,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
@@ -2411,7 +2411,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedNonIdentityTable.ColumnIntMapped), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedNonIdentityTable.ColumnNVarCharMapped), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2431,19 +2431,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityEntitiesDataTable()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2453,7 +2453,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table);
@@ -2473,7 +2473,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -2491,13 +2491,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2507,7 +2507,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, null, DataRowState.Unchanged);
@@ -2527,18 +2527,18 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteForNonIdentityNullEntities()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteForNonIdentityNullEntities()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkDelete((IEnumerable<BulkOperationNonIdentityTable>)null));
             }
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteForNonIdentityNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteForNonIdentityNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkDelete(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
                     (DataTable)null));
@@ -2546,12 +2546,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2571,7 +2571,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
@@ -2587,7 +2587,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2607,12 +2607,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityTableNameEntitiesViaPrimaryKeys()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityTableNameEntitiesViaPrimaryKeys()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2635,12 +2635,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityTableNameDataEntities()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2660,12 +2660,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityTableNameDataEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityTableNameDataEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2687,12 +2687,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2714,19 +2714,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2736,7 +2736,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table);
@@ -2756,7 +2756,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -2774,13 +2774,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2790,7 +2790,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -2813,19 +2813,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2835,7 +2835,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkDelete("InvalidTable", table));
@@ -2846,19 +2846,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2868,7 +2868,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkDelete("MissingTable",
@@ -2882,19 +2882,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityTableNameDataTable()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2904,7 +2904,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table);
@@ -2924,7 +2924,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForNonIdentityTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkDeleteForNonIdentityTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -2942,13 +2942,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2958,7 +2958,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -2981,19 +2981,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3003,7 +3003,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkDelete("InvalidTable", table));
@@ -3014,19 +3014,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3036,7 +3036,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkDelete("MissingTable",
@@ -3050,12 +3050,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityEntitiesViaPrimaryKeys()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityEntitiesViaPrimaryKeys()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3078,12 +3078,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityEntities()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3103,12 +3103,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3129,12 +3129,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3155,12 +3155,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityEntitiesWithBatchSize()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityEntitiesWithBatchSize()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3181,12 +3181,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityEntitiesOnEmptyTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityEntitiesOnEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkDeleteResult = connection.BulkDeleteAsync(tables).Result;
@@ -3197,7 +3197,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3213,7 +3213,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3233,12 +3233,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityMappedEntities()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3258,12 +3258,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityMappedEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityMappedEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3284,12 +3284,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityMappedEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityMappedEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10).AsList();
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3310,7 +3310,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
@@ -3326,7 +3326,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedNonIdentityTable.ColumnIntMapped), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedNonIdentityTable.ColumnNVarCharMapped), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3346,19 +3346,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityEntitiesDataTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3368,7 +3368,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table).Result;
@@ -3388,7 +3388,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3406,13 +3406,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3422,7 +3422,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -3445,18 +3445,18 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteAsyncForNonIdentityNullEntities()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteAsyncForNonIdentityNullEntities()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkDeleteAsync((IEnumerable<BulkOperationNonIdentityTable>)null).Wait());
             }
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteAsyncForNonIdentityNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteAsyncForNonIdentityNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
                     (DataTable)null).Wait());
@@ -3464,12 +3464,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3489,7 +3489,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
@@ -3506,7 +3506,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3526,12 +3526,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityTableNameEntitiesViaPrimaryKeys()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityTableNameEntitiesViaPrimaryKeys()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3554,12 +3554,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityTableNameDataEntities()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3579,12 +3579,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityTableNameDataEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityTableNameDataEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3606,12 +3606,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3633,19 +3633,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityTableNameDataTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3655,7 +3655,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table).Result;
@@ -3675,7 +3675,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3693,13 +3693,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3709,7 +3709,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -3732,19 +3732,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteAsyncForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteAsyncForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3754,7 +3754,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkDeleteAsync("InvalidTable", table).Result);
@@ -3765,19 +3765,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteAsyncForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteAsyncForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3787,7 +3787,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkDeleteAsync("MissingTable",
@@ -3801,19 +3801,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3823,7 +3823,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table).Result;
@@ -3843,7 +3843,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForNonIdentityTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkDeleteAsyncForNonIdentityTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3861,13 +3861,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3877,7 +3877,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -3900,19 +3900,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3922,7 +3922,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkDeleteAsync("InvalidTable", table).Result);
@@ -3933,19 +3933,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkDeleteAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkDeleteAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3955,7 +3955,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkDeleteAsync("MissingTable",
@@ -3973,17 +3973,17 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkDelete(DbDataReader)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForDbDataReader()
+        public void TestMariaDbConnectionBulkDeleteForDbDataReader()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 sourceConnection.InsertAll(tables);
 
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
-                using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                 {
                     // Act
                     var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), reader);
@@ -4001,17 +4001,17 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForDbDataReader()
+        public void TestMariaDbConnectionBulkDeleteAsyncForDbDataReader()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 sourceConnection.InsertAll(tables);
 
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
-                using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                 {
                     // Act
                     var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), reader).Result;
@@ -4029,12 +4029,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteForDbDataReaderOnEmptyTable()
+        public void TestMariaDbConnectionBulkDeleteForDbDataReaderOnEmptyTable()
         {
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
-                using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                 {
                     // Act
                     var bulkDeleteResult = destinationConnection.BulkDelete(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), reader);
@@ -4046,12 +4046,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkDeleteAsyncForDbDataReaderOnEmptyTable()
+        public void TestMariaDbConnectionBulkDeleteAsyncForDbDataReaderOnEmptyTable()
         {
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
-                using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                 {
                     // Act
                     var bulkDeleteResult = destinationConnection.BulkDeleteAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), reader).Result;

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Operations/BulkDeleteTest.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Operations/BulkDeleteTest.cs
@@ -1364,12 +1364,6 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             }
         }
 
-        
-
-        
-
-        
-
         [TestMethod]
         public void TestMariaDbConnectionBulkDeleteAsyncForEntitiesDataTable()
         {

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Operations/BulkInsertTest.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Operations/BulkInsertTest.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -13,7 +13,7 @@ using RepoDb.MariaDb.BulkOperations.IntegrationTests.Models;
 namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
 {
     [TestClass]
-    public class MySqlConnectionBulkInsertOperationsTest
+    public class MariaDbConnectionBulkInsertOperationsTest
     {
         [TestInitialize]
         public void Initialize()
@@ -31,12 +31,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkInsert<TEntity>
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForEntities()
+        public void TestMariaDbConnectionBulkInsertForEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables);
@@ -57,12 +57,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -89,7 +89,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkInsertForEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -105,7 +105,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables, mappings: mappings);
@@ -126,12 +126,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForMappedEntities()
+        public void TestMariaDbConnectionBulkInsertForMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables);
@@ -152,12 +152,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForMappedEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForMappedEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -184,7 +184,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkInsertForMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
@@ -200,7 +200,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedIdentityTable.ColumnIntMapped), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedIdentityTable.ColumnNVarCharMapped), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables, mappings: mappings);
@@ -221,7 +221,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForEntitiesIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForEntitiesIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -238,7 +238,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 Assert.Throws<InvalidTypeException>(() => connection.BulkInsert(tables, mappings));
@@ -246,19 +246,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForEntitiesDataTable()
+        public void TestMariaDbConnectionBulkInsertForEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -268,7 +268,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table);
@@ -288,19 +288,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForEntitiesDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForEntitiesDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -310,7 +310,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -342,7 +342,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkInsertForEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -359,13 +359,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -375,7 +375,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings);
@@ -395,7 +395,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForEntitiesDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForEntitiesDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -413,13 +413,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -429,7 +429,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings));
@@ -440,18 +440,18 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForNullEntities()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForNullEntities()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkInsert((IEnumerable<BulkOperationIdentityTable>)null));
             }
         }
 
         //[TestMethod, ExpectedException(typeof(EmptyException))]
-        //public void ThrowExceptionOnMySqlConnectionBulkInsertForEmptyEntities()
+        //public void ThrowExceptionOnMariaDbConnectionBulkInsertForEmptyEntities()
         //{
-        //    using (var connection = new MySqlConnection(Database.ConnectionString))
+        //    using (var connection = new MariaDbConnection(Database.ConnectionString))
         //    {
         //        connection.BulkInsert(Enumerable.Empty<BulkOperationIdentityTable>());
         //    }
@@ -460,9 +460,9 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
                     (DataTable)null));
@@ -474,12 +474,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkInsert<TEntity>(Extra Fields)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkInsertForEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables);
@@ -500,7 +500,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkInsertForEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
@@ -515,7 +515,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables);
@@ -540,12 +540,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkInsert(TableName)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForTableNameExpandoObjects()
+        public void TestMariaDbConnectionBulkInsertForTableNameExpandoObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables);
@@ -566,12 +566,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForTableNameAnonymousObjects()
+        public void TestMariaDbConnectionBulkInsertForTableNameAnonymousObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationAnonymousObjectIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables);
@@ -592,12 +592,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForTableNameDataEntities()
+        public void TestMariaDbConnectionBulkInsertForTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables);
@@ -618,12 +618,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForTableNameExpandoObjectsWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForTableNameExpandoObjectsWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -645,12 +645,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForTableNameDataEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForTableNameDataEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -687,19 +687,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkInsertForTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -709,7 +709,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table);
@@ -729,19 +729,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForTableNameDbDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForTableNameDbDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -751,7 +751,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -783,7 +783,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkInsertForTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -800,13 +800,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -816,7 +816,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings);
@@ -836,7 +836,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForTableNameDbDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForTableNameDbDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -854,13 +854,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -870,7 +870,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings));
@@ -881,19 +881,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -903,7 +903,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkInsert("InvalidTable", table, DataRowState.Unchanged));
@@ -914,19 +914,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -936,7 +936,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkInsert("MissingTable", table, DataRowState.Unchanged));
@@ -947,19 +947,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForTableNameDataTable()
+        public void TestMariaDbConnectionBulkInsertForTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -969,7 +969,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table);
@@ -989,19 +989,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForTableNameDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForTableNameDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1011,7 +1011,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -1039,7 +1039,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkInsertForTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1056,13 +1056,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1072,7 +1072,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings);
@@ -1092,7 +1092,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForTableNameDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForTableNameDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1110,13 +1110,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1126,7 +1126,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings));
@@ -1137,19 +1137,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1159,7 +1159,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkInsert("InvalidTable", table));
@@ -1170,19 +1170,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1192,7 +1192,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkInsert("MissingTable", table, DataRowState.Unchanged));
@@ -1207,12 +1207,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkInsertAsync<TEntity>
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForEntities()
+        public void TestMariaDbConnectionBulkInsertAsyncForEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables).Result;
@@ -1233,12 +1233,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -1261,7 +1261,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkInsertAsyncForEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1277,7 +1277,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables).Result;
@@ -1298,12 +1298,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForMappedEntities()
+        public void TestMariaDbConnectionBulkInsertAsyncForMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables).Result;
@@ -1324,12 +1324,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForMappedEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForMappedEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -1352,7 +1352,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkInsertAsyncForMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
@@ -1368,7 +1368,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedIdentityTable.ColumnIntMapped), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedIdentityTable.ColumnNVarCharMapped), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables, mappings: mappings).Result;
@@ -1389,7 +1389,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForEntitiesIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForEntitiesIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1406,7 +1406,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 Assert.Throws<AggregateException>(() => connection.BulkInsertAsync(tables, mappings).Result);
@@ -1420,19 +1420,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForEntitiesDataTable()
+        public void TestMariaDbConnectionBulkInsertAsyncForEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1442,7 +1442,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table).Result;
@@ -1462,19 +1462,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForEntitiesDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForEntitiesDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1484,7 +1484,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -1516,7 +1516,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkInsertAsyncForEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1533,13 +1533,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1549,7 +1549,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings).Result;
@@ -1569,7 +1569,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForEntitiesDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForEntitiesDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1587,13 +1587,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1603,7 +1603,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings).Result);
@@ -1614,18 +1614,18 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         //[TestMethod, ExpectedException(typeof(AggregateException))]
-        //public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForNullEntities()
+        //public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForNullEntities()
         //{
-        //    using (var connection = new MySqlConnection(Database.ConnectionString))
+        //    using (var connection = new MariaDbConnection(Database.ConnectionString))
         //    {
         //        Assert.Throws<AggregateException>(() => connection.BulkInsertAsync((IEnumerable<BulkOperationIdentityTable>)null).Wait();)
         //    }
         //}
 
         //[TestMethod, ExpectedException(typeof(AggregateException))]
-        //public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForEmptyEntities()
+        //public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForEmptyEntities()
         //{
-        //    using (var connection = new MySqlConnection(Database.ConnectionString))
+        //    using (var connection = new MariaDbConnection(Database.ConnectionString))
         //    {
         //        Assert.Throws<AggregateException>(() => connection.BulkInsertAsync(Enumerable.Empty<BulkOperationIdentityTable>()).Wait();)
         //    }
@@ -1634,9 +1634,9 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
                     (DataTable)null).Wait());
@@ -1644,9 +1644,9 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForNullEntities()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForNullEntities()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkInsertAsync((IEnumerable<BulkOperationIdentityTable>)null).Result);
             }
@@ -1657,12 +1657,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkInsertAsync<TEntity>(Extra Fields)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkInsertAsyncForEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables).Result;
@@ -1683,7 +1683,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkInsertAsyncForEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
@@ -1698,7 +1698,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables).Result;
@@ -1723,12 +1723,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkInsertAsync(TableName)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForTableNameExpandoObjects()
+        public void TestMariaDbConnectionBulkInsertAsyncForTableNameExpandoObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables).Result;
@@ -1749,12 +1749,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForTableNameAnonymousObjects()
+        public void TestMariaDbConnectionBulkInsertAsyncForTableNameAnonymousObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationAnonymousObjectIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables).Result;
@@ -1775,12 +1775,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForTableNameDataEntities()
+        public void TestMariaDbConnectionBulkInsertAsyncForTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables).Result;
@@ -1801,12 +1801,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForTableNameExpandoObjectsWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForTableNameExpandoObjectsWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -1828,12 +1828,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForTableNameDataEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForTableNameDataEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -1870,19 +1870,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForTableNameDataTable()
+        public void TestMariaDbConnectionBulkInsertAsyncForTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1892,7 +1892,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table).Result;
@@ -1912,19 +1912,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForTableNameDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForTableNameDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1934,7 +1934,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -1966,7 +1966,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkInsertAsyncForTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1983,13 +1983,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1999,7 +1999,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings).Result;
@@ -2019,7 +2019,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForTableNameDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForTableNameDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -2037,13 +2037,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2053,7 +2053,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings).Result);
@@ -2064,19 +2064,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2086,7 +2086,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync("InvalidTable", table).Result);
@@ -2097,19 +2097,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2119,7 +2119,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync("MissingTable", table, DataRowState.Unchanged).Result);
@@ -2130,19 +2130,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkInsertAsyncForTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2152,7 +2152,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table).Result;
@@ -2172,19 +2172,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForTableNameDbDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForTableNameDbDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2194,7 +2194,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -2222,7 +2222,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkInsertAsyncForTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -2239,13 +2239,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2255,7 +2255,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings).Result;
@@ -2275,7 +2275,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForTableNameDbDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForTableNameDbDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -2293,13 +2293,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2309,7 +2309,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings).Result);
@@ -2320,19 +2320,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2342,7 +2342,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync("InvalidTable", table, DataRowState.Unchanged).Result);
@@ -2353,19 +2353,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2375,7 +2375,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync("MissingTable", table, DataRowState.Unchanged).Result);
@@ -2390,12 +2390,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region NonIdentityTable Mirrors
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityEntities()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables);
@@ -2416,12 +2416,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -2444,7 +2444,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -2461,7 +2461,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables, mappings: mappings);
@@ -2482,12 +2482,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityMappedEntities()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables);
@@ -2508,12 +2508,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityMappedEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityMappedEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -2536,7 +2536,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
@@ -2553,7 +2553,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedNonIdentityTable.ColumnIntMapped), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedNonIdentityTable.ColumnNVarCharMapped), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables, mappings: mappings);
@@ -2574,7 +2574,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForNonIdentityEntitiesIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForNonIdentityEntitiesIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -2591,7 +2591,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 Assert.Throws<InvalidTypeException>(() => connection.BulkInsert(tables, mappings));
@@ -2599,19 +2599,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityEntitiesDataTable()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2626,7 +2626,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table);
@@ -2646,19 +2646,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityEntitiesDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityEntitiesDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2673,7 +2673,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -2701,7 +2701,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -2719,13 +2719,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2740,7 +2740,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings);
@@ -2760,7 +2760,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForNonIdentityEntitiesDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForNonIdentityEntitiesDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -2778,13 +2778,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2794,7 +2794,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings));
@@ -2805,18 +2805,18 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForNonIdentityNullEntities()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForNonIdentityNullEntities()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkInsert((IEnumerable<BulkOperationNonIdentityTable>)null));
             }
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForNonIdentityNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForNonIdentityNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
                     (DataTable)null));
@@ -2824,12 +2824,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables);
@@ -2850,7 +2850,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
@@ -2866,7 +2866,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(tables);
@@ -2887,12 +2887,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityTableNameExpandoObjects()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityTableNameExpandoObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables);
@@ -2913,12 +2913,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityTableNameAnonymousObjects()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityTableNameAnonymousObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationAnonymousObjectNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables);
@@ -2939,12 +2939,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityTableNameDataEntities()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables);
@@ -2965,12 +2965,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityTableNameExpandoObjectsWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityTableNameExpandoObjectsWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -2992,12 +2992,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityTableNameDataEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityTableNameDataEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -3020,19 +3020,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3047,7 +3047,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table);
@@ -3067,19 +3067,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityTableNameDbDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityTableNameDbDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3094,7 +3094,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -3122,7 +3122,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3140,13 +3140,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3161,7 +3161,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings);
@@ -3181,7 +3181,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForNonIdentityTableNameDbDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForNonIdentityTableNameDbDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3199,13 +3199,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3215,7 +3215,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings));
@@ -3226,19 +3226,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3248,7 +3248,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkInsert("InvalidTable", table, DataRowState.Unchanged));
@@ -3259,19 +3259,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3281,7 +3281,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkInsert("MissingTable", table, DataRowState.Unchanged));
@@ -3292,19 +3292,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityTableNameDataTable()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3319,7 +3319,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table);
@@ -3339,19 +3339,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityTableNameDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityTableNameDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3366,7 +3366,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -3394,7 +3394,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForNonIdentityTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkInsertForNonIdentityTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3412,13 +3412,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3433,7 +3433,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings);
@@ -3453,7 +3453,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForNonIdentityTableNameDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForNonIdentityTableNameDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3471,13 +3471,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3487,7 +3487,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings));
@@ -3498,19 +3498,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3520,7 +3520,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkInsert("InvalidTable", table));
@@ -3531,19 +3531,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3553,7 +3553,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkInsert("MissingTable", table, DataRowState.Unchanged));
@@ -3564,12 +3564,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityEntities()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables).Result;
@@ -3590,12 +3590,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -3618,7 +3618,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3635,7 +3635,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables).Result;
@@ -3656,12 +3656,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityMappedEntities()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables).Result;
@@ -3682,12 +3682,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityMappedEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityMappedEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -3710,7 +3710,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
@@ -3727,7 +3727,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedNonIdentityTable.ColumnIntMapped), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedNonIdentityTable.ColumnNVarCharMapped), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables, mappings: mappings).Result;
@@ -3748,7 +3748,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForNonIdentityEntitiesIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForNonIdentityEntitiesIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3765,7 +3765,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 Assert.Throws<AggregateException>(() => connection.BulkInsertAsync(tables, mappings).Result);
@@ -3773,19 +3773,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityEntitiesDataTable()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3800,7 +3800,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table).Result;
@@ -3820,19 +3820,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityEntitiesDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityEntitiesDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3847,7 +3847,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -3875,7 +3875,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3893,13 +3893,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3914,7 +3914,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings).Result;
@@ -3934,7 +3934,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForNonIdentityEntitiesDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForNonIdentityEntitiesDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3952,13 +3952,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3968,7 +3968,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings).Result);
@@ -3979,9 +3979,9 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForNonIdentityNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForNonIdentityNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
                     (DataTable)null).Wait());
@@ -3989,12 +3989,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables).Result;
@@ -4015,7 +4015,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
@@ -4031,7 +4031,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(tables).Result;
@@ -4052,12 +4052,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityTableNameExpandoObjects()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameExpandoObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables).Result;
@@ -4078,12 +4078,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityTableNameAnonymousObjects()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameAnonymousObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationAnonymousObjectNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables).Result;
@@ -4104,12 +4104,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDataEntities()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables).Result;
@@ -4130,12 +4130,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityTableNameExpandoObjectsWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameExpandoObjectsWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -4157,12 +4157,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDataEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDataEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkInsertResult = connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -4185,19 +4185,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDataTable()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4212,7 +4212,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table).Result;
@@ -4232,19 +4232,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4259,7 +4259,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -4287,7 +4287,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -4305,13 +4305,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4326,7 +4326,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings).Result;
@@ -4346,7 +4346,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -4364,13 +4364,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4380,7 +4380,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings).Result);
@@ -4391,19 +4391,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4413,7 +4413,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync("InvalidTable", table).Result);
@@ -4424,19 +4424,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4446,7 +4446,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync("MissingTable", table, DataRowState.Unchanged).Result);
@@ -4457,28 +4457,28 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForNonIdentityNullEntities()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForNonIdentityNullEntities()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkInsertAsync((IEnumerable<BulkOperationNonIdentityTable>)null).Result);
             }
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4493,7 +4493,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table).Result;
@@ -4513,19 +4513,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDbDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDbDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4540,7 +4540,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -4568,7 +4568,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -4586,13 +4586,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4607,7 +4607,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         }
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings).Result;
@@ -4627,7 +4627,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDbDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDbDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -4645,13 +4645,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4661,7 +4661,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings).Result);
@@ -4672,19 +4672,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4694,7 +4694,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync("InvalidTable", table, DataRowState.Unchanged).Result);
@@ -4705,19 +4705,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkInsertAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkInsertAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4727,7 +4727,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkInsertAsync("MissingTable", table, DataRowState.Unchanged).Result);
@@ -4742,17 +4742,17 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkInsert(DbDataReader)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertForDbDataReader()
+        public void TestMariaDbConnectionBulkInsertForDbDataReader()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 sourceConnection.InsertAll(tables);
 
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
-                using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                 {
                     // Act
                     var bulkInsertResult = destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), reader);
@@ -4770,17 +4770,17 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkInsertAsyncForDbDataReader()
+        public void TestMariaDbConnectionBulkInsertAsyncForDbDataReader()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 sourceConnection.InsertAll(tables);
 
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
-                using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                 {
                     // Act
                     var bulkInsertResult = destinationConnection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), reader).Result;

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Operations/BulkMergeTest.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Operations/BulkMergeTest.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RepoDb.Extensions;
 using RepoDb.IntegrationTests.Setup;
@@ -15,7 +15,7 @@ using RepoDb.Exceptions;
 namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
 {
     [TestClass]
-    public class MySqlConnectionBulkMergeOperationsTest
+    public class MariaDbConnectionBulkMergeOperationsTest
     {
         [TestInitialize]
         public void Initialize()
@@ -33,12 +33,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkMerge<TEntity>
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForEntitiesForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForEntitiesForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(tables);
@@ -59,12 +59,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForEntitiesForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForEntitiesForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -87,12 +87,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForEntities()
+        public void TestMariaDbConnectionBulkMergeForEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -119,12 +119,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -153,12 +153,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkMergeForEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -186,12 +186,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkMergeForEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -219,7 +219,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkMergeForEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -236,7 +236,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -263,12 +263,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForMappedEntitiesForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForMappedEntitiesForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(tables);
@@ -289,12 +289,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForMappedEntitiesForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForMappedEntitiesForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -317,12 +317,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForMappedEntities()
+        public void TestMariaDbConnectionBulkMergeForMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -349,12 +349,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForMappedEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForMappedEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -383,12 +383,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForMappedEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkMergeForMappedEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -416,12 +416,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForMappedEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkMergeForMappedEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -449,7 +449,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkMergeForMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
@@ -466,7 +466,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedIdentityTable.ColumnIntMapped), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedIdentityTable.ColumnNVarCharMapped), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -493,7 +493,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForEntitiesIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForEntitiesIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -510,7 +510,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 Assert.Throws<InvalidTypeException>(() => connection.BulkMerge(tables, mappings: mappings));
@@ -518,19 +518,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForEntitiesDataTable()
+        public void TestMariaDbConnectionBulkMergeForEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -540,7 +540,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table);
@@ -554,19 +554,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForEntitiesDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForEntitiesDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -576,7 +576,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -601,7 +601,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkMergeForEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -619,13 +619,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -635,7 +635,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table,
@@ -650,7 +650,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForEntitiesDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForEntitiesDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -668,13 +668,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -684,7 +684,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table,
@@ -696,9 +696,9 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
                     (DataTable)null));
@@ -710,12 +710,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkMerge<TEntity>(Extra Fields)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkMergeForEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -742,7 +742,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkMergeForEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
@@ -757,7 +757,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -788,12 +788,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkMerge(TableName)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameExpandoObjectsForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForTableNameExpandoObjectsForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables);
@@ -814,12 +814,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameExpandoObjectsForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForTableNameExpandoObjectsForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -841,12 +841,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameExpandoObjectsForNonEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForTableNameExpandoObjectsForNonEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -873,12 +873,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameExpandoObjectsForNonEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForTableNameExpandoObjectsForNonEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationIdentityTable>(tables);
@@ -906,12 +906,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameAnonymousObjectsForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForTableNameAnonymousObjectsForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationAnonymousObjectIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables);
@@ -932,12 +932,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameAnonymousObjectsForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForTableNameAnonymousObjectsForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationAnonymousObjectIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -959,12 +959,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameAnonymousObjectsForNonEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForTableNameAnonymousObjectsForNonEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -991,12 +991,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameAnonymousObjectsForNonEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForTableNameAnonymousObjectsForNonEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationIdentityTable>(tables);
@@ -1024,12 +1024,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameDataEntitiesForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForTableNameDataEntitiesForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables);
@@ -1050,12 +1050,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameDataEntitiesForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForTableNameDataEntitiesForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -1078,12 +1078,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameDataEntitiesForNonEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForTableNameDataEntitiesForNonEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationIdentityTable>(tables);
@@ -1110,12 +1110,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameDataEntitiesForNonEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForTableNameDataEntitiesForNonEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationIdentityTable>(tables);
@@ -1144,12 +1144,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameDataEntities()
+        public void TestMariaDbConnectionBulkMergeForTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -1176,12 +1176,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameDataEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForTableNameDataEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -1210,12 +1210,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameDataEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkMergeForTableNameDataEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -1244,12 +1244,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkMergeForTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -1288,19 +1288,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkMergeForTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1310,7 +1310,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table);
@@ -1324,19 +1324,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForTableNameDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1346,7 +1346,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -1371,7 +1371,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkMergeForTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1389,13 +1389,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1405,7 +1405,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -1421,7 +1421,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForTableNameDbDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForTableNameDbDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1439,13 +1439,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1455,7 +1455,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -1468,19 +1468,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1490,7 +1490,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkMerge("InvalidTable",
@@ -1502,19 +1502,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1524,7 +1524,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkMerge("MissingTable",
@@ -1536,19 +1536,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameDataTable()
+        public void TestMariaDbConnectionBulkMergeForTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1558,7 +1558,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table);
@@ -1572,7 +1572,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkMergeForTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1590,13 +1590,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1606,7 +1606,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -1622,7 +1622,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForTableNameDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForTableNameDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1640,13 +1640,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1656,7 +1656,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -1669,19 +1669,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1691,7 +1691,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkMerge("InvalidTable", table));
@@ -1702,19 +1702,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1724,7 +1724,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkMerge("MissingTable",
@@ -1740,12 +1740,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkMergeAsync<TEntity>
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForEntitiesForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForEntitiesForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(tables).Result;
@@ -1766,12 +1766,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForEntitiesForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForEntitiesForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -1794,12 +1794,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForEntities()
+        public void TestMariaDbConnectionBulkMergeAsyncForEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -1823,12 +1823,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -1854,12 +1854,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkMergeAsyncForEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1887,12 +1887,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1920,7 +1920,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkMergeAsyncForEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1937,7 +1937,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -1961,12 +1961,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForMappedEntitiesForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForMappedEntitiesForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(tables).Result;
@@ -1987,12 +1987,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForMappedEntitiesForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForMappedEntitiesForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -2015,12 +2015,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForMappedEntities()
+        public void TestMariaDbConnectionBulkMergeAsyncForMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2047,12 +2047,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForMappedEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForMappedEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2081,12 +2081,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForMappedEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkMergeAsyncForMappedEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2114,12 +2114,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForMappedEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForMappedEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2147,7 +2147,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkMergeAsyncForMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
@@ -2164,7 +2164,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedIdentityTable.ColumnIntMapped), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedIdentityTable.ColumnNVarCharMapped), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2191,7 +2191,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForEntitiesIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForEntitiesIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -2208,7 +2208,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 Assert.Throws<AggregateException>(() => connection.BulkMergeAsync(tables,
@@ -2223,19 +2223,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForEntitiesDataTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2245,7 +2245,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table).Result;
@@ -2259,19 +2259,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForEntitiesDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForEntitiesDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2281,7 +2281,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -2306,7 +2306,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkMergeAsyncForEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -2324,13 +2324,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2340,7 +2340,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table,
@@ -2355,7 +2355,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForEntitiesDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForEntitiesDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -2373,13 +2373,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2389,7 +2389,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table,
@@ -2401,18 +2401,18 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         //[TestMethod, ExpectedException(typeof(AggregateException))]
-        //public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForNullEntities()
+        //public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForNullEntities()
         //{
-        //    using (var connection = new MySqlConnection(Database.ConnectionString))
+        //    using (var connection = new MariaDbConnection(Database.ConnectionString))
         //    {
         //        Assert.Throws<AggregateException>(() => connection.BulkInsertAsync((IEnumerable<BulkOperationIdentityTable>)null).Wait();)
         //    }
         //}
 
         //[TestMethod, ExpectedException(typeof(AggregateException))]
-        //public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForEmptyEntities()
+        //public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForEmptyEntities()
         //{
-        //    using (var connection = new MySqlConnection(Database.ConnectionString))
+        //    using (var connection = new MariaDbConnection(Database.ConnectionString))
         //    {
         //        Assert.Throws<AggregateException>(() => connection.BulkInsertAsync(Enumerable.Empty<BulkOperationIdentityTable>()).Wait();)
         //    }
@@ -2421,9 +2421,9 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
                     (DataTable)null).Wait());
@@ -2435,12 +2435,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkMergeAsync<TEntity>(Extra Fields)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkMergeAsyncForEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -2467,7 +2467,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkMergeAsyncForEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
@@ -2483,7 +2483,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -2514,12 +2514,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkMergeAsync(TableName)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameExpandoObjectsForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameExpandoObjectsForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables).Result;
@@ -2540,12 +2540,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameExpandoObjectsForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameExpandoObjectsForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -2567,12 +2567,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameExpandoObjectsForNonEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameExpandoObjectsForNonEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -2599,12 +2599,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameExpandoObjectsForNonEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameExpandoObjectsForNonEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationIdentityTable>(tables);
@@ -2632,12 +2632,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameAnonymousObjectsForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameAnonymousObjectsForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationAnonymousObjectIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables).Result;
@@ -2658,12 +2658,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameAnonymousObjectsForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameAnonymousObjectsForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationAnonymousObjectIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -2685,12 +2685,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameAnonymousObjectsForNonEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameAnonymousObjectsForNonEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -2717,12 +2717,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameAnonymousObjectsForNonEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameAnonymousObjectsForNonEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationIdentityTable>(tables);
@@ -2750,12 +2750,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameDataEntitiesForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameDataEntitiesForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables).Result;
@@ -2776,12 +2776,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameDataEntitiesForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameDataEntitiesForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -2804,12 +2804,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameDataEntitiesForNonEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameDataEntitiesForNonEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationIdentityTable>(tables);
@@ -2836,12 +2836,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameDataEntitiesForNonEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameDataEntitiesForNonEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationIdentityTable>(tables);
@@ -2870,12 +2870,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameDataEntities()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -2902,12 +2902,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameDataEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameDataEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -2936,12 +2936,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameDataEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameDataEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -2970,12 +2970,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -3014,19 +3014,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameDataTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -3036,7 +3036,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table).Result;
@@ -3050,19 +3050,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -3072,7 +3072,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -3097,7 +3097,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -3115,13 +3115,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -3131,7 +3131,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -3147,7 +3147,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForTableNameDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForTableNameDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -3165,13 +3165,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -3181,7 +3181,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -3194,19 +3194,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -3216,7 +3216,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync("InvalidTable", table).Result);
@@ -3227,19 +3227,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -3249,7 +3249,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync("MissingTable",
@@ -3261,19 +3261,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -3283,7 +3283,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table).Result;
@@ -3297,7 +3297,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkMergeAsyncForTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -3315,13 +3315,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -3331,7 +3331,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -3347,7 +3347,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForTableNameDbDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForTableNameDbDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -3365,13 +3365,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -3381,7 +3381,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -3394,19 +3394,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -3416,7 +3416,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync("InvalidTable",
@@ -3428,19 +3428,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -3450,7 +3450,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync("MissingTable",
@@ -3466,12 +3466,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region NonIdentityTable Mirrors
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityEntitiesForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityEntitiesForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(tables);
@@ -3492,12 +3492,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityEntitiesForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityEntitiesForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -3520,12 +3520,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityEntities()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3552,12 +3552,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3586,12 +3586,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3619,12 +3619,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3652,7 +3652,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3669,7 +3669,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3696,12 +3696,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityMappedEntitiesForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityMappedEntitiesForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(tables);
@@ -3722,12 +3722,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityMappedEntitiesForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityMappedEntitiesForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -3750,12 +3750,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityMappedEntities()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3782,12 +3782,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityMappedEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityMappedEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3816,12 +3816,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityMappedEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityMappedEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3849,12 +3849,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityMappedEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityMappedEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3882,7 +3882,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
@@ -3899,7 +3899,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedNonIdentityTable.ColumnIntMapped), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedNonIdentityTable.ColumnNVarCharMapped), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3926,7 +3926,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForNonIdentityEntitiesIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForNonIdentityEntitiesIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3943,7 +3943,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 Assert.Throws<InvalidTypeException>(() => connection.BulkMerge(tables, mappings: mappings));
@@ -3951,19 +3951,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityEntitiesDataTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3973,7 +3973,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table);
@@ -3987,19 +3987,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityEntitiesDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityEntitiesDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4009,7 +4009,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -4034,7 +4034,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -4052,13 +4052,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4068,7 +4068,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table,
@@ -4083,7 +4083,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForNonIdentityEntitiesDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForNonIdentityEntitiesDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -4101,13 +4101,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4117,7 +4117,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table,
@@ -4129,9 +4129,9 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForNonIdentityNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForNonIdentityNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
                     (DataTable)null));
@@ -4139,12 +4139,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -4171,7 +4171,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
@@ -4186,7 +4186,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -4213,12 +4213,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameExpandoObjectsForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameExpandoObjectsForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables);
@@ -4239,12 +4239,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameExpandoObjectsForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameExpandoObjectsForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -4266,12 +4266,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameExpandoObjectsForNonEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameExpandoObjectsForNonEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -4298,12 +4298,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameExpandoObjectsForNonEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameExpandoObjectsForNonEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -4331,12 +4331,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameAnonymousObjectsForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameAnonymousObjectsForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationAnonymousObjectNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables);
@@ -4357,12 +4357,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameAnonymousObjectsForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameAnonymousObjectsForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationAnonymousObjectNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -4384,12 +4384,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameAnonymousObjectsForNonEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameAnonymousObjectsForNonEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -4416,12 +4416,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameAnonymousObjectsForNonEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameAnonymousObjectsForNonEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -4449,12 +4449,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameDataEntitiesForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameDataEntitiesForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables);
@@ -4475,12 +4475,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameDataEntitiesForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameDataEntitiesForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -4503,12 +4503,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameDataEntitiesForNonEmptyTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameDataEntitiesForNonEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -4535,12 +4535,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameDataEntitiesForNonEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameDataEntitiesForNonEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -4569,12 +4569,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameDataEntities()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -4601,12 +4601,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameDataEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameDataEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -4635,12 +4635,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameDataEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameDataEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -4669,12 +4669,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -4703,19 +4703,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4725,7 +4725,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table);
@@ -4739,19 +4739,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4761,7 +4761,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity);
@@ -4786,7 +4786,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -4804,13 +4804,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4820,7 +4820,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -4836,7 +4836,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForNonIdentityTableNameDbDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForNonIdentityTableNameDbDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -4854,13 +4854,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4870,7 +4870,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -4883,19 +4883,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4905,7 +4905,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkMerge("InvalidTable",
@@ -4917,19 +4917,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4939,7 +4939,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkMerge("MissingTable",
@@ -4951,19 +4951,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameDataTable()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4973,7 +4973,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table);
@@ -4987,7 +4987,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForNonIdentityTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkMergeForNonIdentityTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -5005,13 +5005,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -5021,7 +5021,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -5037,7 +5037,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForNonIdentityTableNameDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForNonIdentityTableNameDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -5055,13 +5055,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -5071,7 +5071,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -5084,19 +5084,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -5106,7 +5106,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkMerge("InvalidTable", table));
@@ -5117,19 +5117,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -5139,7 +5139,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkMerge("MissingTable",
@@ -5151,12 +5151,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityEntitiesForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityEntitiesForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(tables).Result;
@@ -5177,12 +5177,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityEntitiesForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityEntitiesForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -5205,12 +5205,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityEntities()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -5234,12 +5234,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -5265,12 +5265,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -5298,12 +5298,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -5331,7 +5331,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -5348,7 +5348,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -5372,12 +5372,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityMappedEntitiesForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityMappedEntitiesForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(tables).Result;
@@ -5398,12 +5398,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityMappedEntitiesForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityMappedEntitiesForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -5426,12 +5426,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityMappedEntities()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -5458,12 +5458,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityMappedEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityMappedEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -5492,12 +5492,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityMappedEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityMappedEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -5525,12 +5525,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityMappedEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityMappedEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -5558,7 +5558,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
@@ -5575,7 +5575,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedNonIdentityTable.ColumnIntMapped), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationMappedNonIdentityTable.ColumnNVarCharMapped), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -5602,7 +5602,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForNonIdentityEntitiesIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForNonIdentityEntitiesIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -5619,7 +5619,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 Assert.Throws<AggregateException>(() => connection.BulkMergeAsync(tables,
@@ -5628,19 +5628,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityEntitiesDataTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -5650,7 +5650,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table).Result;
@@ -5664,19 +5664,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityEntitiesDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityEntitiesDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -5686,7 +5686,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -5711,7 +5711,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -5729,13 +5729,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -5745,7 +5745,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table,
@@ -5760,7 +5760,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForNonIdentityEntitiesDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForNonIdentityEntitiesDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -5778,13 +5778,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -5794,7 +5794,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table,
@@ -5806,9 +5806,9 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForNonIdentityNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForNonIdentityNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkInsertAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
                     (DataTable)null).Wait());
@@ -5816,12 +5816,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -5848,7 +5848,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
@@ -5864,7 +5864,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -5891,12 +5891,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameExpandoObjectsForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameExpandoObjectsForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables).Result;
@@ -5917,12 +5917,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameExpandoObjectsForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameExpandoObjectsForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationExpandoObjectNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -5944,12 +5944,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameExpandoObjectsForNonEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameExpandoObjectsForNonEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -5976,12 +5976,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameExpandoObjectsForNonEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameExpandoObjectsForNonEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -6009,12 +6009,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameAnonymousObjectsForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameAnonymousObjectsForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationAnonymousObjectNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables).Result;
@@ -6035,12 +6035,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameAnonymousObjectsForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameAnonymousObjectsForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationAnonymousObjectNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -6062,12 +6062,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameAnonymousObjectsForNonEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameAnonymousObjectsForNonEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -6094,12 +6094,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameAnonymousObjectsForNonEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameAnonymousObjectsForNonEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -6127,12 +6127,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesForEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesForEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables).Result;
@@ -6153,12 +6153,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesForEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesForEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 var bulkMergeResult = connection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), tables, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -6181,12 +6181,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesForNonEmptyTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesForNonEmptyTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -6213,12 +6213,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesForNonEmptyTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesForNonEmptyTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll<BulkOperationNonIdentityTable>(tables);
@@ -6247,12 +6247,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataEntities()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -6279,12 +6279,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -6313,12 +6313,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -6347,12 +6347,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -6381,19 +6381,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -6403,7 +6403,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table).Result;
@@ -6417,19 +6417,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataTableWithReturnIdentity()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataTableWithReturnIdentity()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -6439,7 +6439,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, identityBehavior: MariaDbBulkImportIdentityBehavior.ReturnIdentity).Result;
@@ -6464,7 +6464,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -6482,13 +6482,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -6498,7 +6498,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -6514,7 +6514,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -6532,13 +6532,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -6548,7 +6548,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -6561,19 +6561,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -6583,7 +6583,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync("InvalidTable", table).Result);
@@ -6594,19 +6594,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -6616,7 +6616,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync("MissingTable",
@@ -6628,19 +6628,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -6650,7 +6650,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table).Result;
@@ -6664,7 +6664,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -6682,13 +6682,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -6698,7 +6698,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -6714,7 +6714,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDbDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDbDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -6732,13 +6732,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -6748,7 +6748,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -6761,19 +6761,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -6783,7 +6783,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync("InvalidTable",
@@ -6795,19 +6795,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkMergeAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkMergeAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -6817,7 +6817,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkMergeAsync("MissingTable",
@@ -6833,17 +6833,17 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkMerge(DbDataReader)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeForDbDataReader()
+        public void TestMariaDbConnectionBulkMergeForDbDataReader()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 sourceConnection.InsertAll(tables);
 
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
-                using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                 {
                     // Act
                     var bulkMergeResult = destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), reader);
@@ -6861,17 +6861,17 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkMergeAsyncForDbDataReader()
+        public void TestMariaDbConnectionBulkMergeAsyncForDbDataReader()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 sourceConnection.InsertAll(tables);
 
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
-                using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                 {
                     // Act
                     var bulkMergeResult = destinationConnection.BulkMergeAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), reader).Result;

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Operations/BulkUpdateTest.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Operations/BulkUpdateTest.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RepoDb.Exceptions;
 using RepoDb.Extensions;
@@ -15,7 +15,7 @@ using System.Linq;
 namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
 {
     [TestClass]
-    public class MySqlConnectionBulkUpdateOperationsTest
+    public class MariaDbConnectionBulkUpdateOperationsTest
     {
         [TestInitialize]
         public void Initialize()
@@ -33,12 +33,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkUpdate<TEntity>
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForEntities()
+        public void TestMariaDbConnectionBulkUpdateForEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -65,12 +65,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkUpdateForEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -98,12 +98,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkUpdateForEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -131,7 +131,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkUpdateForEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -148,7 +148,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -175,12 +175,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForMappedEntities()
+        public void TestMariaDbConnectionBulkUpdateForMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -207,12 +207,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForMappedEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkUpdateForMappedEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -240,12 +240,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForMappedEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkUpdateForMappedEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -273,7 +273,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkUpdateForMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
@@ -290,7 +290,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -317,7 +317,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForEntitiesIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForEntitiesIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -334,7 +334,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 Assert.Throws<InvalidTypeException>(() => connection.BulkUpdate(tables, mappings: mappings));
@@ -342,19 +342,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForEntitiesDataTable()
+        public void TestMariaDbConnectionBulkUpdateForEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -364,7 +364,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table);
@@ -378,7 +378,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkUpdateForEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -396,13 +396,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -412,7 +412,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table,
@@ -427,7 +427,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForEntitiesDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForEntitiesDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -445,13 +445,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -461,7 +461,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table,
@@ -473,18 +473,18 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForNullEntities()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForNullEntities()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkUpdate((IEnumerable<BulkOperationIdentityTable>)null));
             }
         }
 
         //[TestMethod, ExpectedException(typeof(EmptyException))]
-        //public void ThrowExceptionOnMySqlConnectionBulkUpdateForEmptyEntities()
+        //public void ThrowExceptionOnMariaDbConnectionBulkUpdateForEmptyEntities()
         //{
-        //    using (var connection = new MySqlConnection(Database.ConnectionString))
+        //    using (var connection = new MariaDbConnection(Database.ConnectionString))
         //    {
         //        connection.BulkUpdate(Enumerable.Empty<BulkOperationIdentityTable>());
         //    }
@@ -493,9 +493,9 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
                     (DataTable)null));
@@ -507,12 +507,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkUpdate<TEntity>(Extra Fields)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkUpdateForEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -539,7 +539,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkUpdateForEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
@@ -554,7 +554,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -585,12 +585,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkUpdate(TableName)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForTableNameExpandoObjects()
+        public void TestMariaDbConnectionBulkUpdateForTableNameExpandoObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -617,12 +617,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForTableNameAnonymousObjects()
+        public void TestMariaDbConnectionBulkUpdateForTableNameAnonymousObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -649,12 +649,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForTableNameDataEntities()
+        public void TestMariaDbConnectionBulkUpdateForTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -681,12 +681,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForTableNameDataEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkUpdateForTableNameDataEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -715,12 +715,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkUpdateForTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -759,19 +759,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkUpdateForTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -781,7 +781,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table);
@@ -795,7 +795,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkUpdateForTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -813,13 +813,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -829,7 +829,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -845,7 +845,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForTableNameDbDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForTableNameDbDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -863,13 +863,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -879,7 +879,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -892,19 +892,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -914,7 +914,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkUpdate("InvalidTable",
@@ -926,19 +926,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -948,7 +948,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkUpdate("MissingTable",
@@ -960,19 +960,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForTableNameDataTable()
+        public void TestMariaDbConnectionBulkUpdateForTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -982,7 +982,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table);
@@ -996,7 +996,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkUpdateForTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1014,13 +1014,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1030,7 +1030,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -1046,7 +1046,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForTableNameDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForTableNameDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1064,13 +1064,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1080,7 +1080,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -1093,19 +1093,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1115,7 +1115,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkUpdate("InvalidTable", table));
@@ -1126,19 +1126,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1148,7 +1148,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkUpdate("MissingTable",
@@ -1164,12 +1164,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkUpdateAsync<TEntity>
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForEntities()
+        public void TestMariaDbConnectionBulkUpdateAsyncForEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1196,12 +1196,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkUpdateAsyncForEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1229,12 +1229,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkUpdateAsyncForEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1262,7 +1262,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkUpdateAsyncForEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1279,7 +1279,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -1303,12 +1303,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForMappedEntities()
+        public void TestMariaDbConnectionBulkUpdateAsyncForMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1335,12 +1335,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForMappedEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkUpdateAsyncForMappedEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1368,12 +1368,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForMappedEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkUpdateAsyncForMappedEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1401,7 +1401,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkUpdateAsyncForMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedIdentityTables(10);
@@ -1418,7 +1418,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1445,7 +1445,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForEntitiesIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForEntitiesIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1462,7 +1462,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 Assert.Throws<AggregateException>(() => connection.BulkUpdateAsync(tables,
@@ -1477,19 +1477,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForEntitiesDataTable()
+        public void TestMariaDbConnectionBulkUpdateAsyncForEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1499,7 +1499,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table).Result;
@@ -1513,7 +1513,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkUpdateAsyncForEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1531,13 +1531,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1547,7 +1547,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table,
@@ -1562,7 +1562,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForEntitiesDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForEntitiesDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1580,13 +1580,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1596,7 +1596,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table,
@@ -1608,18 +1608,18 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForNullEntities()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForNullEntities()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkUpdateAsync((IEnumerable<BulkOperationIdentityTable>)null).Wait());
             }
         }
 
         //[TestMethod, ExpectedException(typeof(AggregateException))]
-        //public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForEmptyEntities()
+        //public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForEmptyEntities()
         //{
-        //    using (var connection = new MySqlConnection(Database.ConnectionString))
+        //    using (var connection = new MariaDbConnection(Database.ConnectionString))
         //    {
         //        Assert.Throws<AggregateException>(() => connection.BulkUpdateAsync(Enumerable.Empty<BulkOperationIdentityTable>()).Wait();)
         //    }
@@ -1628,9 +1628,9 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
                     (DataTable)null).Wait());
@@ -1642,12 +1642,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkUpdateAsync<TEntity>(Extra Fields)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkUpdateAsyncForEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -1674,7 +1674,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkUpdateAsyncForEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationIdentityTables(10);
@@ -1690,7 +1690,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnInt), nameof(BulkOperationIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -1721,12 +1721,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkUpdateAsync(TableName)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForTableNameExpandoObjects()
+        public void TestMariaDbConnectionBulkUpdateAsyncForTableNameExpandoObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1753,12 +1753,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForTableNameAnonymousObjects()
+        public void TestMariaDbConnectionBulkUpdateAsyncForTableNameAnonymousObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10, true);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1785,12 +1785,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForTableNameDataEntities()
+        public void TestMariaDbConnectionBulkUpdateAsyncForTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1817,12 +1817,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForTableNameDataEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkUpdateAsyncForTableNameDataEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1851,12 +1851,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkUpdateAsyncForTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -1895,19 +1895,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForTableNameDataTable()
+        public void TestMariaDbConnectionBulkUpdateAsyncForTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1917,7 +1917,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table).Result;
@@ -1931,7 +1931,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkUpdateAsyncForTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1949,13 +1949,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -1965,7 +1965,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -1981,7 +1981,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForTableNameDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForTableNameDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -1999,13 +1999,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2015,7 +2015,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -2028,19 +2028,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2050,7 +2050,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync("InvalidTable", table).Result);
@@ -2061,19 +2061,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2083,7 +2083,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync("MissingTable",
@@ -2095,19 +2095,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkUpdateAsyncForTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2117,7 +2117,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table).Result;
@@ -2131,7 +2131,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkUpdateAsyncForTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -2149,13 +2149,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2165,7 +2165,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -2181,7 +2181,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForTableNameDbDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForTableNameDbDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
@@ -2199,13 +2199,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationIdentityTable.ColumnNVarChar), nameof(BulkOperationIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2215,7 +2215,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
@@ -2228,19 +2228,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2250,7 +2250,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync("InvalidTable",
@@ -2262,19 +2262,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationIdentityTable`"))
@@ -2284,7 +2284,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync("MissingTable",
@@ -2300,12 +2300,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region NonIdentityTable Mirrors
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityEntities()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2332,12 +2332,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2365,12 +2365,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2398,7 +2398,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -2415,7 +2415,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2442,12 +2442,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityMappedEntities()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2474,12 +2474,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityMappedEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityMappedEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2507,12 +2507,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityMappedEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityMappedEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2540,7 +2540,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
@@ -2557,7 +2557,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2584,7 +2584,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForNonIdentityEntitiesIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForNonIdentityEntitiesIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -2601,7 +2601,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 Assert.Throws<InvalidTypeException>(() => connection.BulkUpdate(tables, mappings: mappings));
@@ -2609,19 +2609,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityEntitiesDataTable()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2631,7 +2631,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table);
@@ -2645,7 +2645,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -2663,13 +2663,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2679,7 +2679,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table,
@@ -2694,7 +2694,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForNonIdentityEntitiesDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForNonIdentityEntitiesDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -2712,13 +2712,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -2728,7 +2728,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table,
@@ -2740,18 +2740,18 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForNonIdentityNullEntities()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForNonIdentityNullEntities()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkUpdate((IEnumerable<BulkOperationNonIdentityTable>)null));
             }
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForNonIdentityNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForNonIdentityNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<NullReferenceException>(() => connection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
                     (DataTable)null));
@@ -2759,12 +2759,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -2791,7 +2791,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
@@ -2806,7 +2806,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -2833,12 +2833,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityTableNameExpandoObjects()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityTableNameExpandoObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2865,12 +2865,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityTableNameAnonymousObjects()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityTableNameAnonymousObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2897,12 +2897,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityTableNameDataEntities()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2929,12 +2929,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityTableNameDataEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityTableNameDataEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2963,12 +2963,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -2997,19 +2997,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3019,7 +3019,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table);
@@ -3033,7 +3033,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3051,13 +3051,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3067,7 +3067,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -3083,7 +3083,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForNonIdentityTableNameDbDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForNonIdentityTableNameDbDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3101,13 +3101,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3117,7 +3117,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -3130,19 +3130,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3152,7 +3152,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkUpdate("InvalidTable",
@@ -3164,19 +3164,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3186,7 +3186,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkUpdate("MissingTable",
@@ -3198,19 +3198,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityTableNameDataTable()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3220,7 +3220,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table);
@@ -3234,7 +3234,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForNonIdentityTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkUpdateForNonIdentityTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3252,13 +3252,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3268,7 +3268,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -3284,7 +3284,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForNonIdentityTableNameDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForNonIdentityTableNameDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3302,13 +3302,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3318,7 +3318,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<InvalidTypeException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -3331,19 +3331,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3353,7 +3353,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkUpdate("InvalidTable", table));
@@ -3364,19 +3364,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3386,7 +3386,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<MissingFieldsException>(() => destinationConnection.BulkUpdate("MissingTable",
@@ -3398,12 +3398,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityEntities()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3430,12 +3430,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3463,12 +3463,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3496,7 +3496,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3513,7 +3513,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -3537,12 +3537,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityMappedEntities()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityMappedEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3569,12 +3569,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityMappedEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityMappedEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3602,12 +3602,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityMappedEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityMappedEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3635,7 +3635,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityMappedEntitiesWithMappings()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityMappedEntitiesWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationMappedNonIdentityTables(10);
@@ -3652,7 +3652,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3679,7 +3679,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForNonIdentityEntitiesIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForNonIdentityEntitiesIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3696,7 +3696,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 Assert.Throws<AggregateException>(() => connection.BulkUpdateAsync(tables,
@@ -3705,19 +3705,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityEntitiesDataTable()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityEntitiesDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3727,7 +3727,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table).Result;
@@ -3741,7 +3741,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityEntitiesDataTableWithMappings()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityEntitiesDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3759,13 +3759,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3775,7 +3775,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table,
@@ -3790,7 +3790,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForNonIdentityEntitiesDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForNonIdentityEntitiesDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -3808,13 +3808,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -3824,7 +3824,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table,
@@ -3836,18 +3836,18 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForNonIdentityNullEntities()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForNonIdentityNullEntities()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkUpdateAsync((IEnumerable<BulkOperationNonIdentityTable>)null).Wait());
             }
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForNonIdentityNullDataTable()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForNonIdentityNullDataTable()
         {
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 Assert.Throws<AggregateException>(() => connection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
                     (DataTable)null).Wait());
@@ -3855,12 +3855,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityEntitiesWithExtraFields()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityEntitiesWithExtraFields()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -3887,7 +3887,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityEntitiesWithExtraFieldsWithMappings()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityEntitiesWithExtraFieldsWithMappings()
         {
             // Setup
             var tables = Helper.CreateWithExtraFieldsBulkOperationNonIdentityTables(10);
@@ -3903,7 +3903,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnInt), nameof(BulkOperationNonIdentityTable.ColumnInt)));
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Setup
                 connection.InsertAll(tables);
@@ -3930,12 +3930,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameExpandoObjects()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameExpandoObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3962,12 +3962,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameAnonymousObjects()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameAnonymousObjects()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -3994,12 +3994,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameDataEntities()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameDataEntities()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -4026,12 +4026,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameDataEntitiesWithQualifiers()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameDataEntitiesWithQualifiers()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -4060,12 +4060,12 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameDataEntitiesWithUsePhysicalPseudoTempTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
                 connection.InsertAll(tables);
@@ -4094,19 +4094,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameDataTable()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4116,7 +4116,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table).Result;
@@ -4130,7 +4130,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameDataTableWithMappings()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -4148,13 +4148,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4164,7 +4164,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -4180,7 +4180,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -4198,13 +4198,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4214,7 +4214,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -4227,19 +4227,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4249,7 +4249,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync("InvalidTable", table).Result);
@@ -4260,19 +4260,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4282,7 +4282,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync("MissingTable",
@@ -4294,19 +4294,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameDbDataTable()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameDbDataTable()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4316,7 +4316,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table).Result;
@@ -4330,7 +4330,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameDbDataTableWithMappings()
+        public void TestMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameDbDataTableWithMappings()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -4348,13 +4348,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnNVarChar)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4364,7 +4364,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             var bulkUpdateResult = destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -4380,7 +4380,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameDbDataTableIfTheMappingsAreInvalid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameDbDataTableIfTheMappingsAreInvalid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
@@ -4398,13 +4398,13 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
             mappings.Add(new MariaDbBulkInsertMapItem(nameof(BulkOperationNonIdentityTable.ColumnNVarChar), nameof(BulkOperationNonIdentityTable.ColumnInt)));
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4414,7 +4414,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
@@ -4427,19 +4427,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsNotValid()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4449,7 +4449,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync("InvalidTable",
@@ -4461,19 +4461,19 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void ThrowExceptionOnMySqlConnectionBulkUpdateAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
+        public void ThrowExceptionOnMariaDbConnectionBulkUpdateAsyncForNonIdentityTableNameDbDataTableIfTheTableNameIsMissing()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
             // Insert the records first
-            using (var connection = new MySqlConnection(Database.ConnectionString))
+            using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 connection.InsertAll(tables);
             }
 
             // Open the source connection
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Read the data from source connection
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
@@ -4483,7 +4483,7 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
                         table.Load(reader);
 
                         // Open the destination connection
-                        using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                        using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                         {
                             // Act
                             Assert.Throws<AggregateException>(() => destinationConnection.BulkUpdateAsync("MissingTable",
@@ -4499,17 +4499,17 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         #region BulkUpdate(DbDataReader)
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateForDbDataReader()
+        public void TestMariaDbConnectionBulkUpdateForDbDataReader()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 sourceConnection.InsertAll(tables);
 
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
-                using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                 {
                     // Act
                     var bulkUpdateResult = destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), reader);
@@ -4521,17 +4521,17 @@ namespace RepoDb.MariaDb.BulkOperations.IntegrationTests.Operations
         }
 
         [TestMethod]
-        public void TestMySqlConnectionBulkUpdateAsyncForDbDataReader()
+        public void TestMariaDbConnectionBulkUpdateAsyncForDbDataReader()
         {
             // Setup
             var tables = Helper.CreateBulkOperationNonIdentityTables(10);
 
-            using (var sourceConnection = new MySqlConnection(Database.ConnectionString))
+            using (var sourceConnection = new MariaDbConnection(Database.ConnectionString))
             {
                 sourceConnection.InsertAll(tables);
 
                 using (var reader = sourceConnection.ExecuteReader("SELECT * FROM `BulkOperationNonIdentityTable`"))
-                using (var destinationConnection = new MySqlConnection(Database.ConnectionString))
+                using (var destinationConnection = new MariaDbConnection(Database.ConnectionString))
                 {
                     // Act
                     var bulkUpdateResult = destinationConnection.BulkUpdateAsync(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), reader).Result;

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/RepoDb.MariaDb.BulkOperations.IntegrationTests.csproj
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/RepoDb.MariaDb.BulkOperations.IntegrationTests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSTest" Version="4.2.3" />
+    <PackageReference Include="RepoDb.Connector.MariaDb" Version="0.0.1-alpha1" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/RepoDb.MariaDb.BulkOperations.IntegrationTests.csproj
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/RepoDb.MariaDb.BulkOperations.IntegrationTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSTest" Version="4.2.3" />
-    <PackageReference Include="RepoDb.Connector.MariaDb" Version="0.0.1-alpha1" />
+    <PackageReference Include="RepoDb.Connector.MariaDb" Version="0.0.1-alpha2" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Setup/Database.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.IntegrationTests/Setup/Database.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.MariaDb.BulkOperations.IntegrationTests.Models;
 using System;
 
@@ -59,7 +59,7 @@ namespace RepoDb.IntegrationTests.Setup
         /// </summary>
         public static void CreateDatabase()
         {
-            using var connection = new MySqlConnection(ConnectionStringForSystem);
+            using var connection = new MariaDbConnection(ConnectionStringForSystem);
             connection.ExecuteNonQuery("CREATE DATABASE IF NOT EXISTS `RepoDb`;");
         }
 
@@ -73,7 +73,7 @@ namespace RepoDb.IntegrationTests.Setup
         /// </summary>
         public static void EnableServerLocalInfile()
         {
-            using var connection = new MySqlConnection(ConnectionStringForSystem);
+            using var connection = new MariaDbConnection(ConnectionStringForSystem);
             connection.ExecuteNonQuery("SET GLOBAL local_infile = 1;");
         }
 
@@ -82,7 +82,7 @@ namespace RepoDb.IntegrationTests.Setup
         /// </summary>
         public static void Cleanup()
         {
-            using var connection = new MySqlConnection(ConnectionString);
+            using var connection = new MariaDbConnection(ConnectionString);
             connection.Truncate<BulkOperationIdentityTable>();
             connection.Truncate<BulkOperationNonIdentityTable>();
         }
@@ -123,7 +123,7 @@ namespace RepoDb.IntegrationTests.Setup
                     `ColumnNVarChar` NVARCHAR(2000) NULL,
                     PRIMARY KEY (`Id`)
                 ) ENGINE=InnoDB;";
-            using var connection = new MySqlConnection(ConnectionString);
+            using var connection = new MariaDbConnection(ConnectionString);
             connection.ExecuteNonQuery(commandText);
         }
 
@@ -151,7 +151,7 @@ namespace RepoDb.IntegrationTests.Setup
                     `ColumnNVarChar` NVARCHAR(2000) NULL,
                     PRIMARY KEY (`Id`)
                 ) ENGINE=InnoDB;";
-            using var connection = new MySqlConnection(ConnectionString);
+            using var connection = new MariaDbConnection(ConnectionString);
             connection.ExecuteNonQuery(commandText);
         }
 

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Base/BulkDelete.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Base/BulkDelete.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Extensions;
 using RepoDb.Interfaces;
@@ -36,7 +36,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkDeleteBase<TEntity>(this MySqlConnection connection,
+        private static int BulkDeleteBase<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
@@ -45,7 +45,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
             var entityList = entities.AsList();
@@ -106,7 +106,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkDeleteBase(this MySqlConnection connection,
+        private static int BulkDeleteBase(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
@@ -116,7 +116,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             pseudoTableType = ResolvePseudoTableType(pseudoTableType, table?.Rows.Count);
             var pseudoTableName = MariaDbText.GetPseudoTableNameForDelete(tableName, pseudoTableType, connection.GetDbSetting());
@@ -174,7 +174,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkDeleteBase(this MySqlConnection connection,
+        private static int BulkDeleteBase(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<Field> qualifiers = null,
@@ -183,7 +183,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             pseudoTableType = ResolvePseudoTableType(pseudoTableType, null);
             var pseudoTableName = MariaDbText.GetPseudoTableNameForDelete(tableName, pseudoTableType, connection.GetDbSetting());
@@ -247,7 +247,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkDeleteBaseAsync<TEntity>(this MySqlConnection connection,
+        private static async Task<int> BulkDeleteBaseAsync<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
@@ -256,7 +256,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
@@ -319,7 +319,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkDeleteBaseAsync(this MySqlConnection connection,
+        private static async Task<int> BulkDeleteBaseAsync(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
@@ -329,7 +329,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             pseudoTableType = ResolvePseudoTableType(pseudoTableType, table?.Rows.Count);
@@ -389,7 +389,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkDeleteBaseAsync(this MySqlConnection connection,
+        private static async Task<int> BulkDeleteBaseAsync(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<Field> qualifiers = null,
@@ -398,7 +398,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             pseudoTableType = ResolvePseudoTableType(pseudoTableType, null);

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Base/BulkDeleteByKey.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Base/BulkDeleteByKey.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Extensions;
 using RepoDb.Interfaces;
@@ -29,7 +29,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkDeleteByKeyBase<TPrimaryKey>(this MySqlConnection connection,
+        private static int BulkDeleteByKeyBase<TPrimaryKey>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TPrimaryKey> primaryKeys,
             int? bulkCopyTimeout = null,
@@ -37,7 +37,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDeleteByKey,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var primaryKeyList = primaryKeys?.Select(primaryKey => (object)primaryKey).AsList();
             pseudoTableType = ResolvePseudoTableType(pseudoTableType, primaryKeyList?.Count);
@@ -72,7 +72,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkDeleteByKeyBaseAsync<TPrimaryKey>(this MySqlConnection connection,
+        private static async Task<int> BulkDeleteByKeyBaseAsync<TPrimaryKey>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TPrimaryKey> primaryKeys,
             int? bulkCopyTimeout = null,
@@ -80,7 +80,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDeleteByKey,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var primaryKeyList = primaryKeys?.Select(primaryKey => (object)primaryKey).AsList();
@@ -115,7 +115,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkDeleteBaseViaKeyValues(MySqlConnection connection,
+        private static int BulkDeleteBaseViaKeyValues(MariaDbConnection connection,
             string tableName,
             IEnumerable<object> keyValues,
             int? bulkCopyTimeout,
@@ -123,7 +123,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType,
             ITrace trace,
             string traceKey,
-            MySqlTransaction transaction)
+            MariaDbTransaction transaction)
         {
             var pseudoTableName = MariaDbText.GetPseudoTableNameForDeleteByKey(tableName, pseudoTableType, connection.GetDbSetting());
             var dbFields = DbFieldCache.Get(connection, tableName, transaction);
@@ -178,7 +178,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkDeleteBaseViaKeyValuesAsync(MySqlConnection connection,
+        private static async Task<int> BulkDeleteBaseViaKeyValuesAsync(MariaDbConnection connection,
             string tableName,
             IEnumerable<object> keyValues,
             int? bulkCopyTimeout,
@@ -186,7 +186,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType,
             ITrace trace,
             string traceKey,
-            MySqlTransaction transaction,
+            MariaDbTransaction transaction,
             CancellationToken cancellationToken)
         {
             var pseudoTableName = MariaDbText.GetPseudoTableNameForDeleteByKey(tableName, pseudoTableType, connection.GetDbSetting());

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Base/BulkInsert.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Base/BulkInsert.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Exceptions;
 using RepoDb.Extensions;
@@ -39,7 +39,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkInsertBase<TEntity>(this MySqlConnection connection,
+        private static int BulkInsertBase<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -49,7 +49,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
             var entityList = entities.AsList();
@@ -100,7 +100,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkInsertBaseForReturnIdentity<TEntity>(this MySqlConnection connection,
+        private static int BulkInsertBaseForReturnIdentity<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -110,7 +110,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
             var entityList = entities.AsList();
@@ -166,7 +166,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkInsertBaseNoReturnIdentity<TEntity>(this MySqlConnection connection,
+        private static int BulkInsertBaseNoReturnIdentity<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -174,7 +174,7 @@ namespace RepoDb
             int? batchSize = null,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
             using var command = CreateTraceCommand(connection, $"BULK INSERT INTO {tableName}", bulkCopyTimeout, transaction);
@@ -221,7 +221,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkInsertBase(this MySqlConnection connection,
+        private static int BulkInsertBase(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             DataRowState? rowState = null,
@@ -232,7 +232,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             pseudoTableType = ResolvePseudoTableType(pseudoTableType, table?.Rows.Count);
             var dbFields = DbFieldCache.Get(connection, tableName, transaction);
@@ -286,7 +286,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkInsertBaseForReturnIdentity(this MySqlConnection connection,
+        private static int BulkInsertBaseForReturnIdentity(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             DataRowState? rowState = null,
@@ -297,7 +297,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var rows = GetDataRows(table, rowState)?.ToArray();
             var pseudoTableName = MariaDbText.GetPseudoTableNameForInsert(tableName, pseudoTableType, connection.GetDbSetting());
@@ -354,7 +354,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkInsertBaseNoReturnIdentity(this MySqlConnection connection,
+        private static int BulkInsertBaseNoReturnIdentity(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             DataRowState? rowState = null,
@@ -363,7 +363,7 @@ namespace RepoDb
             int? batchSize = null,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             using var command = CreateTraceCommand(connection, $"BULK INSERT INTO {tableName}", bulkCopyTimeout, transaction);
 
@@ -407,7 +407,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkInsertBase(this MySqlConnection connection,
+        private static int BulkInsertBase(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -416,7 +416,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             using var command = CreateTraceCommand(connection, $"BULK INSERT INTO {tableName}", bulkCopyTimeout, transaction);
 
@@ -467,7 +467,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkInsertBaseAsync<TEntity>(this MySqlConnection connection,
+        private static async Task<int> BulkInsertBaseAsync<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -477,7 +477,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
@@ -532,7 +532,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkInsertBaseForReturnIdentityAsync<TEntity>(this MySqlConnection connection,
+        private static async Task<int> BulkInsertBaseForReturnIdentityAsync<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -542,7 +542,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
@@ -600,7 +600,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkInsertBaseNoReturnIdentityAsync<TEntity>(this MySqlConnection connection,
+        private static async Task<int> BulkInsertBaseNoReturnIdentityAsync<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -608,7 +608,7 @@ namespace RepoDb
             int? batchSize = null,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
@@ -658,7 +658,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkInsertBaseAsync(this MySqlConnection connection,
+        private static async Task<int> BulkInsertBaseAsync(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             DataRowState? rowState = null,
@@ -669,7 +669,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             pseudoTableType = ResolvePseudoTableType(pseudoTableType, table?.Rows.Count);
@@ -724,7 +724,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkInsertBaseForReturnIdentityAsync(this MySqlConnection connection,
+        private static async Task<int> BulkInsertBaseForReturnIdentityAsync(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             DataRowState? rowState = null,
@@ -735,7 +735,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var rows = GetDataRows(table, rowState)?.ToArray();
@@ -792,7 +792,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkInsertBaseNoReturnIdentityAsync(this MySqlConnection connection,
+        private static async Task<int> BulkInsertBaseNoReturnIdentityAsync(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             DataRowState? rowState = null,
@@ -801,7 +801,7 @@ namespace RepoDb
             int? batchSize = null,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             using var command = CreateTraceCommand(connection, $"BULK INSERT INTO {tableName}", bulkCopyTimeout, transaction);
@@ -848,7 +848,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkInsertBaseAsync(this MySqlConnection connection,
+        private static async Task<int> BulkInsertBaseAsync(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -857,7 +857,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             using var command = CreateTraceCommand(connection, $"BULK INSERT INTO {tableName}", bulkCopyTimeout, transaction);

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Base/BulkMerge.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Base/BulkMerge.cs
@@ -4,7 +4,7 @@ using System.Data;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Exceptions;
 using RepoDb.Extensions;
@@ -40,7 +40,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkMergeBase<TEntity>(this MySqlConnection connection,
+        private static int BulkMergeBase<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
@@ -51,7 +51,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
             var dbFields = DbFieldCache.Get(connection, tableName, transaction);
@@ -104,7 +104,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkMergeBaseForReturnIdentity<TEntity>(this MySqlConnection connection,
+        private static int BulkMergeBaseForReturnIdentity<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
@@ -115,7 +115,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
             var entityList = entities.AsList();
@@ -176,7 +176,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkMergeBaseNoReturnIdentity<TEntity>(this MySqlConnection connection,
+        private static int BulkMergeBaseNoReturnIdentity<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
@@ -186,7 +186,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
             // Identify the columns
@@ -252,7 +252,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkMergeBase(this MySqlConnection connection,
+        private static int BulkMergeBase(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
@@ -264,7 +264,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var dbFields = DbFieldCache.Get(connection, tableName, transaction);
             var identityField = dbFields.GetIdentity();
@@ -318,7 +318,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkMergeBaseForReturnIdentity(this MySqlConnection connection,
+        private static int BulkMergeBaseForReturnIdentity(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
@@ -330,7 +330,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var rows = GetDataRows(table, rowState)?.ToArray();
             pseudoTableType = ResolvePseudoTableType(pseudoTableType, table?.Rows.Count);
@@ -390,7 +390,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkMergeBaseNoReturnIdentity(this MySqlConnection connection,
+        private static int BulkMergeBaseNoReturnIdentity(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
@@ -401,7 +401,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             // Identify the columns
             pseudoTableType = ResolvePseudoTableType(pseudoTableType, table?.Rows.Count);
@@ -463,7 +463,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkMergeBase(this MySqlConnection connection,
+        private static int BulkMergeBase(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<Field> qualifiers = null,
@@ -473,7 +473,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             // Identify the columns
             pseudoTableType = ResolvePseudoTableType(pseudoTableType, null);
@@ -542,7 +542,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkMergeBaseAsync<TEntity>(this MySqlConnection connection,
+        private static async Task<int> BulkMergeBaseAsync<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
@@ -553,7 +553,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
@@ -610,7 +610,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkMergeBaseForReturnIdentityAsync<TEntity>(this MySqlConnection connection,
+        private static async Task<int> BulkMergeBaseForReturnIdentityAsync<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
@@ -621,7 +621,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
@@ -684,7 +684,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkMergeBaseNoReturnIdentityAsync<TEntity>(this MySqlConnection connection,
+        private static async Task<int> BulkMergeBaseNoReturnIdentityAsync<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers,
@@ -694,7 +694,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType,
             ITrace trace,
             string traceKey,
-            MySqlTransaction transaction,
+            MariaDbTransaction transaction,
             CancellationToken cancellationToken)
             where TEntity : class
         {
@@ -762,7 +762,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkMergeBaseAsync(this MySqlConnection connection,
+        private static async Task<int> BulkMergeBaseAsync(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
@@ -774,7 +774,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var dbFields = DbFieldCache.Get(connection, tableName, transaction);
@@ -832,7 +832,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkMergeBaseForReturnIdentityAsync(this MySqlConnection connection,
+        private static async Task<int> BulkMergeBaseForReturnIdentityAsync(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
@@ -844,7 +844,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var rows = GetDataRows(table, rowState)?.ToArray();
@@ -906,7 +906,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkMergeBaseNoReturnIdentityAsync(this MySqlConnection connection,
+        private static async Task<int> BulkMergeBaseNoReturnIdentityAsync(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
@@ -917,7 +917,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             // Identify the columns
@@ -981,7 +981,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkMergeBaseAsync(this MySqlConnection connection,
+        private static async Task<int> BulkMergeBaseAsync(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<Field> qualifiers = null,
@@ -991,7 +991,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             // Identify the columns

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Base/BulkUpdate.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Base/BulkUpdate.cs
@@ -4,7 +4,7 @@ using System.Data;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Extensions;
 using RepoDb.Interfaces;
@@ -38,7 +38,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkUpdateBase<TEntity>(this MySqlConnection connection,
+        private static int BulkUpdateBase<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
@@ -48,7 +48,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
             // Identify the columns
@@ -118,7 +118,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkUpdateBase(this MySqlConnection connection,
+        private static int BulkUpdateBase(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
@@ -129,7 +129,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             // Identify the columns
             pseudoTableType = ResolvePseudoTableType(pseudoTableType, table?.Rows.Count);
@@ -196,7 +196,7 @@ namespace RepoDb
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static int BulkUpdateBase(this MySqlConnection connection,
+        private static int BulkUpdateBase(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<Field> qualifiers = null,
@@ -206,7 +206,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             // Identify the columns
             var dbFields = DbFieldCache.Get(connection, tableName, transaction);
@@ -279,7 +279,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkUpdateBaseAsync<TEntity>(this MySqlConnection connection,
+        private static async Task<int> BulkUpdateBaseAsync<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
@@ -289,7 +289,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
@@ -361,7 +361,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkUpdateBaseAsync(this MySqlConnection connection,
+        private static async Task<int> BulkUpdateBaseAsync(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
@@ -372,7 +372,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             // Identify the columns
@@ -441,7 +441,7 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<int> BulkUpdateBaseAsync(this MySqlConnection connection,
+        private static async Task<int> BulkUpdateBaseAsync(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<Field> qualifiers = null,
@@ -451,7 +451,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             // Identify the columns

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Base/WriteToServer.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Base/WriteToServer.cs
@@ -5,7 +5,7 @@ using System.Data.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Exceptions;
@@ -34,13 +34,13 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="excludeField"></param>
         /// <returns></returns>
-        internal static int WriteToServerInternal<TEntity>(MySqlConnection connection,
+        internal static int WriteToServerInternal<TEntity>(MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             Field excludeField = null)
             where TEntity : class
         {
@@ -63,7 +63,7 @@ namespace RepoDb
         /// <param name="batchSize"></param>
         /// <param name="excludeField"></param>
         /// <returns></returns>
-        internal static int WriteToServerInternal(MySqlConnection connection,
+        internal static int WriteToServerInternal(MariaDbConnection connection,
             string tableName,
             DataTable table,
             DataRowState? rowState = null,
@@ -91,13 +91,13 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="excludeField"></param>
         /// <returns></returns>
-        internal static int WriteToServerInternal(MySqlConnection connection,
+        internal static int WriteToServerInternal(MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             Field excludeField = null)
         {
             connection.EnsureOpen();
@@ -125,14 +125,14 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="excludeField"></param>
         /// <returns></returns>
-        internal static async Task<int> WriteToServerAsyncInternal<TEntity>(MySqlConnection connection,
+        internal static async Task<int> WriteToServerAsyncInternal<TEntity>(MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             CancellationToken cancellationToken = default,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             Field excludeField = null)
             where TEntity : class
         {
@@ -156,7 +156,7 @@ namespace RepoDb
         /// <param name="cancellationToken"></param>
         /// <param name="excludeField"></param>
         /// <returns></returns>
-        internal static async Task<int> WriteToServerAsyncInternal(MySqlConnection connection,
+        internal static async Task<int> WriteToServerAsyncInternal(MariaDbConnection connection,
             string tableName,
             DataTable table,
             DataRowState? rowState = null,
@@ -186,14 +186,14 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="excludeField"></param>
         /// <returns></returns>
-        internal static async Task<int> WriteToServerAsyncInternal(MySqlConnection connection,
+        internal static async Task<int> WriteToServerAsyncInternal(MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             CancellationToken cancellationToken = default,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             Field excludeField = null)
         {
             await connection.EnsureOpenAsync(cancellationToken);
@@ -259,7 +259,7 @@ namespace RepoDb
         /// <param name="excludeField"></param>
         /// <returns></returns>
         /// <exception cref="InvalidTypeException"></exception>
-        private static MariaDbBulkCopy CreateBulkCopyForDataTable(MySqlConnection connection,
+        private static MariaDbBulkCopy CreateBulkCopyForDataTable(MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<MariaDbBulkInsertMapItem> mappings,
@@ -355,12 +355,12 @@ namespace RepoDb
         /// <param name="excludeField"></param>
         /// <returns></returns>
         /// <exception cref="InvalidTypeException"></exception>
-        private static (MariaDbBulkCopy BulkCopy, IDataReader Reader) CreateBulkCopyForDataReader(MySqlConnection connection,
+        private static (MariaDbBulkCopy BulkCopy, IDataReader Reader) CreateBulkCopyForDataReader(MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<MariaDbBulkInsertMapItem> mappings,
             int? bulkCopyTimeout,
-            MySqlTransaction transaction,
+            MariaDbTransaction transaction,
             Field excludeField = null)
         {
             var dbSetting = connection.GetDbSetting();
@@ -404,10 +404,10 @@ namespace RepoDb
         /// <param name="transaction"></param>
         /// <param name="excludeField"></param>
         /// <returns></returns>
-        private static IEnumerable<MariaDbBulkInsertMapItem> GetDefaultMappingsForDataReader(MySqlConnection connection,
+        private static IEnumerable<MariaDbBulkInsertMapItem> GetDefaultMappingsForDataReader(MariaDbConnection connection,
             string tableName,
             IDataReader reader,
-            MySqlTransaction transaction,
+            MariaDbTransaction transaction,
             Field excludeField = null)
         {
             var dbFields = DbFieldCache.Get(connection, tableName, transaction);
@@ -460,10 +460,10 @@ namespace RepoDb
         /// <param name="commandTimeout"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static DbCommand CreateTraceCommand(MySqlConnection connection,
+        private static DbCommand CreateTraceCommand(MariaDbConnection connection,
             string commandText,
             int? commandTimeout = null,
-            MySqlTransaction transaction = null) =>
+            MariaDbTransaction transaction = null) =>
             (DbCommand)connection.CreateCommand(commandText, CommandType.Text, commandTimeout, transaction);
 
         #endregion

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Helpers/MariaDbExecution.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Helpers/MariaDbExecution.cs
@@ -5,7 +5,7 @@ using System.Data.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Extensions;
 using RepoDb.Interfaces;
@@ -30,14 +30,14 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="trace"></param>
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
-        public static void CreatePseudoTable(MySqlConnection connection,
+        public static void CreatePseudoTable(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             MariaDbBulkImportPseudoTableType pseudoTableType,
             Field qualifierField = null,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var dbSetting = connection.GetDbSetting();
             var commandText = MariaDbText.GetCreatePseudoTableSql(tableName, pseudoTableName, pseudoTableType, dbSetting, qualifierField);
@@ -57,14 +57,14 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task CreatePseudoTableAsync(MySqlConnection connection,
+        public static async Task CreatePseudoTableAsync(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             MariaDbBulkImportPseudoTableType pseudoTableType,
             Field qualifierField = null,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var dbSetting = connection.GetDbSetting();
@@ -84,12 +84,12 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="trace"></param>
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
-        public static void CreatePseudoTableIndex(MySqlConnection connection,
+        public static void CreatePseudoTableIndex(MariaDbConnection connection,
             string pseudoTableName,
             IEnumerable<Field> qualifiers,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             if (qualifiers?.Any() != true)
             {
@@ -115,12 +115,12 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task CreatePseudoTableIndexAsync(MySqlConnection connection,
+        public static async Task CreatePseudoTableIndexAsync(MariaDbConnection connection,
             string pseudoTableName,
             IEnumerable<Field> qualifiers,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             if (qualifiers?.Any() != true)
@@ -141,11 +141,11 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="trace"></param>
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
-        public static void TruncatePseudoTable(MySqlConnection connection,
+        public static void TruncatePseudoTable(MariaDbConnection connection,
             string pseudoTableName,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var dbSetting = connection.GetDbSetting();
             var commandText = MariaDbText.GetTruncatePseudoTableSql(pseudoTableName, dbSetting);
@@ -162,11 +162,11 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task TruncatePseudoTableAsync(MySqlConnection connection,
+        public static async Task TruncatePseudoTableAsync(MariaDbConnection connection,
             string pseudoTableName,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var dbSetting = connection.GetDbSetting();
@@ -182,11 +182,11 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="trace"></param>
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
-        public static void DropPseudoTable(MySqlConnection connection,
+        public static void DropPseudoTable(MariaDbConnection connection,
             string pseudoTableName,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var dbSetting = connection.GetDbSetting();
             var commandText = MariaDbText.GetDropPseudoTableSql(pseudoTableName, dbSetting);
@@ -203,11 +203,11 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task DropPseudoTableAsync(MySqlConnection connection,
+        public static async Task DropPseudoTableAsync(MariaDbConnection connection,
             string pseudoTableName,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var dbSetting = connection.GetDbSetting();
@@ -228,12 +228,12 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="trace"></param>
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
-        public static void AllowNullForColumn(MySqlConnection connection,
+        public static void AllowNullForColumn(MariaDbConnection connection,
             string pseudoTableName,
             string columnName,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var dbSetting = connection.GetDbSetting();
             var commandText = MariaDbText.GetAllowNullForColumnSql(pseudoTableName, columnName, dbSetting);
@@ -251,12 +251,12 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task AllowNullForColumnAsync(MySqlConnection connection,
+        public static async Task AllowNullForColumnAsync(MariaDbConnection connection,
             string pseudoTableName,
             string columnName,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var dbSetting = connection.GetDbSetting();
@@ -274,12 +274,12 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        private static (string SequenceName, bool IsAlwaysGenerated) GetIdentitySequenceMetadata(MySqlConnection connection,
+        private static (string SequenceName, bool IsAlwaysGenerated) GetIdentitySequenceMetadata(MariaDbConnection connection,
             string tableName,
             Field identityField,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var dbSetting = connection.GetDbSetting();
             var commandText = MariaDbText.GetIdentitySequenceMetadataSql(tableName, identityField, dbSetting);
@@ -300,12 +300,12 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private static async Task<(string SequenceName, bool IsAlwaysGenerated)> GetIdentitySequenceMetadataAsync(MySqlConnection connection,
+        private static async Task<(string SequenceName, bool IsAlwaysGenerated)> GetIdentitySequenceMetadataAsync(MariaDbConnection connection,
             string tableName,
             Field identityField,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var dbSetting = connection.GetDbSetting();
@@ -330,7 +330,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        public static int InsertFromPseudoTableForReturnIdentity<TEntity>(MySqlConnection connection,
+        public static int InsertFromPseudoTableForReturnIdentity<TEntity>(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> fields,
@@ -338,7 +338,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
             IList<TEntity> entities,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
             var dbSetting = connection.GetDbSetting();
@@ -373,7 +373,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task<int> InsertFromPseudoTableForReturnIdentityAsync<TEntity>(MySqlConnection connection,
+        public static async Task<int> InsertFromPseudoTableForReturnIdentityAsync<TEntity>(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> fields,
@@ -381,7 +381,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
             IList<TEntity> entities,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
@@ -415,7 +415,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        public static int InsertFromPseudoTableForReturnIdentityForDataTable(MySqlConnection connection,
+        public static int InsertFromPseudoTableForReturnIdentityForDataTable(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> fields,
@@ -423,7 +423,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
             IList<DataRow> rows,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var dbSetting = connection.GetDbSetting();
             var (sequenceName, isAlwaysGenerated) = GetIdentitySequenceMetadata(connection, tableName, identityField, trace, traceKey, transaction);
@@ -455,7 +455,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task<int> InsertFromPseudoTableForReturnIdentityForDataTableAsync(MySqlConnection connection,
+        public static async Task<int> InsertFromPseudoTableForReturnIdentityForDataTableAsync(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> fields,
@@ -463,7 +463,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
             IList<DataRow> rows,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var dbSetting = connection.GetDbSetting();
@@ -499,7 +499,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        public static int MergeFromPseudoTable(MySqlConnection connection,
+        public static int MergeFromPseudoTable(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> fields,
@@ -507,7 +507,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
             Field identityField,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var dbSetting = connection.GetDbSetting();
             var commandText = MariaDbText.GetMergeFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, identityField, dbSetting);
@@ -528,7 +528,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task<int> MergeFromPseudoTableAsync(MySqlConnection connection,
+        public static async Task<int> MergeFromPseudoTableAsync(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> fields,
@@ -536,7 +536,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
             Field identityField,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var dbSetting = connection.GetDbSetting();
@@ -559,7 +559,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        public static int MergeFromPseudoTableForReturnIdentity<TEntity>(MySqlConnection connection,
+        public static int MergeFromPseudoTableForReturnIdentity<TEntity>(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> fields,
@@ -568,7 +568,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
             IList<TEntity> entities,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
             var dbSetting = connection.GetDbSetting();
@@ -604,7 +604,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task<int> MergeFromPseudoTableForReturnIdentityAsync<TEntity>(MySqlConnection connection,
+        public static async Task<int> MergeFromPseudoTableForReturnIdentityAsync<TEntity>(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> fields,
@@ -613,7 +613,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
             IList<TEntity> entities,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
@@ -648,7 +648,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        public static int MergeFromPseudoTableForReturnIdentityForDataTable(MySqlConnection connection,
+        public static int MergeFromPseudoTableForReturnIdentityForDataTable(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> fields,
@@ -657,7 +657,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
             IList<DataRow> rows,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var dbSetting = connection.GetDbSetting();
             var (sequenceName, isAlwaysGenerated) = GetIdentitySequenceMetadata(connection, tableName, identityField, trace, traceKey, transaction);
@@ -690,7 +690,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task<int> MergeFromPseudoTableForReturnIdentityForDataTableAsync(MySqlConnection connection,
+        public static async Task<int> MergeFromPseudoTableForReturnIdentityForDataTableAsync(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> fields,
@@ -699,7 +699,7 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
             IList<DataRow> rows,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var dbSetting = connection.GetDbSetting();
@@ -734,14 +734,14 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        public static int UpdateFromPseudoTable(MySqlConnection connection,
+        public static int UpdateFromPseudoTable(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> fields,
             IEnumerable<Field> qualifiers,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var dbSetting = connection.GetDbSetting();
             var commandText = MariaDbText.GetUpdateFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, dbSetting);
@@ -761,14 +761,14 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task<int> UpdateFromPseudoTableAsync(MySqlConnection connection,
+        public static async Task<int> UpdateFromPseudoTableAsync(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> fields,
             IEnumerable<Field> qualifiers,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var dbSetting = connection.GetDbSetting();
@@ -791,13 +791,13 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
         /// <returns></returns>
-        public static int DeleteFromPseudoTable(MySqlConnection connection,
+        public static int DeleteFromPseudoTable(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> qualifiers,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
             var dbSetting = connection.GetDbSetting();
             var commandText = MariaDbText.GetDeleteFromPseudoTableSql(tableName, pseudoTableName, qualifiers, dbSetting);
@@ -816,13 +816,13 @@ namespace RepoDb.MariaDb.BulkOperations.Extensions
         /// <param name="transaction"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static async Task<int> DeleteFromPseudoTableAsync(MySqlConnection connection,
+        public static async Task<int> DeleteFromPseudoTableAsync(MariaDbConnection connection,
             string tableName,
             string pseudoTableName,
             IEnumerable<Field> qualifiers,
             ITrace trace = null,
             string traceKey = null,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
             var dbSetting = connection.GetDbSetting();

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/MariaDbBulkCopy.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/MariaDbBulkCopy.cs
@@ -6,22 +6,23 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
+using RepoDb.Connector.MariaDb.Bulk;
 
 namespace RepoDb.MariaDb.BulkOperations
 {
     /// <summary>
-    /// An official Bulk loader class used by RepoDB for its bulk operations. It is built on top of <c>MySql.Data</c>'s <see cref="MySqlBulkLoader"/>.
+    /// An official Bulk loader class used by RepoDB for its bulk operations. It is built on top of <c>RepoDb.Connector.MariaDb</c>'s <see cref="MariaDbBulkLoader"/>.
     /// </summary>
     internal sealed class MariaDbBulkCopy
     {
-        private readonly MySqlConnection connection;
+        private readonly MariaDbConnection connection;
 
         /// <summary>
         /// Creates a new instance of <see cref="MariaDbBulkCopy"/> bound to <paramref name="connection"/>.
         /// </summary>
-        /// <param name="connection">The connection <see cref="MySqlBulkLoader"/> will load through.</param>
-        public MariaDbBulkCopy(MySqlConnection connection)
+        /// <param name="connection">The connection <see cref="MariaDbBulkLoader"/> will load through.</param>
+        public MariaDbBulkCopy(MariaDbConnection connection)
         {
             this.connection = connection;
         }
@@ -29,18 +30,18 @@ namespace RepoDb.MariaDb.BulkOperations
         /// <summary>
         /// Gets or sets the destination table name. Expected to already be correctly quoted by the caller
         /// (every call site in <c>WriteToServer.cs</c> sets this from <c>tableName.AsQuoted(true, dbSetting)</c>)
-        /// - passed straight through to <see cref="MySqlBulkLoader.TableName"/> unmodified.
+        /// - passed straight through to <see cref="MariaDbBulkLoader.TableName"/> unmodified.
         /// </summary>
         public string DestinationTableName { get; set; }
 
         /// <summary>
-        /// Gets or sets the bulk-load timeout, in seconds. Mapped directly to <see cref="MySqlBulkLoader.Timeout"/>.
+        /// Gets or sets the bulk-load timeout, in seconds. Mapped directly to <see cref="MariaDbBulkLoader.Timeout"/>.
         /// </summary>
         public int BulkCopyTimeout { get; set; } = 30;
 
         /// <summary>
         /// Gets the source-ordinal-to-destination-column mappings that determine both which columns get
-        /// written and the column order of the temp file built for <see cref="MySqlBulkLoader"/>.
+        /// written and the column order of the temp file built for <see cref="MariaDbBulkLoader"/>.
         /// </summary>
         public List<MariaDbBulkCopyColumnMapping> ColumnMappings { get; } = new();
 
@@ -66,7 +67,7 @@ namespace RepoDb.MariaDb.BulkOperations
         /// The source reader. Read positionally via each mapping's <see cref="MariaDbBulkCopyColumnMapping.SourceOrdinal"/> -
         /// see the remarks on <see cref="MariaDbBulkCopy"/> for why no other ordinal of this reader is ever touched.
         /// </param>
-        /// <returns>The number of rows <see cref="MySqlBulkLoader"/> reports having loaded.</returns>
+        /// <returns>The number of rows <see cref="MariaDbBulkLoader"/> reports having loaded.</returns>
         public int WriteToServer(IDataReader reader) =>
             WriteToServerAsync(reader, CancellationToken.None).GetAwaiter().GetResult();
 
@@ -100,7 +101,7 @@ namespace RepoDb.MariaDb.BulkOperations
         /// </summary>
         /// <param name="rows">The source rows, read positionally via each mapping's <see cref="MariaDbBulkCopyColumnMapping.SourceOrdinal"/> - i.e. the real <see cref="DataTable"/> column index, not the mapping's position in <see cref="ColumnMappings"/> (those can legitimately diverge - see <c>WriteToServer.cs</c>'s remarks on why the ordinal must come from <c>DataTable.Columns.IndexOf</c>).</param>
         /// <param name="columnCount">Unused beyond a defensive bounds check - <see cref="ColumnMappings"/> alone already determines exactly which columns get written.</param>
-        /// <returns>The number of rows <see cref="MySqlBulkLoader"/> reports having loaded.</returns>
+        /// <returns>The number of rows <see cref="MariaDbBulkLoader"/> reports having loaded.</returns>
         public int WriteToServer(DataRow[] rows,
             int columnCount) =>
             WriteToServerAsync(rows, columnCount, CancellationToken.None).GetAwaiter().GetResult();
@@ -215,13 +216,13 @@ namespace RepoDb.MariaDb.BulkOperations
         }
 
         /// <summary>
-        /// Runs the configured <see cref="MySqlBulkLoader"/> against the temp file built by <see cref="WriteRow"/>, back-tick-quoting each mapped destination column along the way - the
+        /// Runs the configured <see cref="MariaDbBulkLoader"/> against the temp file built by <see cref="WriteRow"/>, back-tick-quoting each mapped destination column along the way - the
         /// counterpart to <see cref="DestinationTableName"/> already arriving pre-quoted (see its remarks).
         /// </summary>
         private async Task<int> LoadAsync(string filePath,
             CancellationToken cancellationToken)
         {
-            var bulkLoader = new MySqlBulkLoader(connection)
+            var bulkLoader = new MariaDbBulkLoader(connection)
             {
                 TableName = DestinationTableName,
                 FileName = filePath,

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/MariaDbBulkInsertMapItem.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/MariaDbBulkInsertMapItem.cs
@@ -1,5 +1,5 @@
 using System;
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 
 namespace RepoDb.MariaDb.BulkOperations
 {
@@ -25,17 +25,17 @@ namespace RepoDb.MariaDb.BulkOperations
         /// </summary>
         /// <param name="sourceColumn">The name of the source column or property. This respects the mapping of the properties if the source type is an entity model.</param>
         /// <param name="destinationColumn">The name of the destination column in the database.</param>
-        /// <param name="mySqlDbType">
-        /// The explicit <see cref="MariaDb.MySqlDbType"/> value to bind with for this column. When not
-        /// provided, the type is inferred from the entity property's <c>[MySqlDbType]</c>/<c>[MySqlDbTypeEx]</c> attribute
+        /// <param name="mariaDbType">
+        /// The explicit <see cref="RepoDb.Connector.MariaDb.MariaDbType"/> value to bind with for this column. When not
+        /// provided, the type is inferred from the entity property's <c>[MariaDbType]</c> attribute
         /// (if present) or, failing that, from the .NET CLR value itself.
         /// </param>
         public MariaDbBulkInsertMapItem(string sourceColumn,
             string destinationColumn,
-            MySqlDbType? mySqlDbType) :
+            MariaDbType? mariaDbType) :
             base(sourceColumn, destinationColumn)
         {
-            MySqlDbType = mySqlDbType;
+            MariaDbType = mariaDbType;
         }
 
         #endregion
@@ -43,9 +43,9 @@ namespace RepoDb.MariaDb.BulkOperations
         #region Properties
 
         /// <summary>
-        /// Gets the explicit <see cref="MariaDb.ManagedDataAccess.Client.MySqlDbType"/> value to be used when writing.
+        /// Gets the explicit <see cref="RepoDb.Connector.MariaDb.MariaDbType"/> value to be used when writing.
         /// </summary>
-        public MySqlDbType? MySqlDbType { get; }
+        public MariaDbType? MariaDbType { get; }
 
         #endregion
 
@@ -56,7 +56,7 @@ namespace RepoDb.MariaDb.BulkOperations
         /// </summary>
         /// <returns>The string representation of the current object.</returns>
         public override string ToString() =>
-            $"{base.ToString()} ({MySqlDbType})";
+            $"{base.ToString()} ({MariaDbType})";
 
         #endregion
 
@@ -76,7 +76,7 @@ namespace RepoDb.MariaDb.BulkOperations
             }
 
             var hashCode = base.GetHashCode();
-            hashCode = HashCode.Combine(hashCode, MySqlDbType);
+            hashCode = HashCode.Combine(hashCode, MariaDbType);
 
             return (this.hashCode = hashCode).Value;
         }

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/BaseRepository/BulkDelete.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/BaseRepository/BulkDelete.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -14,10 +14,10 @@ namespace RepoDb
     /// Entity-typed <see cref="BaseRepository{TEntity, TDbConnection}"/> wrappers for the MariaDb bulk-delete
     /// operation. Each method is a thin pass-through onto <see cref="DbRepository{TDbConnection}"/>'s own
     /// wrapper (see <c>Operations/DbRepository/BulkDelete.cs</c>), which in turn calls the
-    /// <see cref="MySqlConnection"/> extension methods - matching the three-tier pattern used throughout
+    /// <see cref="MariaDbConnection"/> extension methods - matching the three-tier pattern used throughout
     /// the rest of RepoDB. DataTable and <c>DbDataReader</c>-based overloads are deliberately not duplicated
     /// at this tier or the <see cref="DbRepository{TDbConnection}"/> tier - they aren't tied to a single
-    /// entity type, so those calls read more naturally straight off <see cref="MySqlConnection"/>.
+    /// entity type, so those calls read more naturally straight off <see cref="MariaDbConnection"/>.
     /// </summary>
     public static partial class BaseRepositoryExtension
     {
@@ -38,7 +38,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static int BulkDelete<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static int BulkDelete<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             int? bulkCopyTimeout = null,
@@ -46,7 +46,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             repository.DbRepository.BulkDelete(ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
@@ -66,7 +66,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static int BulkDelete<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static int BulkDelete<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
@@ -75,7 +75,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             repository.DbRepository.BulkDelete(tableName ?? ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
@@ -99,7 +99,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static Task<int> BulkDeleteAsync<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static Task<int> BulkDeleteAsync<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             int? bulkCopyTimeout = null,
@@ -107,7 +107,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             repository.DbRepository.BulkDeleteAsync(ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
@@ -129,7 +129,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static Task<int> BulkDeleteAsync<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static Task<int> BulkDeleteAsync<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
@@ -138,7 +138,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             repository.DbRepository.BulkDeleteAsync(tableName ?? ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/BaseRepository/BulkDeleteByKey.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/BaseRepository/BulkDeleteByKey.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -13,7 +13,7 @@ namespace RepoDb
     /// bulk-delete-by-key operation. This method is a thin pass-through onto
     /// <see cref="DbRepository{TDbConnection}"/>'s own wrapper (see
     /// <c>Operations/DbRepository/BulkDeleteByKey.cs</c>), which in turn calls the
-    /// <see cref="MySqlConnection"/> extension method - matching the three-tier pattern used throughout
+    /// <see cref="MariaDbConnection"/> extension method - matching the three-tier pattern used throughout
     /// the rest of RepoDB.
     /// </summary>
     public static partial class BaseRepositoryExtension
@@ -36,7 +36,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static int BulkDeleteByKey<TEntity, TPrimaryKey>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static int BulkDeleteByKey<TEntity, TPrimaryKey>(this BaseRepository<TEntity, MariaDbConnection> repository,
             string tableName,
             IEnumerable<TPrimaryKey> primaryKeys,
             int? bulkCopyTimeout = null,
@@ -44,7 +44,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDeleteByKey,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             repository.DbRepository.BulkDeleteByKey(tableName, primaryKeys, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
@@ -69,7 +69,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static Task<int> BulkDeleteByKeyAsync<TEntity, TPrimaryKey>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static Task<int> BulkDeleteByKeyAsync<TEntity, TPrimaryKey>(this BaseRepository<TEntity, MariaDbConnection> repository,
             string tableName,
             IEnumerable<TPrimaryKey> primaryKeys,
             int? bulkCopyTimeout = null,
@@ -77,7 +77,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDeleteByKey,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             repository.DbRepository.BulkDeleteByKeyAsync(tableName, primaryKeys, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/BaseRepository/BulkInsert.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/BaseRepository/BulkInsert.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -12,10 +12,10 @@ namespace RepoDb
     /// Entity-typed <see cref="BaseRepository{TEntity, TDbConnection}"/> wrappers for the MariaDb bulk-insert
     /// operation. Each method is a thin pass-through onto <see cref="DbRepository{TDbConnection}"/>'s own
     /// wrapper (see <c>Operations/DbRepository/BulkInsert.cs</c>), which in turn calls the
-    /// <see cref="MySqlConnection"/> extension methods - matching the three-tier pattern used throughout
+    /// <see cref="MariaDbConnection"/> extension methods - matching the three-tier pattern used throughout
     /// the rest of RepoDB. DataTable and <c>DbDataReader</c>-based overloads are deliberately not duplicated
     /// at this tier or the <see cref="DbRepository{TDbConnection}"/> tier - they aren't tied to a single
-    /// entity type, so those calls read more naturally straight off <see cref="MySqlConnection"/>.
+    /// entity type, so those calls read more naturally straight off <see cref="MariaDbConnection"/>.
     /// </summary>
     public static partial class BaseRepositoryExtension
     {
@@ -36,7 +36,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static int BulkInsert<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static int BulkInsert<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
@@ -45,7 +45,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             repository.DbRepository.BulkInsert(ClassMappedNameCache.Get<TEntity>(), entities, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
@@ -65,7 +65,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static int BulkInsert<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static int BulkInsert<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -75,7 +75,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             repository.DbRepository.BulkInsert(tableName ?? ClassMappedNameCache.Get<TEntity>(), entities, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
@@ -100,7 +100,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static Task<int> BulkInsertAsync<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static Task<int> BulkInsertAsync<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
@@ -109,7 +109,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             repository.DbRepository.BulkInsertAsync(ClassMappedNameCache.Get<TEntity>(), entities, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);
@@ -132,7 +132,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static Task<int> BulkInsertAsync<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static Task<int> BulkInsertAsync<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -142,7 +142,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             repository.DbRepository.BulkInsertAsync(tableName ?? ClassMappedNameCache.Get<TEntity>(), entities, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/BaseRepository/BulkMerge.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/BaseRepository/BulkMerge.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -14,10 +14,10 @@ namespace RepoDb
     /// Entity-typed <see cref="BaseRepository{TEntity, TDbConnection}"/> wrappers for the MariaDb bulk-merge
     /// operation. Each method is a thin pass-through onto <see cref="DbRepository{TDbConnection}"/>'s own
     /// wrapper (see <c>Operations/DbRepository/BulkMerge.cs</c>), which in turn calls the
-    /// <see cref="MySqlConnection"/> extension methods - matching the three-tier pattern used throughout
+    /// <see cref="MariaDbConnection"/> extension methods - matching the three-tier pattern used throughout
     /// the rest of RepoDB. DataTable and <c>DbDataReader</c>-based overloads are deliberately not duplicated
     /// at this tier or the <see cref="DbRepository{TDbConnection}"/> tier - they aren't tied to a single
-    /// entity type, so those calls read more naturally straight off <see cref="MySqlConnection"/>.
+    /// entity type, so those calls read more naturally straight off <see cref="MariaDbConnection"/>.
     /// </summary>
     public static partial class BaseRepositoryExtension
     {
@@ -41,7 +41,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of affected rows.</returns>
-        public static int BulkMerge<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static int BulkMerge<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -51,7 +51,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             repository.DbRepository.BulkMerge(ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
@@ -74,7 +74,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of affected rows.</returns>
-        public static int BulkMerge<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static int BulkMerge<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
@@ -85,7 +85,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             repository.DbRepository.BulkMerge(tableName ?? ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
@@ -112,7 +112,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of affected rows.</returns>
-        public static Task<int> BulkMergeAsync<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static Task<int> BulkMergeAsync<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -122,7 +122,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             repository.DbRepository.BulkMergeAsync(ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);
@@ -147,7 +147,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of affected rows.</returns>
-        public static Task<int> BulkMergeAsync<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static Task<int> BulkMergeAsync<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
@@ -158,7 +158,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             repository.DbRepository.BulkMergeAsync(tableName ?? ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/BaseRepository/BulkUpdate.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/BaseRepository/BulkUpdate.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -14,10 +14,10 @@ namespace RepoDb
     /// Entity-typed <see cref="BaseRepository{TEntity, TDbConnection}"/> wrappers for the MariaDb bulk-update
     /// operation. Each method is a thin pass-through onto <see cref="DbRepository{TDbConnection}"/>'s own
     /// wrapper (see <c>Operations/DbRepository/BulkUpdate.cs</c>), which in turn calls the
-    /// <see cref="MySqlConnection"/> extension methods - matching the three-tier pattern used throughout
+    /// <see cref="MariaDbConnection"/> extension methods - matching the three-tier pattern used throughout
     /// the rest of RepoDB. DataTable and <c>DbDataReader</c>-based overloads are deliberately not duplicated
     /// at this tier or the <see cref="DbRepository{TDbConnection}"/> tier - they aren't tied to a single
-    /// entity type, so those calls read more naturally straight off <see cref="MySqlConnection"/>.
+    /// entity type, so those calls read more naturally straight off <see cref="MariaDbConnection"/>.
     /// </summary>
     public static partial class BaseRepositoryExtension
     {
@@ -39,7 +39,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of updated rows.</returns>
-        public static int BulkUpdate<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static int BulkUpdate<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -48,7 +48,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             repository.DbRepository.BulkUpdate(ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
@@ -69,7 +69,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of updated rows.</returns>
-        public static int BulkUpdate<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static int BulkUpdate<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
@@ -79,7 +79,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             repository.DbRepository.BulkUpdate(tableName ?? ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
@@ -104,7 +104,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of updated rows.</returns>
-        public static Task<int> BulkUpdateAsync<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static Task<int> BulkUpdateAsync<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -113,7 +113,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             repository.DbRepository.BulkUpdateAsync(ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
@@ -136,7 +136,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of updated rows.</returns>
-        public static Task<int> BulkUpdateAsync<TEntity>(this BaseRepository<TEntity, MySqlConnection> repository,
+        public static Task<int> BulkUpdateAsync<TEntity>(this BaseRepository<TEntity, MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
@@ -146,7 +146,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             repository.DbRepository.BulkUpdateAsync(tableName ?? ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/DbRepository/BulkDelete.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/DbRepository/BulkDelete.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
@@ -14,7 +14,7 @@ namespace RepoDb
     /// <summary>
     /// <see cref="DbRepository{TDbConnection}"/> wrappers for the MariaDb bulk-delete operation. Each method
     /// resolves a connection (reusing the transaction's connection when one is supplied, otherwise creating
-    /// one via the repository), delegates to the matching <see cref="MySqlConnection"/> extension method,
+    /// one via the repository), delegates to the matching <see cref="MariaDbConnection"/> extension method,
     /// and disposes the connection afterwards only when the repository owns a per-call connection and no
     /// external transaction was supplied - the same lifecycle every other RepoDB provider's DbRepository
     /// bulk wrapper already follows.
@@ -38,7 +38,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static int BulkDelete<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static int BulkDelete<TEntity>(this DbRepository<MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             int? bulkCopyTimeout = null,
@@ -46,7 +46,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             repository.BulkDelete(ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
@@ -66,7 +66,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static int BulkDelete<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static int BulkDelete<TEntity>(this DbRepository<MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
@@ -75,10 +75,10 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
-            var connection = transaction?.Connection ?? repository.CreateConnection();
+            var connection = (MariaDbConnection)transaction?.Connection ?? repository.CreateConnection();
 
             try
             {
@@ -110,7 +110,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static async Task<int> BulkDeleteAsync<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static async Task<int> BulkDeleteAsync<TEntity>(this DbRepository<MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             int? bulkCopyTimeout = null,
@@ -118,7 +118,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             await repository.BulkDeleteAsync(ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
@@ -140,7 +140,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static async Task<int> BulkDeleteAsync<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static async Task<int> BulkDeleteAsync<TEntity>(this DbRepository<MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
@@ -149,11 +149,11 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
-            var connection = transaction?.Connection ?? repository.CreateConnection();
+            var connection = (MariaDbConnection)transaction?.Connection ?? repository.CreateConnection();
 
             try
             {
@@ -169,9 +169,9 @@ namespace RepoDb
 
         #region Helpers
 
-        private static void DisposeIfOwned(DbRepository<MySqlConnection> repository,
-            MySqlTransaction transaction,
-            MySqlConnection connection)
+        private static void DisposeIfOwned(DbRepository<MariaDbConnection> repository,
+            MariaDbTransaction transaction,
+            MariaDbConnection connection)
         {
             if (repository.ConnectionPersistency == ConnectionPersistency.PerCall && transaction == null)
             {

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/DbRepository/BulkDeleteByKey.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/DbRepository/BulkDeleteByKey.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -11,7 +11,7 @@ namespace RepoDb
     /// <summary>
     /// <see cref="DbRepository{TDbConnection}"/> wrapper for the MariaDb bulk-delete-by-key operation. The
     /// method resolves a connection (reusing the transaction's connection when one is supplied, otherwise
-    /// creating one via the repository), delegates to the matching <see cref="MySqlConnection"/> extension
+    /// creating one via the repository), delegates to the matching <see cref="MariaDbConnection"/> extension
     /// method, and disposes the connection afterwards only when the repository owns a per-call connection
     /// and no external transaction was supplied - the same lifecycle every other RepoDB provider's
     /// DbRepository bulk wrapper already follows.
@@ -35,7 +35,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static int BulkDeleteByKey<TPrimaryKey>(this DbRepository<MySqlConnection> repository,
+        public static int BulkDeleteByKey<TPrimaryKey>(this DbRepository<MariaDbConnection> repository,
             string tableName,
             IEnumerable<TPrimaryKey> primaryKeys,
             int? bulkCopyTimeout = null,
@@ -43,9 +43,9 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDeleteByKey,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
         {
-            var connection = transaction?.Connection ?? repository.CreateConnection();
+            var connection = (MariaDbConnection)transaction?.Connection ?? repository.CreateConnection();
 
             try
             {
@@ -77,7 +77,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static async Task<int> BulkDeleteByKeyAsync<TPrimaryKey>(this DbRepository<MySqlConnection> repository,
+        public static async Task<int> BulkDeleteByKeyAsync<TPrimaryKey>(this DbRepository<MariaDbConnection> repository,
             string tableName,
             IEnumerable<TPrimaryKey> primaryKeys,
             int? bulkCopyTimeout = null,
@@ -85,10 +85,10 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDeleteByKey,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
-            var connection = transaction?.Connection ?? repository.CreateConnection();
+            var connection = (MariaDbConnection)transaction?.Connection ?? repository.CreateConnection();
 
             try
             {

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/DbRepository/BulkInsert.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/DbRepository/BulkInsert.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -11,7 +11,7 @@ namespace RepoDb
     /// <summary>
     /// <see cref="DbRepository{TDbConnection}"/> wrappers for the MariaDb bulk-insert operation. Each method
     /// resolves a connection (reusing the transaction's connection when one is supplied, otherwise creating
-    /// one via the repository), delegates to the matching <see cref="MySqlConnection"/> extension method,
+    /// one via the repository), delegates to the matching <see cref="MariaDbConnection"/> extension method,
     /// and disposes the connection afterwards only when the repository owns a per-call connection and no
     /// external transaction was supplied - the same lifecycle every other RepoDB provider's DbRepository
     /// bulk wrapper already follows.
@@ -35,7 +35,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static int BulkInsert<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static int BulkInsert<TEntity>(this DbRepository<MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
@@ -44,7 +44,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             repository.BulkInsert(ClassMappedNameCache.Get<TEntity>(), entities, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
@@ -64,7 +64,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static int BulkInsert<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static int BulkInsert<TEntity>(this DbRepository<MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -74,10 +74,10 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
-            var connection = transaction?.Connection ?? repository.CreateConnection();
+            var connection = (MariaDbConnection)transaction?.Connection ?? repository.CreateConnection();
 
             try
             {
@@ -110,7 +110,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static async Task<int> BulkInsertAsync<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static async Task<int> BulkInsertAsync<TEntity>(this DbRepository<MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
@@ -119,7 +119,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             await repository.BulkInsertAsync(ClassMappedNameCache.Get<TEntity>(), entities, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);
@@ -142,7 +142,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static async Task<int> BulkInsertAsync<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static async Task<int> BulkInsertAsync<TEntity>(this DbRepository<MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -152,11 +152,11 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
-            var connection = transaction?.Connection ?? repository.CreateConnection();
+            var connection = (MariaDbConnection)transaction?.Connection ?? repository.CreateConnection();
 
             try
             {

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/DbRepository/BulkMerge.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/DbRepository/BulkMerge.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -13,7 +13,7 @@ namespace RepoDb
     /// <summary>
     /// <see cref="DbRepository{TDbConnection}"/> wrappers for the MariaDb bulk-merge operation. Each method
     /// resolves a connection (reusing the transaction's connection when one is supplied, otherwise creating
-    /// one via the repository), delegates to the matching <see cref="MySqlConnection"/> extension method,
+    /// one via the repository), delegates to the matching <see cref="MariaDbConnection"/> extension method,
     /// and disposes the connection afterwards only when the repository owns a per-call connection and no
     /// external transaction was supplied - the same lifecycle every other RepoDB provider's DbRepository
     /// bulk wrapper already follows.
@@ -40,7 +40,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of affected rows.</returns>
-        public static int BulkMerge<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static int BulkMerge<TEntity>(this DbRepository<MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -50,7 +50,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             repository.BulkMerge(ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
@@ -73,7 +73,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of affected rows.</returns>
-        public static int BulkMerge<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static int BulkMerge<TEntity>(this DbRepository<MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
@@ -84,10 +84,10 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
-            var connection = transaction?.Connection ?? repository.CreateConnection();
+            var connection = (MariaDbConnection)transaction?.Connection ?? repository.CreateConnection();
 
             try
             {
@@ -122,7 +122,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of affected rows.</returns>
-        public static async Task<int> BulkMergeAsync<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static async Task<int> BulkMergeAsync<TEntity>(this DbRepository<MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -132,7 +132,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             await repository.BulkMergeAsync(ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);
@@ -157,7 +157,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of affected rows.</returns>
-        public static async Task<int> BulkMergeAsync<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static async Task<int> BulkMergeAsync<TEntity>(this DbRepository<MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
@@ -168,11 +168,11 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
-            var connection = transaction?.Connection ?? repository.CreateConnection();
+            var connection = (MariaDbConnection)transaction?.Connection ?? repository.CreateConnection();
 
             try
             {

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/DbRepository/BulkUpdate.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/DbRepository/BulkUpdate.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -13,7 +13,7 @@ namespace RepoDb
     /// <summary>
     /// <see cref="DbRepository{TDbConnection}"/> wrappers for the MariaDb bulk-update operation. Each method
     /// resolves a connection (reusing the transaction's connection when one is supplied, otherwise creating
-    /// one via the repository), delegates to the matching <see cref="MySqlConnection"/> extension method,
+    /// one via the repository), delegates to the matching <see cref="MariaDbConnection"/> extension method,
     /// and disposes the connection afterwards only when the repository owns a per-call connection and no
     /// external transaction was supplied - the same lifecycle every other RepoDB provider's DbRepository
     /// bulk wrapper already follows.
@@ -38,7 +38,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of updated rows.</returns>
-        public static int BulkUpdate<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static int BulkUpdate<TEntity>(this DbRepository<MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -47,7 +47,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             repository.BulkUpdate(ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
@@ -68,7 +68,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of updated rows.</returns>
-        public static int BulkUpdate<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static int BulkUpdate<TEntity>(this DbRepository<MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
@@ -78,10 +78,10 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class
         {
-            var connection = transaction?.Connection ?? repository.CreateConnection();
+            var connection = (MariaDbConnection)transaction?.Connection ?? repository.CreateConnection();
 
             try
             {
@@ -114,7 +114,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of updated rows.</returns>
-        public static async Task<int> BulkUpdateAsync<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static async Task<int> BulkUpdateAsync<TEntity>(this DbRepository<MariaDbConnection> repository,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -123,7 +123,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             await repository.BulkUpdateAsync(ClassMappedNameCache.Get<TEntity>(), entities, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
@@ -146,7 +146,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of updated rows.</returns>
-        public static async Task<int> BulkUpdateAsync<TEntity>(this DbRepository<MySqlConnection> repository,
+        public static async Task<int> BulkUpdateAsync<TEntity>(this DbRepository<MariaDbConnection> repository,
             string tableName,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
@@ -156,11 +156,11 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
-            var connection = transaction?.Connection ?? repository.CreateConnection();
+            var connection = (MariaDbConnection)transaction?.Connection ?? repository.CreateConnection();
 
             try
             {

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/MariaDbConnection/BulkDelete.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/MariaDbConnection/BulkDelete.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -17,170 +17,159 @@ namespace RepoDb
         #region Sync
 
         /// <summary>
-        /// Updates existing rows in the database in bulk, matched by the defined qualifiers (defaults to
-        /// the primary key). Returns the number of updated rows.
+        /// Deletes existing rows from the database in bulk, matched by the defined qualifiers (defaults
+        /// to the primary key). Returns the number of deleted rows.
         /// </summary>
         /// <typeparam name="TEntity">The type of the data entity.</typeparam>
         /// <param name="connection">The connection object to be used.</param>
-        /// <param name="entities">The list of entities to be bulk-updated.</param>
+        /// <param name="entities">The list of entities to be bulk-deleted.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
-        /// <param name="mappings">The explicit mapping of the source properties/columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
         /// <param name="trace">The trace object to be used.</param>
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
-        /// <returns>The number of updated rows.</returns>
-        public static int BulkUpdate<TEntity>(this MySqlConnection connection,
+        /// <returns>The number of deleted rows.</returns>
+        public static int BulkDelete<TEntity>(this MariaDbConnection connection,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
-            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null)
+            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
-            BulkUpdateBase(connection, ClassMappedNameCache.Get<TEntity>(), entities, ParseQualifiers(qualifiers), mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
+            BulkDeleteBase(connection, ClassMappedNameCache.Get<TEntity>(), entities, ParseQualifiers(qualifiers), bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
         /// <summary>
-        /// Updates existing rows in the database in bulk, matched by the defined qualifiers (defaults to
-        /// the primary key). Returns the number of updated rows.
+        /// Deletes existing rows from the database in bulk, matched by the defined qualifiers (defaults
+        /// to the primary key). Returns the number of deleted rows.
         /// </summary>
         /// <typeparam name="TEntity">The type of the data entity.</typeparam>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="tableName">The name of the target table.</param>
-        /// <param name="entities">The list of entities to be bulk-updated.</param>
+        /// <param name="entities">The list of entities to be bulk-deleted.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
-        /// <param name="mappings">The explicit mapping of the source properties/columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
         /// <param name="trace">The trace object to be used.</param>
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
-        /// <returns>The number of updated rows.</returns>
-        public static int BulkUpdate<TEntity>(this MySqlConnection connection,
+        /// <returns>The number of deleted rows.</returns>
+        public static int BulkDelete<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
-            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null)
+            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
-            BulkUpdateBase(connection, tableName, entities, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
+            BulkDeleteBase(connection, tableName, entities, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
         /// <summary>
-        /// Updates the rows of the target table in bulk from a <see cref="DataTable"/>. Uses the
-        /// <see cref="DataTable.TableName"/> property as the target table. Returns the number of updated
+        /// Deletes rows from the target table in bulk, matched against a <see cref="DataTable"/>. Uses the
+        /// <see cref="DataTable.TableName"/> property as the target table. Returns the number of deleted
         /// rows.
         /// </summary>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="table">The source <see cref="DataTable"/>.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
         /// <param name="rowState">The state of the rows to be included; when null, every row is included.</param>
-        /// <param name="mappings">The explicit mapping of the source columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
         /// <param name="trace">The trace object to be used.</param>
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
-        /// <returns>The number of updated rows.</returns>
-        public static int BulkUpdate(this MySqlConnection connection,
+        /// <returns>The number of deleted rows.</returns>
+        public static int BulkDelete(this MariaDbConnection connection,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
             DataRowState? rowState = null,
-            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null) =>
-            BulkUpdate(connection, table?.TableName, table, qualifiers, rowState, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
+            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
+            MariaDbTransaction transaction = null) =>
+            BulkDelete(connection, table?.TableName, table, qualifiers, rowState, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
         /// <summary>
-        /// Updates the rows of the target table in bulk from a <see cref="DataTable"/>. Returns the
-        /// number of updated rows.
+        /// Deletes rows from the target table in bulk, matched against a <see cref="DataTable"/>. Returns
+        /// the number of deleted rows.
         /// </summary>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="tableName">The name of the target table.</param>
         /// <param name="table">The source <see cref="DataTable"/>.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
         /// <param name="rowState">The state of the rows to be included; when null, every row is included.</param>
-        /// <param name="mappings">The explicit mapping of the source columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
         /// <param name="trace">The trace object to be used.</param>
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
-        /// <returns>The number of updated rows.</returns>
-        public static int BulkUpdate(this MySqlConnection connection,
+        /// <returns>The number of deleted rows.</returns>
+        public static int BulkDelete(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
             DataRowState? rowState = null,
-            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null) =>
-            BulkUpdateBase(connection, tableName, table, qualifiers, rowState, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
+            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
+            MariaDbTransaction transaction = null) =>
+            BulkDeleteBase(connection, tableName, table, qualifiers, rowState, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
         /// <summary>
-        /// Updates existing rows in the database in bulk by streaming a <see cref="DbDataReader"/> to a
+        /// Deletes rows from the target table in bulk by streaming a <see cref="DbDataReader"/> to a
         /// staging table as rows are read from the source rather than materializing them into memory first,
-        /// matched by the defined qualifiers (defaults to the primary key). Returns the number of updated
+        /// matched by the defined qualifiers (defaults to the primary key). Returns the number of deleted
         /// rows.
         /// </summary>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="tableName">The name of the target table.</param>
         /// <param name="reader">The source <see cref="DbDataReader"/> to stream from.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
-        /// <param name="mappings">The explicit mapping of the source columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
         /// <param name="trace">The trace object to be used.</param>
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
-        /// <returns>The number of updated rows.</returns>
-        public static int BulkUpdate(this MySqlConnection connection,
+        /// <returns>The number of deleted rows.</returns>
+        public static int BulkDelete(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<Field> qualifiers = null,
-            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null) =>
-            BulkUpdateBase(connection, tableName, reader, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
+            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
+            MariaDbTransaction transaction = null) =>
+            BulkDeleteBase(connection, tableName, reader, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
         #endregion
 
         #region Async
 
         /// <summary>
-        /// Updates existing rows in the database in bulk in an asynchronous way, matched by the defined
-        /// qualifiers (defaults to the primary key). Returns the number of updated rows.
+        /// Deletes existing rows from the database in bulk in an asynchronous way, matched by the defined
+        /// qualifiers (defaults to the primary key). Returns the number of deleted rows.
         /// </summary>
         /// <typeparam name="TEntity">The type of the data entity.</typeparam>
         /// <param name="connection">The connection object to be used.</param>
-        /// <param name="entities">The list of entities to be bulk-updated.</param>
+        /// <param name="entities">The list of entities to be bulk-deleted.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
-        /// <param name="mappings">The explicit mapping of the source properties/columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
@@ -188,31 +177,29 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
-        /// <returns>The number of updated rows.</returns>
-        public static Task<int> BulkUpdateAsync<TEntity>(this MySqlConnection connection,
+        /// <returns>The number of deleted rows.</returns>
+        public static Task<int> BulkDeleteAsync<TEntity>(this MariaDbConnection connection,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
-            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null,
+            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
-            BulkUpdateBaseAsync(connection, ClassMappedNameCache.Get<TEntity>(), entities, ParseQualifiers(qualifiers), mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
+            BulkDeleteBaseAsync(connection, ClassMappedNameCache.Get<TEntity>(), entities, ParseQualifiers(qualifiers), bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
         /// <summary>
-        /// Updates existing rows in the database in bulk in an asynchronous way, matched by the defined
-        /// qualifiers (defaults to the primary key). Returns the number of updated rows.
+        /// Deletes existing rows from the database in bulk in an asynchronous way, matched by the defined
+        /// qualifiers (defaults to the primary key). Returns the number of deleted rows.
         /// </summary>
         /// <typeparam name="TEntity">The type of the data entity.</typeparam>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="tableName">The name of the target table.</param>
-        /// <param name="entities">The list of entities to be bulk-updated.</param>
+        /// <param name="entities">The list of entities to be bulk-deleted.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
-        /// <param name="mappings">The explicit mapping of the source properties/columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
@@ -220,32 +207,30 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
-        /// <returns>The number of updated rows.</returns>
-        public static Task<int> BulkUpdateAsync<TEntity>(this MySqlConnection connection,
+        /// <returns>The number of deleted rows.</returns>
+        public static Task<int> BulkDeleteAsync<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
-            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null,
+            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
-            BulkUpdateBaseAsync(connection, tableName, entities, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
+            BulkDeleteBaseAsync(connection, tableName, entities, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
         /// <summary>
-        /// Updates the rows of the target table in bulk from a <see cref="DataTable"/> in an asynchronous
-        /// way. Uses the <see cref="DataTable.TableName"/> property as the target table. Returns the number
-        /// of updated rows.
+        /// Deletes rows from the target table in bulk in an asynchronous way, matched against a
+        /// <see cref="DataTable"/>. Uses the <see cref="DataTable.TableName"/> property as the target table.
+        /// Returns the number of deleted rows.
         /// </summary>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="table">The source <see cref="DataTable"/>.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
         /// <param name="rowState">The state of the rows to be included; when null, every row is included.</param>
-        /// <param name="mappings">The explicit mapping of the source columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
@@ -253,31 +238,29 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
-        /// <returns>The number of updated rows.</returns>
-        public static Task<int> BulkUpdateAsync(this MySqlConnection connection,
+        /// <returns>The number of deleted rows.</returns>
+        public static Task<int> BulkDeleteAsync(this MariaDbConnection connection,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
             DataRowState? rowState = null,
-            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null,
+            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default) =>
-            BulkUpdateAsync(connection, table?.TableName, table, qualifiers, rowState, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
+            BulkDeleteAsync(connection, table?.TableName, table, qualifiers, rowState, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
         /// <summary>
-        /// Updates the rows of the target table in bulk from a <see cref="DataTable"/> in an asynchronous
-        /// way. Returns the number of updated rows.
+        /// Deletes rows from the target table in bulk in an asynchronous way, matched against a
+        /// <see cref="DataTable"/>. Returns the number of deleted rows.
         /// </summary>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="tableName">The name of the target table.</param>
         /// <param name="table">The source <see cref="DataTable"/>.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
         /// <param name="rowState">The state of the rows to be included; when null, every row is included.</param>
-        /// <param name="mappings">The explicit mapping of the source columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
@@ -285,33 +268,31 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
-        /// <returns>The number of updated rows.</returns>
-        public static Task<int> BulkUpdateAsync(this MySqlConnection connection,
+        /// <returns>The number of deleted rows.</returns>
+        public static Task<int> BulkDeleteAsync(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
             DataRowState? rowState = null,
-            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null,
+            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default) =>
-            BulkUpdateBaseAsync(connection, tableName, table, qualifiers, rowState, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
+            BulkDeleteBaseAsync(connection, tableName, table, qualifiers, rowState, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
         /// <summary>
-        /// Updates existing rows in the database in bulk in an asynchronous way by streaming a
+        /// Deletes rows from the target table in bulk in an asynchronous way by streaming a
         /// <see cref="DbDataReader"/> to a staging table as rows are read from the source rather than
         /// materializing them into memory first, matched by the defined qualifiers (defaults to the primary
-        /// key). Returns the number of updated rows.
+        /// key). Returns the number of deleted rows.
         /// </summary>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="tableName">The name of the target table.</param>
         /// <param name="reader">The source <see cref="DbDataReader"/> to stream from.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
-        /// <param name="mappings">The explicit mapping of the source columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
@@ -319,20 +300,19 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
-        /// <returns>The number of updated rows.</returns>
-        public static Task<int> BulkUpdateAsync(this MySqlConnection connection,
+        /// <returns>The number of deleted rows.</returns>
+        public static Task<int> BulkDeleteAsync(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<Field> qualifiers = null,
-            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
-            MySqlTransaction transaction = null,
+            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default) =>
-            BulkUpdateBaseAsync(connection, tableName, reader, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
+            BulkDeleteBaseAsync(connection, tableName, reader, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
         #endregion
     }

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/MariaDbConnection/BulkDeleteByKey.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/MariaDbConnection/BulkDeleteByKey.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -27,7 +27,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static int BulkDeleteByKey<TPrimaryKey>(this MySqlConnection connection,
+        public static int BulkDeleteByKey<TPrimaryKey>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TPrimaryKey> primaryKeys,
             int? bulkCopyTimeout = null,
@@ -35,7 +35,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDeleteByKey,
-            MySqlTransaction transaction = null) =>
+            MariaDbTransaction transaction = null) =>
             BulkDeleteByKeyBase(connection, tableName, primaryKeys, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
         #endregion
@@ -58,7 +58,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of deleted rows.</returns>
-        public static Task<int> BulkDeleteByKeyAsync<TPrimaryKey>(this MySqlConnection connection,
+        public static Task<int> BulkDeleteByKeyAsync<TPrimaryKey>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TPrimaryKey> primaryKeys,
             int? bulkCopyTimeout = null,
@@ -66,7 +66,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkDeleteByKey,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default) =>
             BulkDeleteByKeyBaseAsync(connection, tableName, primaryKeys, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/MariaDbConnection/BulkInsert.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/MariaDbConnection/BulkInsert.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 namespace RepoDb
 {
     /// <summary>
-    /// Contains the official bulk operations of RepoDB for MariaDb, exposed as <see cref="MySqlConnection"/>
+    /// Contains the official bulk operations of RepoDB for MariaDb, exposed as <see cref="MariaDbConnection"/>
     /// extension methods (i.e. <c>BulkInsert</c>, <c>BulkDelete</c>, <c>BulkMerge</c> and <c>BulkUpdate</c>).
     /// </summary>
     public static partial class MariaDbConnectionExtension
@@ -33,7 +33,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static int BulkInsert<TEntity>(this MySqlConnection connection,
+        public static int BulkInsert<TEntity>(this MariaDbConnection connection,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
@@ -42,7 +42,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             BulkInsertBase(connection, ClassMappedNameCache.Get<TEntity>(), entities, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
@@ -62,7 +62,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static int BulkInsert<TEntity>(this MySqlConnection connection,
+        public static int BulkInsert<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -72,7 +72,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             BulkInsertBase(connection, tableName, entities, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
@@ -92,7 +92,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static int BulkInsert(this MySqlConnection connection,
+        public static int BulkInsert(this MariaDbConnection connection,
             DataTable table,
             DataRowState? rowState = null,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -102,7 +102,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null) =>
+            MariaDbTransaction transaction = null) =>
             BulkInsert(connection, table?.TableName, table, rowState, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static int BulkInsert(this MySqlConnection connection,
+        public static int BulkInsert(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             DataRowState? rowState = null,
@@ -132,7 +132,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null) =>
+            MariaDbTransaction transaction = null) =>
             BulkInsertBase(connection, tableName, table, rowState, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static int BulkInsert(this MySqlConnection connection,
+        public static int BulkInsert(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -165,7 +165,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null) =>
+            MariaDbTransaction transaction = null) =>
             BulkInsertBase(connection, tableName, reader, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
         #endregion
@@ -189,7 +189,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static Task<int> BulkInsertAsync<TEntity>(this MySqlConnection connection,
+        public static Task<int> BulkInsertAsync<TEntity>(this MariaDbConnection connection,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
@@ -198,7 +198,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             BulkInsertBaseAsync(connection, ClassMappedNameCache.Get<TEntity>(), entities, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);
@@ -221,7 +221,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static Task<int> BulkInsertAsync<TEntity>(this MySqlConnection connection,
+        public static Task<int> BulkInsertAsync<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -231,7 +231,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             BulkInsertBaseAsync(connection, tableName, entities, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);
@@ -254,7 +254,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static Task<int> BulkInsertAsync(this MySqlConnection connection,
+        public static Task<int> BulkInsertAsync(this MariaDbConnection connection,
             DataTable table,
             DataRowState? rowState = null,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -264,7 +264,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default) =>
             BulkInsertAsync(connection, table?.TableName, table, rowState, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
@@ -286,7 +286,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static Task<int> BulkInsertAsync(this MySqlConnection connection,
+        public static Task<int> BulkInsertAsync(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             DataRowState? rowState = null,
@@ -297,7 +297,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default) =>
             BulkInsertBaseAsync(connection, tableName, table, rowState, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
@@ -321,7 +321,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of inserted rows.</returns>
-        public static Task<int> BulkInsertAsync(this MySqlConnection connection,
+        public static Task<int> BulkInsertAsync(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -330,7 +330,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkInsert,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default) =>
             BulkInsertBaseAsync(connection, tableName, reader, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/MariaDbConnection/BulkMerge.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/MariaDbConnection/BulkMerge.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -34,7 +34,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of affected rows.</returns>
-        public static int BulkMerge<TEntity>(this MySqlConnection connection,
+        public static int BulkMerge<TEntity>(this MariaDbConnection connection,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -44,7 +44,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             BulkMergeBase(connection, ClassMappedNameCache.Get<TEntity>(), entities, ParseQualifiers(qualifiers), mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
@@ -67,7 +67,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of affected rows.</returns>
-        public static int BulkMerge<TEntity>(this MySqlConnection connection,
+        public static int BulkMerge<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
@@ -78,7 +78,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null)
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
             BulkMergeBase(connection, tableName, entities, qualifiers, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
@@ -100,7 +100,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of affected rows.</returns>
-        public static int BulkMerge(this MySqlConnection connection,
+        public static int BulkMerge(this MariaDbConnection connection,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
             DataRowState? rowState = null,
@@ -111,7 +111,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null) =>
+            MariaDbTransaction transaction = null) =>
             BulkMerge(connection, table?.TableName, table, qualifiers, rowState, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of affected rows.</returns>
-        public static int BulkMerge(this MySqlConnection connection,
+        public static int BulkMerge(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
@@ -144,7 +144,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null) =>
+            MariaDbTransaction transaction = null) =>
             BulkMergeBase(connection, tableName, table, qualifiers, rowState, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction);
 
         /// <summary>
@@ -170,7 +170,7 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <returns>The number of affected rows.</returns>
-        public static int BulkMerge(this MySqlConnection connection,
+        public static int BulkMerge(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<Field> qualifiers = null,
@@ -180,7 +180,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null) =>
+            MariaDbTransaction transaction = null) =>
             BulkMergeBase(connection, tableName, reader, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
         #endregion
@@ -206,7 +206,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of affected rows.</returns>
-        public static Task<int> BulkMergeAsync<TEntity>(this MySqlConnection connection,
+        public static Task<int> BulkMergeAsync<TEntity>(this MariaDbConnection connection,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
             IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
@@ -216,7 +216,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             BulkMergeBaseAsync(connection, ClassMappedNameCache.Get<TEntity>(), entities, ParseQualifiers(qualifiers), mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);
@@ -241,7 +241,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of affected rows.</returns>
-        public static Task<int> BulkMergeAsync<TEntity>(this MySqlConnection connection,
+        public static Task<int> BulkMergeAsync<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
@@ -252,7 +252,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
             BulkMergeBaseAsync(connection, tableName, entities, qualifiers, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);
@@ -276,7 +276,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of affected rows.</returns>
-        public static Task<int> BulkMergeAsync(this MySqlConnection connection,
+        public static Task<int> BulkMergeAsync(this MariaDbConnection connection,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
             DataRowState? rowState = null,
@@ -287,7 +287,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default) =>
             BulkMergeAsync(connection, table?.TableName, table, qualifiers, rowState, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
@@ -310,7 +310,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of affected rows.</returns>
-        public static Task<int> BulkMergeAsync(this MySqlConnection connection,
+        public static Task<int> BulkMergeAsync(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
@@ -322,7 +322,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default) =>
             BulkMergeBaseAsync(connection, tableName, table, qualifiers, rowState, mappings, bulkCopyTimeout, batchSize, identityBehavior, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
@@ -347,7 +347,7 @@ namespace RepoDb
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
         /// <returns>The number of affected rows.</returns>
-        public static Task<int> BulkMergeAsync(this MySqlConnection connection,
+        public static Task<int> BulkMergeAsync(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<Field> qualifiers = null,
@@ -357,7 +357,7 @@ namespace RepoDb
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
             string traceKey = MariaDbTraceKeys.MariaDbBulkMerge,
-            MySqlTransaction transaction = null,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default) =>
             BulkMergeBaseAsync(connection, tableName, reader, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/MariaDbConnection/BulkUpdate.cs
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/Operations/MariaDbConnection/BulkUpdate.cs
@@ -1,4 +1,4 @@
-using MySql.Data.MySqlClient;
+using RepoDb.Connector.MariaDb;
 using RepoDb.Enumerations.MariaDb;
 using RepoDb.Interfaces;
 using RepoDb.MariaDb.BulkOperations;
@@ -17,159 +17,170 @@ namespace RepoDb
         #region Sync
 
         /// <summary>
-        /// Deletes existing rows from the database in bulk, matched by the defined qualifiers (defaults
-        /// to the primary key). Returns the number of deleted rows.
+        /// Updates existing rows in the database in bulk, matched by the defined qualifiers (defaults to
+        /// the primary key). Returns the number of updated rows.
         /// </summary>
         /// <typeparam name="TEntity">The type of the data entity.</typeparam>
         /// <param name="connection">The connection object to be used.</param>
-        /// <param name="entities">The list of entities to be bulk-deleted.</param>
+        /// <param name="entities">The list of entities to be bulk-updated.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
+        /// <param name="mappings">The explicit mapping of the source properties/columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
         /// <param name="trace">The trace object to be used.</param>
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
-        /// <returns>The number of deleted rows.</returns>
-        public static int BulkDelete<TEntity>(this MySqlConnection connection,
+        /// <returns>The number of updated rows.</returns>
+        public static int BulkUpdate<TEntity>(this MariaDbConnection connection,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
+            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null)
+            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
-            BulkDeleteBase(connection, ClassMappedNameCache.Get<TEntity>(), entities, ParseQualifiers(qualifiers), bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
+            BulkUpdateBase(connection, ClassMappedNameCache.Get<TEntity>(), entities, ParseQualifiers(qualifiers), mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
         /// <summary>
-        /// Deletes existing rows from the database in bulk, matched by the defined qualifiers (defaults
-        /// to the primary key). Returns the number of deleted rows.
+        /// Updates existing rows in the database in bulk, matched by the defined qualifiers (defaults to
+        /// the primary key). Returns the number of updated rows.
         /// </summary>
         /// <typeparam name="TEntity">The type of the data entity.</typeparam>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="tableName">The name of the target table.</param>
-        /// <param name="entities">The list of entities to be bulk-deleted.</param>
+        /// <param name="entities">The list of entities to be bulk-updated.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
+        /// <param name="mappings">The explicit mapping of the source properties/columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
         /// <param name="trace">The trace object to be used.</param>
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
-        /// <returns>The number of deleted rows.</returns>
-        public static int BulkDelete<TEntity>(this MySqlConnection connection,
+        /// <returns>The number of updated rows.</returns>
+        public static int BulkUpdate<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
+            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null)
+            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
+            MariaDbTransaction transaction = null)
             where TEntity : class =>
-            BulkDeleteBase(connection, tableName, entities, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
+            BulkUpdateBase(connection, tableName, entities, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
         /// <summary>
-        /// Deletes rows from the target table in bulk, matched against a <see cref="DataTable"/>. Uses the
-        /// <see cref="DataTable.TableName"/> property as the target table. Returns the number of deleted
+        /// Updates the rows of the target table in bulk from a <see cref="DataTable"/>. Uses the
+        /// <see cref="DataTable.TableName"/> property as the target table. Returns the number of updated
         /// rows.
         /// </summary>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="table">The source <see cref="DataTable"/>.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
         /// <param name="rowState">The state of the rows to be included; when null, every row is included.</param>
+        /// <param name="mappings">The explicit mapping of the source columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
         /// <param name="trace">The trace object to be used.</param>
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
-        /// <returns>The number of deleted rows.</returns>
-        public static int BulkDelete(this MySqlConnection connection,
+        /// <returns>The number of updated rows.</returns>
+        public static int BulkUpdate(this MariaDbConnection connection,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
             DataRowState? rowState = null,
+            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null) =>
-            BulkDelete(connection, table?.TableName, table, qualifiers, rowState, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
+            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
+            MariaDbTransaction transaction = null) =>
+            BulkUpdate(connection, table?.TableName, table, qualifiers, rowState, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
         /// <summary>
-        /// Deletes rows from the target table in bulk, matched against a <see cref="DataTable"/>. Returns
-        /// the number of deleted rows.
+        /// Updates the rows of the target table in bulk from a <see cref="DataTable"/>. Returns the
+        /// number of updated rows.
         /// </summary>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="tableName">The name of the target table.</param>
         /// <param name="table">The source <see cref="DataTable"/>.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
         /// <param name="rowState">The state of the rows to be included; when null, every row is included.</param>
+        /// <param name="mappings">The explicit mapping of the source columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
         /// <param name="trace">The trace object to be used.</param>
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
-        /// <returns>The number of deleted rows.</returns>
-        public static int BulkDelete(this MySqlConnection connection,
+        /// <returns>The number of updated rows.</returns>
+        public static int BulkUpdate(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
             DataRowState? rowState = null,
+            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null) =>
-            BulkDeleteBase(connection, tableName, table, qualifiers, rowState, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
+            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
+            MariaDbTransaction transaction = null) =>
+            BulkUpdateBase(connection, tableName, table, qualifiers, rowState, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
         /// <summary>
-        /// Deletes rows from the target table in bulk by streaming a <see cref="DbDataReader"/> to a
+        /// Updates existing rows in the database in bulk by streaming a <see cref="DbDataReader"/> to a
         /// staging table as rows are read from the source rather than materializing them into memory first,
-        /// matched by the defined qualifiers (defaults to the primary key). Returns the number of deleted
+        /// matched by the defined qualifiers (defaults to the primary key). Returns the number of updated
         /// rows.
         /// </summary>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="tableName">The name of the target table.</param>
         /// <param name="reader">The source <see cref="DbDataReader"/> to stream from.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
+        /// <param name="mappings">The explicit mapping of the source columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
         /// <param name="trace">The trace object to be used.</param>
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
-        /// <returns>The number of deleted rows.</returns>
-        public static int BulkDelete(this MySqlConnection connection,
+        /// <returns>The number of updated rows.</returns>
+        public static int BulkUpdate(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<Field> qualifiers = null,
+            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null) =>
-            BulkDeleteBase(connection, tableName, reader, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
+            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
+            MariaDbTransaction transaction = null) =>
+            BulkUpdateBase(connection, tableName, reader, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction);
 
         #endregion
 
         #region Async
 
         /// <summary>
-        /// Deletes existing rows from the database in bulk in an asynchronous way, matched by the defined
-        /// qualifiers (defaults to the primary key). Returns the number of deleted rows.
+        /// Updates existing rows in the database in bulk in an asynchronous way, matched by the defined
+        /// qualifiers (defaults to the primary key). Returns the number of updated rows.
         /// </summary>
         /// <typeparam name="TEntity">The type of the data entity.</typeparam>
         /// <param name="connection">The connection object to be used.</param>
-        /// <param name="entities">The list of entities to be bulk-deleted.</param>
+        /// <param name="entities">The list of entities to be bulk-updated.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
+        /// <param name="mappings">The explicit mapping of the source properties/columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
@@ -177,29 +188,31 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
-        /// <returns>The number of deleted rows.</returns>
-        public static Task<int> BulkDeleteAsync<TEntity>(this MySqlConnection connection,
+        /// <returns>The number of updated rows.</returns>
+        public static Task<int> BulkUpdateAsync<TEntity>(this MariaDbConnection connection,
             IEnumerable<TEntity> entities,
             Expression<Func<TEntity, object>> qualifiers = null,
+            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null,
+            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
-            BulkDeleteBaseAsync(connection, ClassMappedNameCache.Get<TEntity>(), entities, ParseQualifiers(qualifiers), bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
+            BulkUpdateBaseAsync(connection, ClassMappedNameCache.Get<TEntity>(), entities, ParseQualifiers(qualifiers), mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
         /// <summary>
-        /// Deletes existing rows from the database in bulk in an asynchronous way, matched by the defined
-        /// qualifiers (defaults to the primary key). Returns the number of deleted rows.
+        /// Updates existing rows in the database in bulk in an asynchronous way, matched by the defined
+        /// qualifiers (defaults to the primary key). Returns the number of updated rows.
         /// </summary>
         /// <typeparam name="TEntity">The type of the data entity.</typeparam>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="tableName">The name of the target table.</param>
-        /// <param name="entities">The list of entities to be bulk-deleted.</param>
+        /// <param name="entities">The list of entities to be bulk-updated.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
+        /// <param name="mappings">The explicit mapping of the source properties/columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
@@ -207,30 +220,32 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
-        /// <returns>The number of deleted rows.</returns>
-        public static Task<int> BulkDeleteAsync<TEntity>(this MySqlConnection connection,
+        /// <returns>The number of updated rows.</returns>
+        public static Task<int> BulkUpdateAsync<TEntity>(this MariaDbConnection connection,
             string tableName,
             IEnumerable<TEntity> entities,
             IEnumerable<Field> qualifiers = null,
+            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null,
+            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default)
             where TEntity : class =>
-            BulkDeleteBaseAsync(connection, tableName, entities, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
+            BulkUpdateBaseAsync(connection, tableName, entities, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
         /// <summary>
-        /// Deletes rows from the target table in bulk in an asynchronous way, matched against a
-        /// <see cref="DataTable"/>. Uses the <see cref="DataTable.TableName"/> property as the target table.
-        /// Returns the number of deleted rows.
+        /// Updates the rows of the target table in bulk from a <see cref="DataTable"/> in an asynchronous
+        /// way. Uses the <see cref="DataTable.TableName"/> property as the target table. Returns the number
+        /// of updated rows.
         /// </summary>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="table">The source <see cref="DataTable"/>.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
         /// <param name="rowState">The state of the rows to be included; when null, every row is included.</param>
+        /// <param name="mappings">The explicit mapping of the source columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
@@ -238,29 +253,31 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
-        /// <returns>The number of deleted rows.</returns>
-        public static Task<int> BulkDeleteAsync(this MySqlConnection connection,
+        /// <returns>The number of updated rows.</returns>
+        public static Task<int> BulkUpdateAsync(this MariaDbConnection connection,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
             DataRowState? rowState = null,
+            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null,
+            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default) =>
-            BulkDeleteAsync(connection, table?.TableName, table, qualifiers, rowState, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
+            BulkUpdateAsync(connection, table?.TableName, table, qualifiers, rowState, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
         /// <summary>
-        /// Deletes rows from the target table in bulk in an asynchronous way, matched against a
-        /// <see cref="DataTable"/>. Returns the number of deleted rows.
+        /// Updates the rows of the target table in bulk from a <see cref="DataTable"/> in an asynchronous
+        /// way. Returns the number of updated rows.
         /// </summary>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="tableName">The name of the target table.</param>
         /// <param name="table">The source <see cref="DataTable"/>.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
         /// <param name="rowState">The state of the rows to be included; when null, every row is included.</param>
+        /// <param name="mappings">The explicit mapping of the source columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
@@ -268,31 +285,33 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
-        /// <returns>The number of deleted rows.</returns>
-        public static Task<int> BulkDeleteAsync(this MySqlConnection connection,
+        /// <returns>The number of updated rows.</returns>
+        public static Task<int> BulkUpdateAsync(this MariaDbConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<Field> qualifiers = null,
             DataRowState? rowState = null,
+            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null,
+            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default) =>
-            BulkDeleteBaseAsync(connection, tableName, table, qualifiers, rowState, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
+            BulkUpdateBaseAsync(connection, tableName, table, qualifiers, rowState, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
         /// <summary>
-        /// Deletes rows from the target table in bulk in an asynchronous way by streaming a
+        /// Updates existing rows in the database in bulk in an asynchronous way by streaming a
         /// <see cref="DbDataReader"/> to a staging table as rows are read from the source rather than
         /// materializing them into memory first, matched by the defined qualifiers (defaults to the primary
-        /// key). Returns the number of deleted rows.
+        /// key). Returns the number of updated rows.
         /// </summary>
         /// <param name="connection">The connection object to be used.</param>
         /// <param name="tableName">The name of the target table.</param>
         /// <param name="reader">The source <see cref="DbDataReader"/> to stream from.</param>
         /// <param name="qualifiers">The fields used to match existing rows.</param>
+        /// <param name="mappings">The explicit mapping of the source columns to the destination columns.</param>
         /// <param name="bulkCopyTimeout">The command timeout, in seconds.</param>
         /// <param name="batchSize">The number of rows in each batch. When null, the provider's default batch size is used.</param>
         /// <param name="pseudoTableType">The type of staging (pseudo) table to create and reuse for this operation.</param>
@@ -300,19 +319,20 @@ namespace RepoDb
         /// <param name="traceKey">The tracing key to be used.</param>
         /// <param name="transaction">The transaction to be used.</param>
         /// <param name="cancellationToken">The token to cancel the asynchronous operation.</param>
-        /// <returns>The number of deleted rows.</returns>
-        public static Task<int> BulkDeleteAsync(this MySqlConnection connection,
+        /// <returns>The number of updated rows.</returns>
+        public static Task<int> BulkUpdateAsync(this MariaDbConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<Field> qualifiers = null,
+            IEnumerable<MariaDbBulkInsertMapItem> mappings = null,
             int? bulkCopyTimeout = null,
             int? batchSize = null,
             MariaDbBulkImportPseudoTableType pseudoTableType = default,
             ITrace trace = null,
-            string traceKey = MariaDbTraceKeys.MariaDbBulkDelete,
-            MySqlTransaction transaction = null,
+            string traceKey = MariaDbTraceKeys.MariaDbBulkUpdate,
+            MariaDbTransaction transaction = null,
             CancellationToken cancellationToken = default) =>
-            BulkDeleteBaseAsync(connection, tableName, reader, qualifiers, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
+            BulkUpdateBaseAsync(connection, tableName, reader, qualifiers, mappings, bulkCopyTimeout, batchSize, pseudoTableType, trace, traceKey, transaction, cancellationToken);
 
         #endregion
     }

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.csproj
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.csproj
@@ -21,7 +21,7 @@
     <PackageVersion Condition="'$(RepoDbMariaDbBulkOperationsVersion)' != ''">$(RepoDbMariaDbBulkOperationsVersion)</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="RepoDb.Connector.MariaDb" Version="0.0.1-alpha1" />
+    <PackageReference Include="RepoDb.Connector.MariaDb" Version="0.0.1-alpha2" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\LICENSE.txt" Pack="True" PackagePath="\" />

--- a/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.csproj
+++ b/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations/RepoDb.MariaDb.BulkOperations.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <Nullable>annotations</Nullable>
-    <Description>An extension library that contains the official Bulk Operations of RepoDB for MariaDB (using MySql.Data).</Description>
+    <Description>An extension library that contains the official Bulk Operations of RepoDB for MariaDB (using RepoDb.Connector.MariaDb).</Description>
     <PackageTags>orm hybrid-orm micro-orm mariadb bulkoperations</PackageTags>
     <RepositoryUrl>https://github.com/mikependon/RepoDb/tree/master/RepoDb.Extensions/RepoDb.MariaDb.BulkOperations</RepositoryUrl>
     <PackageReleaseNotes>http://repodb.net/release/mariadbbulk</PackageReleaseNotes>
@@ -21,8 +21,7 @@
     <PackageVersion Condition="'$(RepoDbMariaDbBulkOperationsVersion)' != ''">$(RepoDbMariaDbBulkOperationsVersion)</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
-    <PackageReference Include="MySql.Data" Version="9.7.0" />
+    <PackageReference Include="RepoDb.Connector.MariaDb" Version="0.0.1-alpha1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\..\LICENSE.txt" Pack="True" PackagePath="\" />

--- a/RepoDb.MariaDb/RepoDb.MariaDb.IntegrationTests/RepoDb.MariaDb.IntegrationTests.csproj
+++ b/RepoDb.MariaDb/RepoDb.MariaDb.IntegrationTests/RepoDb.MariaDb.IntegrationTests.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSTest" Version="4.2.3" />
-    <PackageReference Include="RepoDb.Connector.MariaDb" Version="0.0.1-alpha1" />
+    <PackageReference Include="RepoDb.Connector.MariaDb" Version="0.0.1-alpha2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\RepoDb.Core\RepoDb\RepoDb.csproj" />

--- a/RepoDb.MariaDb/RepoDb.MariaDb.UnitTests/RepoDb.MariaDb.UnitTests.csproj
+++ b/RepoDb.MariaDb/RepoDb.MariaDb.UnitTests/RepoDb.MariaDb.UnitTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSTest" Version="4.2.3" />
-    <PackageReference Include="RepoDb.Connector.MariaDb" Version="0.0.1-alpha1" />
+    <PackageReference Include="RepoDb.Connector.MariaDb" Version="0.0.1-alpha2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RepoDb.MariaDb\RepoDb.MariaDb.csproj" />

--- a/RepoDb.MariaDb/RepoDb.MariaDb/RepoDb.MariaDb.csproj
+++ b/RepoDb.MariaDb/RepoDb.MariaDb/RepoDb.MariaDb.csproj
@@ -24,7 +24,7 @@
     <Compile Remove="Attributes\MariaDbTypeMapAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="RepoDb.Connector.MariaDb" Version="0.0.1-alpha1" />
+    <PackageReference Include="RepoDb.Connector.MariaDb" Version="0.0.1-alpha2" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE.txt" Pack="True" PackagePath="\" />


### PR DESCRIPTION
# RepoDb.MariaDb.BulkOperations Migration Summary

Migrated `RepoDb.MariaDb.BulkOperations` from `MySql.Data` to `RepoDb.Connector.MariaDb` (v0.0.1-alpha1) across 34 changed files — main library and Integration Tests. Note: there's no `RepoDb.MariaDb.BulkOperations.UnitTests` project (none of the BulkOperations extension packages — Db2, MySql, Oracle, etc. — have one; only Integration Tests exist), so Integration Tests is the full test scope here.

## Key Changes

- **csproj files (2)**: swapped `MySql.Data` / `BouncyCastle.Cryptography` for a `RepoDb.Connector.MariaDb` package reference.
- **Mechanical replace**: `MySqlConnection` → `MariaDbConnection`, `MySqlTransaction` → `MariaDbTransaction` throughout the extension-method surface (`Base/`, `Operations/BaseRepository/`, `Operations/DbRepository/`, `Helpers/MariaDbExecution.cs`) and Integration Tests.
- **Folder rename**: `Operations/MySqlConnection/` → `Operations/MariaDbConnection/` (the folder name documents which connection type the extension methods target).
- **`MariaDbBulkCopy.cs`** (the internal LOAD-DATA-based bulk engine): now builds on the connector's public `RepoDb.Connector.MariaDb.Bulk.MariaDbBulkLoader` instead of instantiating `MySql.Data`'s `MySqlBulkLoader` directly — required because `MariaDbConnection.InnerConnection` is `internal` to the connector assembly, so this project can no longer reach the raw `MySqlConnection` to construct a loader itself. All the actual bulk-loading logic (temp-file writing, escaping, tab/newline format) is untouched.
- **`MariaDbBulkInsertMapItem.cs`**: its optional explicit-type parameter/property moved from `MySqlDbType?` to the connector's `MariaDbType?`.
- **Bug found and fixed**: `MariaDbTransaction.Connection` (inherited from `DbTransaction`) returns the base `DbConnection` type, unlike `MySqlTransaction.Connection` which covariantly returned `MySqlConnection`. This broke type inference on `transaction?.Connection ?? repository.CreateConnection()` in all 5 `Operations/DbRepository/*.cs` files; fixed by casting to `MariaDbConnection` (safe — the connector's transaction always wraps a `MariaDbConnection` internally).
- **README.md** and a stale doc comment (`BulkOperationIdentityTable.cs`) updated to drop `MySql`-specific mentions.

## Verification

- `net8.0`, `net9.0`, and `net10.0` all build cleanly with zero warnings/errors for both the main library and Integration Tests.
- Integration Tests need a live MariaDB instance to actually run, which was not available in this session.
