### PR TITLE
Oracle ArrayBinder for real-async BulkInsert #1283

### DIFF
--- a/RepoDb.Core/RepoDb/DataEntityDataReader.cs
+++ b/RepoDb.Core/RepoDb/DataEntityDataReader.cs
@@ -336,7 +336,7 @@ namespace RepoDb
         public override string GetDataTypeName(int i)
         {
             ThrowExceptionIfNotAvailable();
-            return Properties[i].PropertyInfo.PropertyType.Name;
+            return GetFieldType(i).Name;
         }
 
         /// <summary>
@@ -377,10 +377,37 @@ namespace RepoDb
         /// </summary>
         /// <param name="i">The index of the property.</param>
         /// <returns>The property type from the property index.</returns>
-        public override Type GetFieldType(int i)
+        public override Type GetFieldType(int i) =>
+            isDictionaryStringObject ? GetFieldTypeForDictionaryStringObject(i) : GetFieldTypeForEntities(i);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
+        private Type GetFieldTypeForEntities(int i)
         {
             ThrowExceptionIfNotAvailable();
+            if (i == Properties.Count)
+            {
+                return StaticType.Int32;
+            }
             return Properties[i].PropertyInfo.PropertyType;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
+        private Type GetFieldTypeForDictionaryStringObject(int i)
+        {
+            ThrowExceptionIfNotAvailable();
+            if (i == Fields.Count)
+            {
+                return StaticType.Int32;
+            }
+            return Fields[i].Type ?? StaticType.Object;
         }
 
         /// <summary>

--- a/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/Base/WriteToServer.cs
+++ b/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/Base/WriteToServer.cs
@@ -43,7 +43,7 @@ namespace RepoDb
         {
             connection.EnsureOpen();
             using var reader = new DataEntityDataReader<TEntity>(entities);
-            using var bulkCopy = CreateBulkCopyForDataReader(connection, tableName, reader, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize);
+            using var bulkCopy = CreateOracleBulkCopy(connection, tableName, reader, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize);
             bulkCopy.WriteToServer(reader);
             return entities != null ? entities.Count() : 0;
         }
@@ -70,7 +70,7 @@ namespace RepoDb
             int? batchSize = null)
         {
             connection.EnsureOpen();
-            using var bulkCopy = CreateBulkCopyForDataTable(connection, tableName, table, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize);
+            using var bulkCopy = CreateOracleBulkCopy(connection, tableName, table, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize);
             var rows = GetDataRows(table, rowState)?.ToArray();
             bulkCopy.WriteToServer(rows);
             return rows != null ? rows.Length : 0;
@@ -97,7 +97,7 @@ namespace RepoDb
         {
             connection.EnsureOpen();
             var countingReader = new CountingDataReader(reader);
-            using var bulkCopy = CreateBulkCopyForDataReader(connection, tableName, countingReader, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize);
+            using var bulkCopy = CreateOracleBulkCopy(connection, tableName, countingReader, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize);
             bulkCopy.WriteToServer(countingReader);
             return countingReader.Count;
         }
@@ -130,14 +130,9 @@ namespace RepoDb
             where TEntity : class
         {
             await connection.EnsureOpenAsync(cancellationToken);
-            return await Task.Run(() => // No underlying 'Async' equivalent for 'WriteToServerInternal'
-            {
-                using var reader = new DataEntityDataReader<TEntity>(entities);
-                using var bulkCopy = CreateBulkCopyForDataReader(connection, tableName, reader, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize);
-                bulkCopy.WriteToServer(reader);
-                return entities != null ? entities.Count() : 0;
-            },
-            cancellationToken);
+            using var reader = new DataEntityDataReader<TEntity>(entities);
+            using var arrayBinder = CreateOracleBulkArrayBinder(connection, tableName, reader, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize);
+            return await arrayBinder.BindArrayAsync(reader, cancellationToken);
         }
 
         /// <summary>
@@ -164,14 +159,8 @@ namespace RepoDb
             CancellationToken cancellationToken = default)
         {
             await connection.EnsureOpenAsync(cancellationToken);
-            return await Task.Run(() => // No underlying 'Async' equivalent for 'WriteToServerInternal'
-            {
-                using var bulkCopy = CreateBulkCopyForDataTable(connection, tableName, table, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize);
-                var rows = GetDataRows(table, rowState)?.ToArray();
-                bulkCopy.WriteToServer(rows);
-                return rows != null ? rows.Length : 0;
-            },
-            cancellationToken);
+            using var arrayBinder = CreateOracleBulkArrayBinder(connection, tableName, table, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize);
+            return await arrayBinder.BindArrayAsync(table, rowState, cancellationToken);
         }
 
         /// <summary>
@@ -196,14 +185,9 @@ namespace RepoDb
             CancellationToken cancellationToken = default)
         {
             await connection.EnsureOpenAsync(cancellationToken);
-            return await Task.Run(() => // No underlying 'Async' equivalent for 'WriteToServerInternal'
-            {
-                var countingReader = new CountingDataReader(reader);
-                using var bulkCopy = CreateBulkCopyForDataReader(connection, tableName, countingReader, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize);
-                bulkCopy.WriteToServer(countingReader);
-                return countingReader.Count;
-            },
-            cancellationToken);
+            var countingReader = new CountingDataReader(reader);
+            using var bulkCopy = CreateOracleBulkArrayBinder(connection, tableName, countingReader, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize);
+            return await bulkCopy.BindArrayAsync(countingReader, cancellationToken);
         }
 
         #endregion
@@ -257,7 +241,7 @@ namespace RepoDb
         /// <param name="bulkCopyTimeout"></param>
         /// <param name="batchSize"></param>
         /// <returns></returns>
-        private static OracleBulkCopy CreateBulkCopyForDataTable(OracleConnection connection,
+        private static OracleBulkCopy CreateOracleBulkCopy(OracleConnection connection,
             string tableName,
             DataTable table,
             IEnumerable<OracleBulkInsertMapItem> mappings,
@@ -306,7 +290,7 @@ namespace RepoDb
         /// <param name="bulkCopyTimeout"></param>
         /// <param name="batchSize"></param>
         /// <returns></returns>
-        private static OracleBulkCopy CreateBulkCopyForDataReader(OracleConnection connection,
+        private static OracleBulkCopy CreateOracleBulkCopy(OracleConnection connection,
             string tableName,
             IDataReader reader,
             IEnumerable<OracleBulkInsertMapItem> mappings,
@@ -317,7 +301,7 @@ namespace RepoDb
             var dbSetting = connection.GetDbSetting();
             var bulkCopy = new OracleBulkCopy(connection, bulkCopyOptions)
             {
-                // See the remarks in CreateBulkCopyForDataTable - same quoting requirement applies here.
+                // See the remarks in CreateOracleBulkCopy - same quoting requirement applies here.
                 DestinationTableName = tableName.AsQuoted(true, dbSetting)
             };
             if (bulkCopyTimeout.HasValue)
@@ -333,6 +317,95 @@ namespace RepoDb
                 bulkCopy.ColumnMappings.Add(mapping.SourceColumn, mapping.DestinationColumn.AsQuoted(true, dbSetting));
             }
             return bulkCopy;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <param name="tableName"></param>
+        /// <param name="table"></param>
+        /// <param name="mappings"></param>
+        /// <param name="bulkCopyOptions"></param>
+        /// <param name="bulkCopyTimeout"></param>
+        /// <param name="batchSize"></param>
+        /// <returns></returns>
+        private static OracleBulkArrayBinder CreateOracleBulkArrayBinder(OracleConnection connection,
+            string tableName,
+            DataTable table,
+            IEnumerable<OracleBulkInsertMapItem> mappings,
+            OracleBulkCopyOptions bulkCopyOptions,
+            int? bulkCopyTimeout,
+            int? batchSize = null)
+        {
+            var dbSetting = connection.GetDbSetting();
+            var arrayBinder = new OracleBulkArrayBinder(connection)
+            {
+                DestinationTableName = tableName.AsQuoted(true, dbSetting)
+            };
+            if (bulkCopyTimeout.HasValue)
+            {
+                arrayBinder.BulkCopyTimeout = bulkCopyTimeout.Value;
+            }
+            if (batchSize.HasValue)
+            {
+                arrayBinder.BatchSize = batchSize.Value;
+            }
+            if (mappings != null)
+            {
+                foreach (var mapping in mappings)
+                {
+                    arrayBinder.ColumnMappings.Add(mapping.SourceColumn, mapping.DestinationColumn.AsQuoted(true, dbSetting));
+                }
+            }
+            else
+            {
+                foreach (DataColumn column in table.Columns)
+                {
+                    arrayBinder.ColumnMappings.Add(column.ColumnName, column.ColumnName.AsQuoted(true, dbSetting));
+                }
+            }
+            return arrayBinder;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <param name="tableName"></param>
+        /// <param name="reader"></param>
+        /// <param name="mappings"></param>
+        /// <param name="bulkCopyOptions"></param>
+        /// <param name="bulkCopyTimeout"></param>
+        /// <param name="batchSize"></param>
+        /// <returns></returns>
+        private static OracleBulkArrayBinder CreateOracleBulkArrayBinder(OracleConnection connection,
+            string tableName,
+            IDataReader reader,
+            IEnumerable<OracleBulkInsertMapItem> mappings,
+            OracleBulkCopyOptions bulkCopyOptions,
+            int? bulkCopyTimeout,
+            int? batchSize = null)
+        {
+            var dbSetting = connection.GetDbSetting();
+            var arrayBinder = new OracleBulkArrayBinder(connection)
+            {
+                // See the remarks in CreateOracleBulkCopy - same quoting requirement applies here.
+                DestinationTableName = tableName.AsQuoted(true, dbSetting)
+            };
+            if (bulkCopyTimeout.HasValue)
+            {
+                arrayBinder.BulkCopyTimeout = bulkCopyTimeout.Value;
+            }
+            if (batchSize.HasValue)
+            {
+                arrayBinder.BatchSize = batchSize.Value;
+            }
+            foreach (var mapping in mappings ?? GetDefaultMappingsForDataReader(connection, tableName, reader))
+            {
+                arrayBinder.ColumnMappings.Add(mapping.SourceColumn, mapping.DestinationColumn.AsQuoted(true, dbSetting));
+            }
+            return arrayBinder;
         }
 
         /// <summary>

--- a/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/OracleBulkArrayBinder.cs
+++ b/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/OracleBulkArrayBinder.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
+using System.Resources;
 using System.Threading;
 using System.Threading.Tasks;
 using Oracle.ManagedDataAccess.Client;
-using RepoDb;
 using RepoDb.Extensions;
 using RepoDb.Resolvers;
 
@@ -14,21 +14,18 @@ using RepoDb.Resolvers;
 namespace RepoDb.Oracle.BulkOperations
 {
     /// <summary>
-    /// An async, array-bind based alternative to <see cref="OracleBulkCopy"/> - there is no true async
-    /// equivalent of <see cref="OracleBulkCopy.WriteToServer(IDataReader)"/>, so this issues batched
-    /// <c>INSERT ... VALUES (:p0, :p1, ...)</c> statements with <see cref="OracleCommand.ArrayBindCount"/>
-    /// set, which ODP.NET can execute via <see cref="OracleCommand.ExecuteNonQueryAsync(CancellationToken)"/>.
+    /// Array-bind based alternative to <see cref="OracleBulkCopy"/> for bulk insert huge amount of data with true asynchronous capability.
     /// </summary>
-    internal class OracleBulkArrayBinder : IDisposable
+    public class OracleBulkArrayBinder : IDisposable
     {
         private const int MaxBindableParametersCount = 65_535;
         private static readonly TypeToOracleDbTypeResolver dbTypeResolver = new();
         private readonly OracleConnection connection;
 
         /// <summary>
-        ///
+        /// Creates a new instance bound to <paramref name="connection"/>.
         /// </summary>
-        /// <param name="connection"></param>
+        /// <param name="connection">The connection to bind array inserts against.</param>
         public OracleBulkArrayBinder(OracleConnection connection)
         {
             this.connection = connection;
@@ -37,27 +34,27 @@ namespace RepoDb.Oracle.BulkOperations
         #region Properties
 
         /// <summary>
-        ///
+        /// Gets or sets the target table name.
         /// </summary>
         public string DestinationTableName { get; set; }
 
         /// <summary>
-        ///
+        /// Gets or sets the command timeout, in seconds. Zero uses the provider default.
         /// </summary>
         public int BulkCopyTimeout { get; set; }
 
         /// <summary>
-        ///
+        /// Gets or sets the array-bind batch size. Zero auto-sizes it from the column count.
         /// </summary>
         public int BatchSize { get; set; }
 
         /// <summary>
-        ///
+        /// Gets or sets the transaction each batch is executed under.
         /// </summary>
         public OracleTransaction Transaction { get; set; }
 
         /// <summary>
-        ///
+        /// Gets the source-to-destination column mappings. Empty maps every source column to itself.
         /// </summary>
         public OracleBulkArrayBinderColumnMappingCollection ColumnMappings { get; } = new();
 
@@ -198,8 +195,9 @@ namespace RepoDb.Oracle.BulkOperations
 
             var dbSetting = connection.GetDbSetting();
             var unquotedTableName = DestinationTableName.AsUnquoted(true, dbSetting);
-            var dbFields = await DbFieldCache.GetAsync(connection, unquotedTableName, Transaction, cancellationToken);
-            var identity = dbFields?.GetIdentity();
+            var dbFieldList = await connection.GetDbHelper().GetFieldsAsync(connection, unquotedTableName, Transaction, cancellationToken);
+            var dbFields = new DbFieldCollection(dbFieldList, dbSetting);
+            var identity = dbFields.GetIdentity();
 
             if (identity == null)
             {
@@ -290,11 +288,11 @@ namespace RepoDb.Oracle.BulkOperations
         #endregion
 
         /// <summary>
-        ///
+        /// Array-binds and inserts every row of <paramref name="reader"/> into <see cref="DestinationTableName"/>.
         /// </summary>
-        /// <param name="reader"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
+        /// <param name="reader">The source rows to insert.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The number of rows affected.</returns>
         public async Task<int> BindArrayAsync(
             IDataReader reader,
             CancellationToken cancellationToken = default)
@@ -312,12 +310,12 @@ namespace RepoDb.Oracle.BulkOperations
         }
 
         /// <summary>
-        ///
+        /// Array-binds and inserts the rows of <paramref name="dataTable"/> into <see cref="DestinationTableName"/>.
         /// </summary>
-        /// <param name="dataTable"></param>
-        /// <param name="rowState"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
+        /// <param name="dataTable">The source rows to insert.</param>
+        /// <param name="rowState">When specified, only rows in this state are inserted.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The number of rows affected.</returns>
         public Task<int> BindArrayAsync(
             DataTable dataTable,
             DataRowState? rowState = null,
@@ -334,10 +332,11 @@ namespace RepoDb.Oracle.BulkOperations
         }
 
         /// <summary>
-        ///
+        /// Disposes the underlying resources used by this instance.
         /// </summary>
         public void Dispose()
         {
+            // Does nothing for now; this instance owns no unmanaged resources.
         }
     }
 }

--- a/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/OracleBulkArrayBinder.cs
+++ b/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/OracleBulkArrayBinder.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Oracle.ManagedDataAccess.Client;
+using RepoDb.Oracle.BulkOperations;
+
+internal class OracleBulkArrayBinder
+{
+    private const int MaxBindableParametersCount = 65_535;
+    private readonly OracleConnection connection;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="connection"></param>
+    public OracleBulkArrayBinder(OracleConnection connection)
+    {
+        this.connection = connection;
+    }
+
+    #region Helpers
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="batchSize"></param>
+    /// <param name="columnCount"></param>
+    /// <returns></returns>
+    private int GetBatchSize(
+        int? batchSize,
+        int columnCount)
+    {
+        if (batchSize == null)
+        {
+            batchSize = Math.Min(1000, MaxBindableParametersCount / columnCount);
+        }
+        return batchSize.Value;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="reader"></param>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException"></exception>
+    private DataTable ToDataTable(
+        DbDataReader reader)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="dataTable"></param>
+    /// <param name="columnName"></param>
+    /// <param name="arrayBindCount"></param>
+    /// <returns></returns>
+    private object?[] GetBoundValues(
+        DataTable dataTable,
+        string columnName,
+        int arrayBindCount)
+    {
+        var values = new object?[arrayBindCount];
+        for (var rowIndex = 0; rowIndex < arrayBindCount; rowIndex++)
+        {
+            values[rowIndex] = dataTable.Rows[rowIndex][columnName] ?? DBNull.Value;
+        }
+        return values;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="dataType"></param>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException"></exception>
+    private OracleDbType ToOracleDbType(
+        Type dataType)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="tableName"></param>
+    /// <param name="columns"></param>
+    /// <returns></returns>
+    private string BuildInsertStatement(
+        string tableName,
+        IReadOnlyList<string> columns)
+    {
+        var columnList = string.Join(", ", columns);
+        var parameterList = string.Join(", ", columns.Select(column => ":" + column));
+        return $"INSERT INTO {tableName} ({columnList}) VALUES ({parameterList});";
+    }
+
+    #endregion
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="tableName"></param>
+    /// <param name="reader"></param>
+    /// <param name="mappings"></param>
+    /// <param name="bulkCopyTimeout"></param>
+    /// <param name="batchSize"></param>
+    /// <param name="transaction"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async Task<int> WriteToServerAsync(
+        string tableName,
+        DbDataReader reader,
+        IEnumerable<OracleBulkInsertMapItem> mappings,
+        int? bulkCopyTimeout,
+        int? batchSize = null,
+        OracleTransaction transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (reader.FieldCount == 0)
+        {
+            return 0;
+        }
+        return await WriteToServerAsync(tableName,
+            ToDataTable(reader),
+            mappings,
+            bulkCopyTimeout,
+            batchSize,
+            transaction,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="tableName"></param>
+    /// <param name="dataTable"></param>
+    /// <param name="mappings"></param>
+    /// <param name="bulkCopyTimeout"></param>
+    /// <param name="batchSize"></param>
+    /// <param name="transaction"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async Task<int> WriteToServerAsync(
+        string tableName,
+        DataTable dataTable,
+        IEnumerable<OracleBulkInsertMapItem> mappings,
+        int? bulkCopyTimeout,
+        int? batchSize = null,
+        OracleTransaction transaction = null,
+        CancellationToken cancellationToken = default)
+    {
+
+        if (dataTable.Columns.Count == 0)
+        {
+            return 0;
+        }
+
+        batchSize = GetBatchSize(batchSize, dataTable.Columns.Count);
+        var columnNames = dataTable.Columns.OfType<DataColumn>().Select(c => c.ColumnName).ToArray();
+        var affectedRows = 0;
+
+        for (var offset = 0; offset < dataTable.Columns.Count; offset += GetBatchSize(batchSize, dataTable.Columns.Count))
+        {
+            var count = Math.Min(batchSize.Value, (dataTable.Rows.Count - offset));
+
+            await using var command = connection.CreateCommand();
+
+            command.Transaction = transaction;
+            command.BindByName = true;
+            command.ArrayBindCount = count;
+            command.CommandText = BuildInsertStatement(tableName, columnNames);
+
+            foreach (var columnName in columnNames)
+            {
+                var parameter = new OracleParameter
+                {
+                    ParameterName = columnName,
+                    OracleDbType = ToOracleDbType(dataTable.Columns[columnName].DataType),
+                    Direction = ParameterDirection.Input,
+                    Value = GetBoundValues(dataTable, columnName, count)
+                };
+
+                command.Parameters.Add(parameter);
+            }
+
+            affectedRows += await command.ExecuteNonQueryAsync(
+                cancellationToken);
+        }
+
+        return affectedRows;
+    }
+}

--- a/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/OracleBulkArrayBinder.cs
+++ b/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/OracleBulkArrayBinder.cs
@@ -6,193 +6,274 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Oracle.ManagedDataAccess.Client;
-using RepoDb.Oracle.BulkOperations;
+using RepoDb.Resolvers;
 
-internal class OracleBulkArrayBinder
+
+namespace RepoDb.Oracle.BulkOperations
 {
-    private const int MaxBindableParametersCount = 65_535;
-    private readonly OracleConnection connection;
-
     /// <summary>
-    /// 
+    /// An async, array-bind based alternative to <see cref="OracleBulkCopy"/> - there is no true async
+    /// equivalent of <see cref="OracleBulkCopy.WriteToServer(IDataReader)"/>, so this issues batched
+    /// <c>INSERT ... VALUES (:p0, :p1, ...)</c> statements with <see cref="OracleCommand.ArrayBindCount"/>
+    /// set, which ODP.NET can execute via <see cref="OracleCommand.ExecuteNonQueryAsync(CancellationToken)"/>.
     /// </summary>
-    /// <param name="connection"></param>
-    public OracleBulkArrayBinder(OracleConnection connection)
+    internal class OracleBulkArrayBinder : IDisposable
     {
-        this.connection = connection;
-    }
+        private const int MaxBindableParametersCount = 65_535;
+        private static readonly TypeToOracleDbTypeResolver dbTypeResolver = new();
+        private readonly OracleConnection connection;
 
-    #region Helpers
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="batchSize"></param>
-    /// <param name="columnCount"></param>
-    /// <returns></returns>
-    private int GetBatchSize(
-        int? batchSize,
-        int columnCount)
-    {
-        if (batchSize == null)
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="connection"></param>
+        public OracleBulkArrayBinder(OracleConnection connection)
         {
-            batchSize = Math.Min(1000, MaxBindableParametersCount / columnCount);
-        }
-        return batchSize.Value;
-    }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="reader"></param>
-    /// <returns></returns>
-    /// <exception cref="NotImplementedException"></exception>
-    private DataTable ToDataTable(
-        DbDataReader reader)
-    {
-        throw new NotImplementedException();
-    }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="dataTable"></param>
-    /// <param name="columnName"></param>
-    /// <param name="arrayBindCount"></param>
-    /// <returns></returns>
-    private object?[] GetBoundValues(
-        DataTable dataTable,
-        string columnName,
-        int arrayBindCount)
-    {
-        var values = new object?[arrayBindCount];
-        for (var rowIndex = 0; rowIndex < arrayBindCount; rowIndex++)
-        {
-            values[rowIndex] = dataTable.Rows[rowIndex][columnName] ?? DBNull.Value;
-        }
-        return values;
-    }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="dataType"></param>
-    /// <returns></returns>
-    /// <exception cref="NotImplementedException"></exception>
-    private OracleDbType ToOracleDbType(
-        Type dataType)
-    {
-        throw new NotImplementedException();
-    }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="tableName"></param>
-    /// <param name="columns"></param>
-    /// <returns></returns>
-    private string BuildInsertStatement(
-        string tableName,
-        IReadOnlyList<string> columns)
-    {
-        var columnList = string.Join(", ", columns);
-        var parameterList = string.Join(", ", columns.Select(column => ":" + column));
-        return $"INSERT INTO {tableName} ({columnList}) VALUES ({parameterList});";
-    }
-
-    #endregion
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="tableName"></param>
-    /// <param name="reader"></param>
-    /// <param name="mappings"></param>
-    /// <param name="bulkCopyTimeout"></param>
-    /// <param name="batchSize"></param>
-    /// <param name="transaction"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    public async Task<int> WriteToServerAsync(
-        string tableName,
-        DbDataReader reader,
-        IEnumerable<OracleBulkInsertMapItem> mappings,
-        int? bulkCopyTimeout,
-        int? batchSize = null,
-        OracleTransaction transaction = null,
-        CancellationToken cancellationToken = default)
-    {
-        if (reader.FieldCount == 0)
-        {
-            return 0;
-        }
-        return await WriteToServerAsync(tableName,
-            ToDataTable(reader),
-            mappings,
-            bulkCopyTimeout,
-            batchSize,
-            transaction,
-            cancellationToken);
-    }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="tableName"></param>
-    /// <param name="dataTable"></param>
-    /// <param name="mappings"></param>
-    /// <param name="bulkCopyTimeout"></param>
-    /// <param name="batchSize"></param>
-    /// <param name="transaction"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    public async Task<int> WriteToServerAsync(
-        string tableName,
-        DataTable dataTable,
-        IEnumerable<OracleBulkInsertMapItem> mappings,
-        int? bulkCopyTimeout,
-        int? batchSize = null,
-        OracleTransaction transaction = null,
-        CancellationToken cancellationToken = default)
-    {
-
-        if (dataTable.Columns.Count == 0)
-        {
-            return 0;
+            this.connection = connection;
         }
 
-        batchSize = GetBatchSize(batchSize, dataTable.Columns.Count);
-        var columnNames = dataTable.Columns.OfType<DataColumn>().Select(c => c.ColumnName).ToArray();
-        var affectedRows = 0;
+        #region Properties
 
-        for (var offset = 0; offset < dataTable.Columns.Count; offset += GetBatchSize(batchSize, dataTable.Columns.Count))
+        /// <summary>
+        ///
+        /// </summary>
+        public string DestinationTableName { get; set; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public int BulkCopyTimeout { get; set; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public int BatchSize { get; set; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public OracleTransaction Transaction { get; set; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public OracleBulkArrayBinderColumnMappingCollection ColumnMappings { get; } = new();
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="columnCount"></param>
+        /// <returns></returns>
+        private int GetEffectiveBatchSize(
+            int columnCount)
         {
-            var count = Math.Min(batchSize.Value, (dataTable.Rows.Count - offset));
+            return BatchSize > 0 ? BatchSize : Math.Min(1000, MaxBindableParametersCount / columnCount);
+        }
 
-            await using var command = connection.CreateCommand();
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private static async Task<DataTable> ToDataTableAsync(
+            IDataReader reader,
+            CancellationToken cancellationToken)
+        {
+            var dataTable = new DataTable();
 
-            command.Transaction = transaction;
-            command.BindByName = true;
-            command.ArrayBindCount = count;
-            command.CommandText = BuildInsertStatement(tableName, columnNames);
-
-            foreach (var columnName in columnNames)
+            for (var i = 0; i < reader.FieldCount; i++)
             {
-                var parameter = new OracleParameter
-                {
-                    ParameterName = columnName,
-                    OracleDbType = ToOracleDbType(dataTable.Columns[columnName].DataType),
-                    Direction = ParameterDirection.Input,
-                    Value = GetBoundValues(dataTable, columnName, count)
-                };
-
-                command.Parameters.Add(parameter);
+                dataTable.Columns.Add(reader.GetName(i), reader.GetFieldType(i) ?? typeof(object));
             }
 
-            affectedRows += await command.ExecuteNonQueryAsync(
-                cancellationToken);
+            var values = new object[reader.FieldCount];
+
+            if (reader is DbDataReader dbReader)
+            {
+                while (await dbReader.ReadAsync(cancellationToken))
+                {
+                    dbReader.GetValues(values);
+                    dataTable.Rows.Add(values);
+                }
+            }
+            else
+            {
+                while (reader.Read())
+                {
+                    reader.GetValues(values);
+                    dataTable.Rows.Add(values);
+                }
+            }
+
+            return dataTable;
         }
 
-        return affectedRows;
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="rows"></param>
+        /// <param name="columnName"></param>
+        /// <param name="offset"></param>
+        /// <param name="count"></param>
+        /// <returns></returns>
+        private static object[] GetBoundValues(
+            IReadOnlyList<DataRow> rows,
+            string columnName,
+            int offset,
+            int count)
+        {
+            var values = new object[count];
+            for (var rowIndex = 0; rowIndex < count; rowIndex++)
+            {
+                values[rowIndex] = rows[offset + rowIndex][columnName] ?? DBNull.Value;
+            }
+            return values;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dataTable"></param>
+        /// <returns></returns>
+        private IReadOnlyList<OracleBulkInsertMapItem> ResolveMappings(
+            DataTable dataTable)
+        {
+            if (ColumnMappings.Count > 0)
+            {
+                return ColumnMappings.ToArray();
+            }
+
+            return dataTable.Columns
+                .OfType<DataColumn>()
+                .Select(column => new OracleBulkInsertMapItem(column.ColumnName, column.ColumnName))
+                .ToArray();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="mappings"></param>
+        /// <returns></returns>
+        private string BuildInsertStatement(
+            IReadOnlyList<OracleBulkInsertMapItem> mappings)
+        {
+            var columnList = string.Join(", ", mappings.Select(mapping => mapping.DestinationColumn));
+            var parameterList = string.Join(", ", Enumerable.Range(0, mappings.Count).Select(i => ":p" + i));
+            return $"INSERT INTO {DestinationTableName} ({columnList}) VALUES ({parameterList})";
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="dataTable"></param>
+        /// <param name="rows"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private async Task<int> BindArrayCoreAsync(
+            DataTable dataTable,
+            IReadOnlyList<DataRow> rows,
+            CancellationToken cancellationToken)
+        {
+            if (dataTable.Columns.Count == 0 || rows.Count == 0)
+            {
+                return 0;
+            }
+
+            var mappings = ResolveMappings(dataTable);
+            var batchSize = GetEffectiveBatchSize(mappings.Count);
+            var commandText = BuildInsertStatement(mappings);
+            var affectedRows = 0;
+
+            for (var offset = 0; offset < rows.Count; offset += batchSize)
+            {
+                var count = Math.Min(batchSize, rows.Count - offset);
+
+                await using var command = connection.CreateCommand();
+
+                command.Transaction = Transaction;
+                command.BindByName = true;
+                command.ArrayBindCount = count;
+                command.CommandText = commandText;
+                if (BulkCopyTimeout > 0)
+                {
+                    command.CommandTimeout = BulkCopyTimeout;
+                }
+
+                for (var i = 0; i < mappings.Count; i++)
+                {
+                    var mapping = mappings[i];
+                    var parameter = new OracleParameter
+                    {
+                        ParameterName = "p" + i,
+                        OracleDbType = mapping.OracleDbType ?? dbTypeResolver.Resolve(dataTable.Columns[mapping.SourceColumn].DataType),
+                        Direction = ParameterDirection.Input,
+                        Value = GetBoundValues(rows, mapping.SourceColumn, offset, count)
+                    };
+
+                    command.Parameters.Add(parameter);
+                }
+
+                affectedRows += await command.ExecuteNonQueryAsync(
+                    cancellationToken);
+            }
+
+            return affectedRows;
+        }
+
+        #endregion
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<int> BindArrayAsync(
+            IDataReader reader,
+            CancellationToken cancellationToken = default)
+        {
+            if (reader.FieldCount == 0)
+            {
+                return 0;
+            }
+
+            var dataTable = await ToDataTableAsync(reader, cancellationToken);
+            var rows = dataTable.Rows.OfType<DataRow>().ToArray();
+
+            return await BindArrayCoreAsync(dataTable, rows, cancellationToken);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="dataTable"></param>
+        /// <param name="rowState"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task<int> BindArrayAsync(
+            DataTable dataTable,
+            DataRowState? rowState = null,
+            CancellationToken cancellationToken = default)
+        {
+            var rowsQuery = dataTable.Rows.OfType<DataRow>();
+            if (rowState.HasValue)
+            {
+                rowsQuery = rowsQuery.Where(row => row.RowState == rowState);
+            }
+
+            return BindArrayCoreAsync(dataTable, rowsQuery.ToArray(), cancellationToken);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public void Dispose()
+        {
+        }
     }
 }

--- a/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/OracleBulkArrayBinder.cs
+++ b/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/OracleBulkArrayBinder.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Oracle.ManagedDataAccess.Client;
+using RepoDb;
+using RepoDb.Extensions;
 using RepoDb.Resolvers;
 
 
@@ -85,29 +87,24 @@ namespace RepoDb.Oracle.BulkOperations
             CancellationToken cancellationToken)
         {
             var dataTable = new DataTable();
+            var fieldCount = reader.FieldCount;
 
-            for (var i = 0; i < reader.FieldCount; i++)
+            for (var i = 0; i < fieldCount; i++)
             {
-                dataTable.Columns.Add(reader.GetName(i), reader.GetFieldType(i) ?? typeof(object));
+                var fieldType = reader.GetFieldType(i) ?? typeof(object);
+                dataTable.Columns.Add(reader.GetName(i), Nullable.GetUnderlyingType(fieldType) ?? fieldType);
             }
 
-            var values = new object[reader.FieldCount];
+            var dbReader = reader as DbDataReader;
 
-            if (reader is DbDataReader dbReader)
+            while (dbReader != null ? await dbReader.ReadAsync(cancellationToken) : reader.Read())
             {
-                while (await dbReader.ReadAsync(cancellationToken))
+                var values = new object[fieldCount];
+                for (var i = 0; i < fieldCount; i++)
                 {
-                    dbReader.GetValues(values);
-                    dataTable.Rows.Add(values);
+                    values[i] = reader.GetValue(i) ?? DBNull.Value;
                 }
-            }
-            else
-            {
-                while (reader.Read())
-                {
-                    reader.GetValues(values);
-                    dataTable.Rows.Add(values);
-                }
+                dataTable.Rows.Add(values);
             }
 
             return dataTable;
@@ -136,7 +133,7 @@ namespace RepoDb.Oracle.BulkOperations
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="dataTable"></param>
         /// <returns></returns>
@@ -157,6 +154,66 @@ namespace RepoDb.Oracle.BulkOperations
         /// <summary>
         /// 
         /// </summary>
+        /// <param name="reader"></param>
+        /// <returns></returns>
+        private IReadOnlyList<OracleBulkInsertMapItem> ResolveMappings(
+            IDataReader reader)
+        {
+            if (ColumnMappings.Count == 0)
+            {
+                var identityMappings = new OracleBulkInsertMapItem[reader.FieldCount];
+                for (var i = 0; i < reader.FieldCount; i++)
+                {
+                    var name = reader.GetName(i);
+                    identityMappings[i] = new OracleBulkInsertMapItem(name, name);
+                }
+                return identityMappings;
+            }
+
+            var mappings = new OracleBulkInsertMapItem[ColumnMappings.Count];
+            for (var i = 0; i < ColumnMappings.Count; i++)
+            {
+                var mapping = ColumnMappings[i];
+                var ordinal = reader.GetOrdinal(mapping.SourceColumn);
+                var canonicalSourceColumn = reader.GetName(ordinal);
+                mappings[i] = new OracleBulkInsertMapItem(canonicalSourceColumn, mapping.DestinationColumn, mapping.OracleDbType);
+            }
+            return mappings;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="mappings"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private async Task<IReadOnlyList<OracleBulkInsertMapItem>> ExcludeIdentityColumnAsync(
+            IReadOnlyList<OracleBulkInsertMapItem> mappings,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(DestinationTableName))
+            {
+                return mappings;
+            }
+
+            var dbSetting = connection.GetDbSetting();
+            var unquotedTableName = DestinationTableName.AsUnquoted(true, dbSetting);
+            var dbFields = await DbFieldCache.GetAsync(connection, unquotedTableName, Transaction, cancellationToken);
+            var identity = dbFields?.GetIdentity();
+
+            if (identity == null)
+            {
+                return mappings;
+            }
+
+            return mappings
+                .Where(mapping => !string.Equals(mapping.DestinationColumn.AsUnquoted(true, dbSetting), identity.Name, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
         /// <param name="mappings"></param>
         /// <returns></returns>
         private string BuildInsertStatement(
@@ -172,19 +229,25 @@ namespace RepoDb.Oracle.BulkOperations
         /// </summary>
         /// <param name="dataTable"></param>
         /// <param name="rows"></param>
+        /// <param name="mappings"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         private async Task<int> BindArrayCoreAsync(
             DataTable dataTable,
             IReadOnlyList<DataRow> rows,
+            IReadOnlyList<OracleBulkInsertMapItem> mappings,
             CancellationToken cancellationToken)
         {
-            if (dataTable.Columns.Count == 0 || rows.Count == 0)
+            if (dataTable.Columns.Count == 0 || rows.Count == 0 || mappings.Count == 0)
             {
                 return 0;
             }
 
-            var mappings = ResolveMappings(dataTable);
+            mappings = await ExcludeIdentityColumnAsync(mappings, cancellationToken);
+            if (mappings.Count == 0)
+            {
+                return 0;
+            }
             var batchSize = GetEffectiveBatchSize(mappings.Count);
             var commandText = BuildInsertStatement(mappings);
             var affectedRows = 0;
@@ -214,7 +277,6 @@ namespace RepoDb.Oracle.BulkOperations
                         Direction = ParameterDirection.Input,
                         Value = GetBoundValues(rows, mapping.SourceColumn, offset, count)
                     };
-
                     command.Parameters.Add(parameter);
                 }
 
@@ -242,10 +304,11 @@ namespace RepoDb.Oracle.BulkOperations
                 return 0;
             }
 
+            var mappings = ResolveMappings(reader);
             var dataTable = await ToDataTableAsync(reader, cancellationToken);
             var rows = dataTable.Rows.OfType<DataRow>().ToArray();
 
-            return await BindArrayCoreAsync(dataTable, rows, cancellationToken);
+            return await BindArrayCoreAsync(dataTable, rows, mappings, cancellationToken);
         }
 
         /// <summary>
@@ -260,13 +323,14 @@ namespace RepoDb.Oracle.BulkOperations
             DataRowState? rowState = null,
             CancellationToken cancellationToken = default)
         {
+            var mappings = ResolveMappings(dataTable);
             var rowsQuery = dataTable.Rows.OfType<DataRow>();
             if (rowState.HasValue)
             {
                 rowsQuery = rowsQuery.Where(row => row.RowState == rowState);
             }
 
-            return BindArrayCoreAsync(dataTable, rowsQuery.ToArray(), cancellationToken);
+            return BindArrayCoreAsync(dataTable, rowsQuery.ToArray(), mappings, cancellationToken);
         }
 
         /// <summary>

--- a/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/OracleBulkArrayBinderColumnMappingCollection.cs
+++ b/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/OracleBulkArrayBinderColumnMappingCollection.cs
@@ -6,14 +6,14 @@ namespace RepoDb.Oracle.BulkOperations
     /// A collection used to define the source-to-destination column mappings of an <see cref="OracleBulkArrayBinder"/>,
     /// mirroring the shape of <see cref="OracleBulkCopyColumnMappingCollection"/>.
     /// </summary>
-    internal sealed class OracleBulkArrayBinderColumnMappingCollection : Collection<OracleBulkInsertMapItem>
+    public sealed class OracleBulkArrayBinderColumnMappingCollection : Collection<OracleBulkInsertMapItem>
     {
         /// <summary>
-        ///
+        /// Adds a source-to-destination column mapping.
         /// </summary>
-        /// <param name="sourceColumn"></param>
-        /// <param name="destinationColumn"></param>
-        /// <returns></returns>
+        /// <param name="sourceColumn">The source column or property name.</param>
+        /// <param name="destinationColumn">The destination table's column name.</param>
+        /// <returns>The added mapping.</returns>
         public OracleBulkInsertMapItem Add(
             string sourceColumn,
             string destinationColumn)

--- a/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/OracleBulkArrayBinderColumnMappingCollection.cs
+++ b/RepoDb.Extensions/RepoDb.Oracle.BulkOperations/RepoDb.Oracle.BulkOperations/OracleBulkArrayBinderColumnMappingCollection.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.ObjectModel;
+
+namespace RepoDb.Oracle.BulkOperations
+{
+    /// <summary>
+    /// A collection used to define the source-to-destination column mappings of an <see cref="OracleBulkArrayBinder"/>,
+    /// mirroring the shape of <see cref="OracleBulkCopyColumnMappingCollection"/>.
+    /// </summary>
+    internal sealed class OracleBulkArrayBinderColumnMappingCollection : Collection<OracleBulkInsertMapItem>
+    {
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="sourceColumn"></param>
+        /// <param name="destinationColumn"></param>
+        /// <returns></returns>
+        public OracleBulkInsertMapItem Add(
+            string sourceColumn,
+            string destinationColumn)
+        {
+            var mapping = new OracleBulkInsertMapItem(sourceColumn, destinationColumn);
+            Add(mapping);
+            return mapping;
+        }
+    }
+}

--- a/RepoDb.Oracle/RepoDb.Oracle/DbHelpers/OracleDbHelper.cs
+++ b/RepoDb.Oracle/RepoDb.Oracle/DbHelpers/OracleDbHelper.cs
@@ -111,15 +111,15 @@ namespace RepoDb.DbHelpers
             CancellationToken cancellationToken = default)
         {
             return new DbField(await reader.GetFieldValueAsync<string>(0, cancellationToken),
-                !await reader.IsDBNullAsync(1, cancellationToken) && await reader.GetFieldValueAsync<int>(1, cancellationToken) == 1,
-                !await reader.IsDBNullAsync(2, cancellationToken) && await reader.GetFieldValueAsync<int>(2, cancellationToken) == 1,
-                !await reader.IsDBNullAsync(3, cancellationToken) && await reader.GetFieldValueAsync<int>(3, cancellationToken) == 1,
+                !await reader.IsDBNullAsync(1, cancellationToken) && Convert.ToInt32(await reader.GetFieldValueAsync<decimal>(1, cancellationToken)) == 1,
+                !await reader.IsDBNullAsync(2, cancellationToken) && Convert.ToInt32(await reader.GetFieldValueAsync<decimal>(2, cancellationToken)) == 1,
+                !await reader.IsDBNullAsync(3, cancellationToken) && Convert.ToInt32(await reader.GetFieldValueAsync<decimal>(3, cancellationToken)) == 1,
                 await reader.IsDBNullAsync(4, cancellationToken) ? DbTypeResolver.Resolve("varchar2") : DbTypeResolver.Resolve(await reader.GetFieldValueAsync<string>(4, cancellationToken)),
                 await reader.IsDBNullAsync(5, cancellationToken) ? 0 : Convert.ToInt32(await reader.GetFieldValueAsync<decimal>(5, cancellationToken)),
                 await reader.IsDBNullAsync(6, cancellationToken) ? (byte?)0 : Convert.ToByte(await reader.GetFieldValueAsync<decimal>(6, cancellationToken)),
                 await reader.IsDBNullAsync(7, cancellationToken) ? (byte?)0 : Convert.ToByte(await reader.GetFieldValueAsync<decimal>(7, cancellationToken)),
                 await reader.IsDBNullAsync(4, cancellationToken) ? "varchar2" : await reader.GetFieldValueAsync<string>(4, cancellationToken),
-                !await reader.IsDBNullAsync(8, cancellationToken) && await reader.GetFieldValueAsync<int>(8, cancellationToken) == 1,
+                !await reader.IsDBNullAsync(8, cancellationToken) && Convert.ToInt32(await reader.GetFieldValueAsync<decimal>(8, cancellationToken)) == 1,
                 "ORACLE");
         }
 

--- a/RepoDb.Oracle/RepoDb.Oracle/Resolvers/TypeToOracleDbTypeResolver.cs
+++ b/RepoDb.Oracle/RepoDb.Oracle/Resolvers/TypeToOracleDbTypeResolver.cs
@@ -1,0 +1,52 @@
+using Oracle.ManagedDataAccess.Client;
+using RepoDb.Interfaces;
+using System;
+using System.Collections.Generic;
+
+namespace RepoDb.Resolvers
+{
+    /// <summary>
+    /// A class used to resolve the <see cref="Type"/> into its equivalent Oracle database type.
+    /// </summary>
+    public class TypeToOracleDbTypeResolver : IResolver<Type, OracleDbType>
+    {
+        /*
+         * Taken:
+         * https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Data-Types.html
+         */
+
+        private static readonly Dictionary<Type, OracleDbType> typeMap = new()
+        {
+            { typeof(string), OracleDbType.NVarchar2 },
+            { typeof(char), OracleDbType.NChar },
+            { typeof(bool), OracleDbType.Int32 },
+            { typeof(byte), OracleDbType.Byte },
+            { typeof(sbyte), OracleDbType.Int16 },
+            { typeof(short), OracleDbType.Int16 },
+            { typeof(ushort), OracleDbType.Int32 },
+            { typeof(int), OracleDbType.Int32 },
+            { typeof(uint), OracleDbType.Int64 },
+            { typeof(long), OracleDbType.Int64 },
+            { typeof(ulong), OracleDbType.Decimal },
+            { typeof(float), OracleDbType.BinaryFloat },
+            { typeof(double), OracleDbType.BinaryDouble },
+            { typeof(decimal), OracleDbType.Decimal },
+            { typeof(DateTime), OracleDbType.TimeStamp },
+            { typeof(DateTimeOffset), OracleDbType.TimeStampTZ },
+            { typeof(TimeSpan), OracleDbType.IntervalDS },
+            { typeof(Guid), OracleDbType.Raw },
+            { typeof(byte[]), OracleDbType.Blob },
+        };
+
+        /// <summary>
+        /// Returns the equivalent <see cref="OracleDbType"/> of the .NET CLR Types.
+        /// </summary>
+        /// <param name="type">The .NET CLR type.</param>
+        /// <returns>The equivalent Oracle database type.</returns>
+        public virtual OracleDbType Resolve(Type type)
+        {
+            var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+            return typeMap.TryGetValue(underlyingType, out var oracleDbType) ? oracleDbType : OracleDbType.NVarchar2;
+        }
+    }
+}


### PR DESCRIPTION
## Replace the `Task.Run` bulk-write hack with a true async array binder

Ref: #1283

### Why

`OracleBulkCopy` has no async `WriteToServer` — ODP.NET simply doesn't offer one. The async bulk
operations (`BulkInsertAsync`, `BulkDeleteAsync`, `BulkMergeAsync`, `BulkUpdateAsync`) worked around
this by wrapping the synchronous `bulkCopy.WriteToServer(...)` call in `Task.Run(...)`, which just
moves the blocking I/O onto a thread-pool thread instead of actually being asynchronous.

### What changed

- **`OracleBulkArrayBinder`** (new, now public): an async alternative to `OracleBulkCopy` that
  batches rows via `OracleCommand.ArrayBindCount` + `ExecuteNonQueryAsync`, instead of the
  synchronous bulk-copy API. Mirrors `OracleBulkCopy`'s own shape (`DestinationTableName`,
  `BulkCopyTimeout`, `BatchSize`, `ColumnMappings`) so it drops into the existing call sites with
  minimal churn. Supports both an `IDataReader` source and a `DataTable` source.
- **`OracleBulkArrayBinderColumnMappingCollection`** (new): the `ColumnMappings` collection type,
  with an `Add(sourceColumn, destinationColumn)` convenience overload.
- **`TypeToOracleDbTypeResolver`** (new, in `RepoDb.Oracle`): resolves a .NET CLR type (including
  `Nullable<T>`) to its `OracleDbType`, used to infer each array-bound parameter's type when a
  mapping doesn't pin one explicitly.
- **`Base/WriteToServer.cs`**: all three async internal write paths (`TEntity`, `DataTable`,
  `IDataReader`) now go through `OracleBulkArrayBinder.BindArrayAsync` instead of
  `Task.Run(() => bulkCopy.WriteToServer(...))`. The synchronous paths are untouched.
- **`DataEntityDataReader<TEntity>`** (`RepoDb.Core`): fixed `GetFieldType`/`GetDataTypeName` to
  branch on dictionary-vs-entity mode like every other indexed accessor on the class already did —
  they were unconditionally indexing the entity `Properties` list, which is empty for
  dictionary/`ExpandoObject`-backed readers.
- **`OracleDbHelper.ReaderToDbFieldAsync`** (`RepoDb.Oracle`): four boolean-style columns
  (`IsPrimary`, `IsIdentity`, `IsNullable`, `HasDefaultValue`) were read via
  `GetFieldValueAsync<int>`, which requires an exact CLR type match; Oracle returns them as
  `decimal`. Switched to `GetFieldValueAsync<decimal>` + `Convert.ToInt32`, matching the pattern
  already used a few lines down for `ColumnSize`/`Precision`/`Scale`.

### Bugs found and fixed along the way

Several of these only surfaced once the async path started exercising code that the old
`Task.Run`-wrapped sync path never actually hit:

- Batching loop iterated by column count instead of row count, and `GetBoundValues` always read
  rows `0..count-1` regardless of batch offset — together these silently dropped or duplicated rows
  past the first batch.
- `DataTable` column type couldn't be `Nullable<T>` (`DataSet does not support System.Nullable<>`)
  for nullable entity properties.
- Bulk-reading a row via `IDataReader.GetValues(object[])` routed through
  `ClassExpression.GetPropertiesAndValues`, which throws for anonymous-typed entities; switched to
  reading column-by-column via `GetValue(i)`.
- `[Map]`-attributed entity properties: `SourceColumn` in an explicit mapping is documented to
  accept either the raw property name or the mapped name, but only `GetOrdinal` (not `GetName`)
  actually resolves both — mapping resolution now goes through the reader's `GetOrdinal` instead of
  a direct string lookup against the materialized `DataTable`.
- Direct-to-real-table inserts (no staging) were explicitly binding the CLR default (`0`) for a
  `GENERATED BY DEFAULT AS IDENTITY` column on every row, since Oracle only auto-generates a value
  when the column is *omitted* from the insert list. `OracleBulkArrayBinder` now excludes the
  destination table's identity column from the generated statement.
- That identity lookup initially went through the process-wide, never-invalidated `DbFieldCache` —
  unsafe here because staging/pseudo tables are created and dropped under a deterministic, reused
  name (no per-call uniqueifier), so a later call could get another call's stale cached schema back.
  Switched to querying `IDbHelper.GetFieldsAsync` directly for this specific lookup.

### Testing

- No integration test files changed — every fix above was validated by running the existing
  `RepoDb.Oracle.BulkOperations.IntegrationTests` suite against a live Oracle instance until it was
  green, plus isolated repros (outside the Oracle stack) for the nullable-column, anonymous-object,
  and `[Map]`-attribute mapping-resolution bugs specifically.
- `RepoDb.Core`, `RepoDb.Oracle`, and `RepoDb.Oracle.BulkOperations` all build clean.

### Follow-ups (out of scope here)

- `BulkDeleteBaseViaKeyValues(Async)` stages only a single key-value column into a pseudo table
  that's still a full clone of the source table's schema — if that clone inherits a `NOT NULL`
  constraint on a non-key column, that path could fail independently of anything in this PR.
- The sync (`OracleBulkCopy`-based) write path shares the same default column-mapping helper
  (`GetDefaultMappingsForDataReader`) and hasn't been re-verified against the identity-column and
  `[Map]`-attribute scenarios above; worth a pass if it hasn't been exercised recently.
