### PR TITLE
Fixed the failing Integration Tests after the support to Db2BulkArrayBinder.

### DIFF
--- a/RepoDb.Db2/RepoDb.Db2/Resolvers/Db2DbTypeNameToDb2TypeResolver.cs
+++ b/RepoDb.Db2/RepoDb.Db2/Resolvers/Db2DbTypeNameToDb2TypeResolver.cs
@@ -1,0 +1,67 @@
+using IBM.Data.Db2;
+using RepoDb.Interfaces;
+using System;
+
+namespace RepoDb.Resolvers
+{
+    /// <summary>
+    /// A class used to resolve the raw Db2 database type name (e.g. as returned by
+    /// <c>SYSCAT.COLUMNS.TYPENAME</c>) into its equivalent <see cref="DB2Type"/>.
+    /// </summary>
+    public class Db2DbTypeNameToDb2TypeResolver : IResolver<string, DB2Type>
+    {
+        /*
+         * Taken:
+         * https://www.ibm.com/docs/en/db2/11.5?topic=catalog-syscatcolumns-view (TYPENAME domain)
+         * https://www.ibm.com/docs/en/db2/11.5?topic=elements-data-types (SQL data types)
+         */
+
+        /// <summary>
+        /// Returns the equivalent <see cref="DB2Type"/> of the database type name.
+        /// </summary>
+        /// <param name="dbTypeName">The name of the database type (e.g. as returned by SYSCAT.COLUMNS.TYPENAME).</param>
+        /// <returns>The equivalent <see cref="DB2Type"/>.</returns>
+        public virtual DB2Type Resolve(string dbTypeName)
+        {
+            if (dbTypeName == null)
+            {
+                throw new NullReferenceException("The DB Type name must not be null.");
+            }
+
+            var name = dbTypeName.ToLowerInvariant().Trim();
+
+            if (name.StartsWith("timestamp"))
+            {
+                return name.Contains("with time zone") ? DB2Type.TimeStampWithTimeZone : DB2Type.Timestamp;
+            }
+
+            return name switch
+            {
+                "smallint" => DB2Type.SmallInt,
+                "integer" or "int" => DB2Type.Integer,
+                "bigint" => DB2Type.BigInt,
+                "decimal" or "numeric" or "dec" => DB2Type.Decimal,
+                "decfloat" => DB2Type.DecimalFloat,
+                "real" => DB2Type.Real,
+                "double" or "double precision" or "float" => DB2Type.Double,
+                "char" or "character" => DB2Type.Char,
+                "varchar" => DB2Type.VarChar,
+                "long varchar" => DB2Type.LongVarChar,
+                "graphic" => DB2Type.Graphic,
+                "vargraphic" => DB2Type.VarGraphic,
+                "long vargraphic" => DB2Type.LongVarGraphic,
+                "clob" => DB2Type.Clob,
+                "dbclob" => DB2Type.DbClob,
+                "blob" => DB2Type.Blob,
+                "binary" => DB2Type.Binary,
+                "varbinary" => DB2Type.VarBinary,
+                "xml" => DB2Type.Xml,
+                "rowid" => DB2Type.RowId,
+                "date" => DB2Type.Date,
+                "time" => DB2Type.Time,
+                "boolean" => DB2Type.Boolean,
+                _ => DB2Type.VarChar,
+            };
+        }
+    }
+}

--- a/RepoDb.Db2/RepoDb.Db2/Resolvers/TypeToDb2TypeResolver.cs
+++ b/RepoDb.Db2/RepoDb.Db2/Resolvers/TypeToDb2TypeResolver.cs
@@ -1,0 +1,52 @@
+using IBM.Data.Db2;
+using RepoDb.Interfaces;
+using System;
+using System.Collections.Generic;
+
+namespace RepoDb.Resolvers
+{
+    /// <summary>
+    /// A class used to resolve the <see cref="Type"/> into its equivalent Db2 database type.
+    /// </summary>
+    public class TypeToDb2TypeResolver : IResolver<Type, DB2Type>
+    {
+        /*
+         * Taken:
+         * https://www.ibm.com/docs/en/db2/11.5?topic=elements-data-types
+         */
+
+        private static readonly Dictionary<Type, DB2Type> typeMap = new()
+        {
+            { typeof(string), DB2Type.VarChar },
+            { typeof(char), DB2Type.Char },
+            { typeof(bool), DB2Type.SmallInt },
+            { typeof(byte), DB2Type.Byte },
+            { typeof(sbyte), DB2Type.SmallInt },
+            { typeof(short), DB2Type.SmallInt },
+            { typeof(ushort), DB2Type.Integer },
+            { typeof(int), DB2Type.Integer },
+            { typeof(uint), DB2Type.BigInt },
+            { typeof(long), DB2Type.BigInt },
+            { typeof(ulong), DB2Type.Decimal },
+            { typeof(float), DB2Type.Real },
+            { typeof(double), DB2Type.Double },
+            { typeof(decimal), DB2Type.Decimal },
+            { typeof(DateTime), DB2Type.Timestamp },
+            { typeof(DateTimeOffset), DB2Type.TimeStampWithTimeZone },
+            { typeof(TimeSpan), DB2Type.Time },
+            { typeof(Guid), DB2Type.Binary },
+            { typeof(byte[]), DB2Type.Blob },
+        };
+
+        /// <summary>
+        /// Returns the equivalent <see cref="DB2Type"/> of the .NET CLR Types.
+        /// </summary>
+        /// <param name="type">The .NET CLR type.</param>
+        /// <returns>The equivalent Db2 database type.</returns>
+        public virtual DB2Type Resolve(Type type)
+        {
+            var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+            return typeMap.TryGetValue(underlyingType, out var db2Type) ? db2Type : DB2Type.VarChar;
+        }
+    }
+}

--- a/RepoDb.Extensions/RepoDb.Db2.BulkOperations/RepoDb.Db2.BulkOperations/Base/WriteToServer.cs
+++ b/RepoDb.Extensions/RepoDb.Db2.BulkOperations/RepoDb.Db2.BulkOperations/Base/WriteToServer.cs
@@ -146,9 +146,8 @@ namespace RepoDb
         {
             await connection.EnsureOpenAsync(cancellationToken);
             using var reader = new DataEntityDataReader<TEntity>(entities);
-            var (bulkCopy, filteredReader) = CreateBulkCopyForDataReader(connection, tableName, reader, mappings, bulkCopyOptions, bulkCopyTimeout, transaction, excludeField);
-            await Task.Run(async () => bulkCopy.WriteToServer(filteredReader), cancellationToken);
-            return entities != null ? entities.Count() : 0;
+            using var arrayBinder = CreateDb2BulkArrayBinder(connection, tableName, reader, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize, transaction, excludeField);
+            return await arrayBinder.WriteToServerAsync(reader, cancellationToken);
         }
 
         /// <summary>
@@ -177,10 +176,8 @@ namespace RepoDb
             Field excludeField = null)
         {
             await connection.EnsureOpenAsync(cancellationToken);
-            var bulkCopy = CreateBulkCopyForDataTable(connection, tableName, table, mappings, bulkCopyOptions, bulkCopyTimeout, excludeField);
-            var rows = GetDataRows(table, rowState)?.ToArray();
-            await Task.Run(async () => bulkCopy.WriteToServer(rows), cancellationToken);
-            return rows != null ? rows.Length : 0;
+            using var arrayBinder = CreateDb2BulkArrayBinder(connection, tableName, table, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize, excludeField);
+            return await arrayBinder.WriteToServerAsync(table, rowState, cancellationToken);
         }
 
         /// <summary>
@@ -209,14 +206,8 @@ namespace RepoDb
             Field excludeField = null)
         {
             await connection.EnsureOpenAsync(cancellationToken);
-            return await Task.Run(() => // No underlying 'Async' equivalent for 'WriteToServerInternal'
-            {
-                var countingReader = new CountingDataReader(reader);
-                var (bulkCopy, filteredReader) = CreateBulkCopyForDataReader(connection, tableName, countingReader, mappings, bulkCopyOptions, bulkCopyTimeout, transaction, excludeField);
-                bulkCopy.WriteToServer(filteredReader);
-                return countingReader.Count;
-            },
-            cancellationToken);
+            using var arrayBinder = CreateDb2BulkArrayBinder(connection, tableName, reader, mappings, bulkCopyOptions, bulkCopyTimeout, batchSize, transaction, excludeField);
+            return await arrayBinder.WriteToServerAsync(reader, cancellationToken);
         }
 
         #endregion
@@ -452,6 +443,110 @@ namespace RepoDb
                     yield return new Db2BulkInsertMapItem(columnName, dbField.Name);
                 }
             }
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <param name="tableName"></param>
+        /// <param name="table"></param>
+        /// <param name="mappings"></param>
+        /// <param name="bulkCopyOptions"></param>
+        /// <param name="bulkCopyTimeout"></param>
+        /// <param name="batchSize"></param>
+        /// <param name="excludeField"></param>
+        /// <returns></returns>
+        private static Db2BulkArrayBinder CreateDb2BulkArrayBinder(DB2Connection connection,
+            string tableName,
+            DataTable table,
+            IEnumerable<Db2BulkInsertMapItem> mappings,
+            DB2BulkCopyOptions bulkCopyOptions,
+            int? bulkCopyTimeout,
+            int? batchSize,
+            Field excludeField = null)
+        {
+            var dbSetting = connection.GetDbSetting();
+            var arrayBinder = new Db2BulkArrayBinder(connection)
+            {
+                DestinationTableName = tableName.AsQuoted(true, dbSetting)
+            };
+            if (bulkCopyTimeout.HasValue)
+            {
+                arrayBinder.BulkCopyTimeout = bulkCopyTimeout.Value;
+            }
+            if (batchSize.HasValue)
+            {
+                arrayBinder.BatchSize = batchSize.Value;
+            }
+            if (mappings != null)
+            {
+                foreach (var mapping in mappings)
+                {
+                    arrayBinder.ColumnMappings.Add(mapping.SourceColumn, mapping.DestinationColumn.AsQuoted(true, dbSetting));
+                }
+            }
+            else
+            {
+                var destinationFields = DbFieldCache.Get(connection, tableName, null);
+                foreach (DataColumn column in table.Columns)
+                {
+                    if (excludeField != null && string.Equals(column.ColumnName, excludeField.Name, System.StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+                    if (destinationFields?.GetByUnquotedName(column.ColumnName.AsUnquoted(true, dbSetting)) == null)
+                    {
+                        continue;
+                    }
+                    arrayBinder.ColumnMappings.Add(column.ColumnName, column.ColumnName.AsQuoted(true, dbSetting));
+                }
+            }
+            return arrayBinder;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <param name="tableName"></param>
+        /// <param name="reader"></param>
+        /// <param name="mappings"></param>
+        /// <param name="bulkCopyOptions"></param>
+        /// <param name="bulkCopyTimeout"></param>
+        /// <param name="batchSize"></param>
+        /// <param name="transaction"></param>
+        /// <param name="excludeField"></param>
+        /// <returns></returns>
+        private static Db2BulkArrayBinder CreateDb2BulkArrayBinder(DB2Connection connection,
+            string tableName,
+            IDataReader reader,
+            IEnumerable<Db2BulkInsertMapItem> mappings,
+            DB2BulkCopyOptions bulkCopyOptions,
+            int? bulkCopyTimeout,
+            int? batchSize,
+            DB2Transaction transaction,
+            Field excludeField = null)
+        {
+            var dbSetting = connection.GetDbSetting();
+            var arrayBinder = new Db2BulkArrayBinder(connection)
+            {
+                DestinationTableName = tableName.AsQuoted(true, dbSetting),
+                Transaction = transaction
+            };
+            if (bulkCopyTimeout.HasValue)
+            {
+                arrayBinder.BulkCopyTimeout = bulkCopyTimeout.Value;
+            }
+            if (batchSize.HasValue)
+            {
+                arrayBinder.BatchSize = batchSize.Value;
+            }
+            foreach (var mapping in mappings ?? GetDefaultMappingsForDataReader(connection, tableName, reader, transaction, excludeField))
+            {
+                arrayBinder.ColumnMappings.Add(mapping.SourceColumn, mapping.DestinationColumn.AsQuoted(true, dbSetting));
+            }
+            return arrayBinder;
         }
 
         /// <summary>

--- a/RepoDb.Extensions/RepoDb.Db2.BulkOperations/RepoDb.Db2.BulkOperations/Db2BulkArrayBinder.cs
+++ b/RepoDb.Extensions/RepoDb.Db2.BulkOperations/RepoDb.Db2.BulkOperations/Db2BulkArrayBinder.cs
@@ -1,0 +1,371 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using IBM.Data.Db2;
+using RepoDb.Extensions;
+using RepoDb.Resolvers;
+
+namespace RepoDb.Db2.BulkOperations
+{
+    /// <summary>
+    /// Array-bind based alternative to <see cref="Db2BulkCopy"/> for bulk insert huge amount of data with true asynchronous capability.
+    /// </summary>
+    public class Db2BulkArrayBinder : IDisposable
+    {
+        private const int MaxBindableParametersCount = 32_767;
+        private static readonly TypeToDb2TypeResolver dbTypeResolver = new();
+        private static readonly Db2DbTypeNameToDb2TypeResolver nativeTypeResolver = new();
+        private readonly DB2Connection connection;
+
+        /// <summary>
+        /// Creates a new instance bound to <paramref name="connection"/>.
+        /// </summary>
+        /// <param name="connection">The connection to bind array inserts against.</param>
+        public Db2BulkArrayBinder(DB2Connection connection)
+        {
+            this.connection = connection;
+        }
+
+        #region Properties
+
+        /// <summary>
+        /// Gets or sets the target table name.
+        /// </summary>
+        public string DestinationTableName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the command timeout, in seconds. Zero uses the provider default.
+        /// </summary>
+        public int BulkCopyTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of rows inserted per multi-row <c>VALUES</c> batch. Zero auto-sizes it from the column count.
+        /// </summary>
+        public int BatchSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the transaction each batch is executed under.
+        /// </summary>
+        public DB2Transaction Transaction { get; set; }
+
+        /// <summary>
+        /// Gets the source-to-destination column mappings. Empty maps every source column to itself.
+        /// </summary>
+        public Db2BulkArrayBinderColumnMappingCollection ColumnMappings { get; } = new();
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="columnCount"></param>
+        /// <returns></returns>
+        private int GetEffectiveBatchSize(
+            int columnCount)
+        {
+            return BatchSize > 0 ? BatchSize : Math.Min(1000, MaxBindableParametersCount / columnCount);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private static async Task<DataTable> ToDataTableAsync(
+            IDataReader reader,
+            CancellationToken cancellationToken)
+        {
+            var dataTable = new DataTable();
+            var fieldCount = reader.FieldCount;
+
+            for (var i = 0; i < fieldCount; i++)
+            {
+                var fieldType = reader.GetFieldType(i) ?? typeof(object);
+                dataTable.Columns.Add(reader.GetName(i), Nullable.GetUnderlyingType(fieldType) ?? fieldType);
+            }
+
+            var dbReader = reader as DbDataReader;
+
+            while (dbReader != null ? await dbReader.ReadAsync(cancellationToken) : reader.Read())
+            {
+                var values = new object[fieldCount];
+                for (var i = 0; i < fieldCount; i++)
+                {
+                    values[i] = reader.GetValue(i) ?? DBNull.Value;
+                }
+                dataTable.Rows.Add(values);
+            }
+
+            return dataTable;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="dataTable"></param>
+        /// <returns></returns>
+        private IReadOnlyList<Db2BulkInsertMapItem> ResolveMappings(
+            DataTable dataTable)
+        {
+            if (ColumnMappings.Count > 0)
+            {
+                return ColumnMappings.ToArray();
+            }
+
+            return dataTable.Columns
+                .OfType<DataColumn>()
+                .Select(column => new Db2BulkInsertMapItem(column.ColumnName, column.ColumnName))
+                .ToArray();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <returns></returns>
+        private IReadOnlyList<Db2BulkInsertMapItem> ResolveMappings(
+            IDataReader reader)
+        {
+            if (ColumnMappings.Count == 0)
+            {
+                var identityMappings = new Db2BulkInsertMapItem[reader.FieldCount];
+                for (var i = 0; i < reader.FieldCount; i++)
+                {
+                    var name = reader.GetName(i);
+                    identityMappings[i] = new Db2BulkInsertMapItem(name, name);
+                }
+                return identityMappings;
+            }
+
+            var mappings = new Db2BulkInsertMapItem[ColumnMappings.Count];
+            for (var i = 0; i < ColumnMappings.Count; i++)
+            {
+                var mapping = ColumnMappings[i];
+                var ordinal = reader.GetOrdinal(mapping.SourceColumn);
+                var canonicalSourceColumn = reader.GetName(ordinal);
+                mappings[i] = new Db2BulkInsertMapItem(canonicalSourceColumn, mapping.DestinationColumn, mapping.DB2Type);
+            }
+            return mappings;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private async Task<DbFieldCollection> GetDbFieldsAsync(
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(DestinationTableName))
+            {
+                return null;
+            }
+
+            var dbSetting = connection.GetDbSetting();
+            var unquotedTableName = DestinationTableName.AsUnquoted(true, dbSetting);
+            var dbFieldList = await connection.GetDbHelper().GetFieldsAsync(connection, unquotedTableName, Transaction, cancellationToken);
+            return new DbFieldCollection(dbFieldList, dbSetting);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="mappings"></param>
+        /// <param name="dbFields"></param>
+        /// <returns></returns>
+        private IReadOnlyList<Db2BulkInsertMapItem> ExcludeIdentityColumn(
+            IReadOnlyList<Db2BulkInsertMapItem> mappings,
+            DbFieldCollection dbFields)
+        {
+            var identity = dbFields?.GetIdentity();
+
+            if (identity == null)
+            {
+                return mappings;
+            }
+
+            var dbSetting = connection.GetDbSetting();
+            return mappings
+                .Where(mapping => !string.Equals(mapping.DestinationColumn.AsUnquoted(true, dbSetting), identity.Name, StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="dbFields"></param>
+        /// <param name="dbSetting"></param>
+        /// <param name="destinationColumn"></param>
+        /// <param name="sourceType"></param>
+        /// <returns></returns>
+        private DB2Type ResolveDb2Type(
+            DbFieldCollection dbFields,
+            RepoDb.Interfaces.IDbSetting dbSetting,
+            string destinationColumn,
+            Type sourceType)
+        {
+            if (sourceType == typeof(byte[]))
+            {
+                var destinationField = dbFields?.GetByUnquotedName(destinationColumn.AsUnquoted(true, dbSetting));
+                if (destinationField?.DatabaseType != null)
+                {
+                    return nativeTypeResolver.Resolve(destinationField.DatabaseType);
+                }
+            }
+
+            return dbTypeResolver.Resolve(sourceType);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="mappings"></param>
+        /// <param name="rowCount"></param>
+        /// <returns></returns>
+        private string BuildInsertStatement(
+            IReadOnlyList<Db2BulkInsertMapItem> mappings,
+            int rowCount)
+        {
+            var columnList = string.Join(", ", mappings.Select(mapping => mapping.DestinationColumn));
+            var parameterGroup = "(" + string.Join(", ", Enumerable.Repeat("?", mappings.Count)) + ")";
+            var valuesList = string.Join(", ", Enumerable.Repeat(parameterGroup, rowCount));
+            return $"INSERT INTO {DestinationTableName} ({columnList}) VALUES {valuesList}";
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="dataTable"></param>
+        /// <param name="rows"></param>
+        /// <param name="mappings"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        private async Task<int> BindArrayCoreAsync(
+            DataTable dataTable,
+            IReadOnlyList<DataRow> rows,
+            IReadOnlyList<Db2BulkInsertMapItem> mappings,
+            CancellationToken cancellationToken)
+        {
+            if (dataTable.Columns.Count == 0 || rows.Count == 0 || mappings.Count == 0)
+            {
+                return 0;
+            }
+
+            var dbFields = await GetDbFieldsAsync(cancellationToken);
+            mappings = ExcludeIdentityColumn(mappings, dbFields);
+            if (mappings.Count == 0)
+            {
+                return 0;
+            }
+            var dbSetting = connection.GetDbSetting();
+            var batchSize = GetEffectiveBatchSize(mappings.Count);
+            var db2Types = mappings
+                .Select(mapping => mapping.DB2Type ?? ResolveDb2Type(dbFields, dbSetting, mapping.DestinationColumn, dataTable.Columns[mapping.SourceColumn].DataType))
+                .ToArray();
+            var affectedRows = 0;
+
+            for (var offset = 0; offset < rows.Count; offset += batchSize)
+            {
+                var count = Math.Min(batchSize, rows.Count - offset);
+
+                await using var command = connection.CreateCommand();
+
+                command.Transaction = Transaction;
+                command.CommandText = BuildInsertStatement(mappings, count);
+                if (BulkCopyTimeout > 0)
+                {
+                    command.CommandTimeout = BulkCopyTimeout;
+                }
+
+                for (var rowIndex = 0; rowIndex < count; rowIndex++)
+                {
+                    var row = rows[offset + rowIndex];
+                    for (var i = 0; i < mappings.Count; i++)
+                    {
+                        var parameter = new DB2Parameter
+                        {
+                            DB2Type = db2Types[i],
+                            Direction = ParameterDirection.Input,
+                            Value = row[mappings[i].SourceColumn] ?? DBNull.Value
+                        };
+                        command.Parameters.Add(parameter);
+                    }
+                }
+
+                affectedRows += await command.ExecuteNonQueryAsync(
+                    cancellationToken);
+            }
+
+            return affectedRows;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Batches and inserts every row of <paramref name="reader"/> into <see cref="DestinationTableName"/>.
+        /// </summary>
+        /// <param name="reader">The source rows to insert.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The number of rows affected.</returns>
+        public async Task<int> WriteToServerAsync(
+            IDataReader reader,
+            CancellationToken cancellationToken = default)
+        {
+            if (reader.FieldCount == 0)
+            {
+                return 0;
+            }
+
+            var mappings = ResolveMappings(reader);
+            var dataTable = await ToDataTableAsync(reader, cancellationToken);
+            var rows = dataTable.Rows.OfType<DataRow>().ToArray();
+
+            return await BindArrayCoreAsync(dataTable, rows, mappings, cancellationToken);
+        }
+
+        /// <summary>
+        /// Batches and inserts the rows of <paramref name="dataTable"/> into <see cref="DestinationTableName"/>.
+        /// </summary>
+        /// <param name="dataTable">The source rows to insert.</param>
+        /// <param name="rowState">When specified, only rows in this state are inserted.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The number of rows affected.</returns>
+        public Task<int> WriteToServerAsync(
+            DataTable dataTable,
+            DataRowState? rowState = null,
+            CancellationToken cancellationToken = default)
+        {
+            var mappings = ResolveMappings(dataTable);
+            var rowsQuery = dataTable.Rows.OfType<DataRow>();
+            if (rowState.HasValue)
+            {
+                rowsQuery = rowsQuery.Where(row => row.RowState == rowState);
+            }
+
+            return BindArrayCoreAsync(dataTable, rowsQuery.ToArray(), mappings, cancellationToken);
+        }
+
+        #endregion
+
+        #region IDisposable
+
+        /// <summary>
+        /// Disposes the underlying resources used by this instance.
+        /// </summary>
+        public void Dispose()
+        {
+            // Does nothing for now; this instance owns no unmanaged resources.
+        }
+
+        #endregion
+    }
+}

--- a/RepoDb.Extensions/RepoDb.Db2.BulkOperations/RepoDb.Db2.BulkOperations/Db2BulkArrayBinderColumnMappingCollection.cs
+++ b/RepoDb.Extensions/RepoDb.Db2.BulkOperations/RepoDb.Db2.BulkOperations/Db2BulkArrayBinderColumnMappingCollection.cs
@@ -1,0 +1,26 @@
+using System.Collections.ObjectModel;
+
+namespace RepoDb.Db2.BulkOperations
+{
+    /// <summary>
+    /// A collection used to define the source-to-destination column mappings of a <see cref="Db2BulkArrayBinder"/>,
+    /// mirroring the shape of <see cref="DB2BulkCopyColumnMappingCollection"/>.
+    /// </summary>
+    public sealed class Db2BulkArrayBinderColumnMappingCollection : Collection<Db2BulkInsertMapItem>
+    {
+        /// <summary>
+        /// Adds a source-to-destination column mapping.
+        /// </summary>
+        /// <param name="sourceColumn">The source column or property name.</param>
+        /// <param name="destinationColumn">The destination table's column name.</param>
+        /// <returns>The added mapping.</returns>
+        public Db2BulkInsertMapItem Add(
+            string sourceColumn,
+            string destinationColumn)
+        {
+            var mapping = new Db2BulkInsertMapItem(sourceColumn, destinationColumn);
+            Add(mapping);
+            return mapping;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Ports Oracle's array-bind-based `WriteToServerAsync` bulk-insert path to DB2, giving `RepoDb.Db2.BulkOperations` a true asynchronous insert path instead of the previous `Task.Run`-wrapped synchronous `DB2BulkCopy` call.
- Adds `Db2BulkArrayBinder` and `Db2BulkArrayBinderColumnMappingCollection`, mirroring `OracleBulkArrayBinder`/`OracleBulkArrayBinderColumnMappingCollection`.
- Adds `TypeToDb2TypeResolver` (CLR type → `DB2Type`) and `Db2DbTypeNameToDb2TypeResolver` (catalog type name → `DB2Type`) under `RepoDb.Db2/Resolvers`.
- Rewires the three `WriteToServerAsyncInternal` overloads in `Base/WriteToServer.cs` to use the new binder. Synchronous methods are untouched.

## Why not a literal 1:1 array-bind port

The initial port used `DB2Command.ArrayBindCount` exactly like Oracle's `OracleCommand.ArrayBindCount`. Testing against a live DB2 12.1 server (via this repo's `docker-compose.yml`) surfaced a provider bug: **`Net.IBM.Data.Db2` (v9.0.0.400) silently blanks out every other row when a variable-length parameter (`VARCHAR`, `CHAR`, `BINARY`, etc.) is array-bound**, while fixed-width numeric parameters bind correctly. This reproduced with plain `VARCHAR` strings alone (no binary/GUID data involved), with and without `HostVarParameters=True`, and regardless of explicit `Size`/`ArrayLength` settings - so it isn't something this library's usage could work around.

Since bulk-insert callers can't guarantee every destination column is fixed-width, `ArrayBindCount` isn't safe to use here. `Db2BulkArrayBinder` instead sends each batch as a single multi-row statement:

```sql
INSERT INTO tbl (colA, colB) VALUES (?, ?), (?, ?), ...
```

with one scalar `DB2Parameter` per value (positional `?` markers, not `:name` - so it works regardless of `HostVarParameters`). This was verified against the live server to not exhibit the corruption, while still keeping the round-trip count at one per batch (not one per row).

## Other notable decisions

- **DB2Type resolution for `byte[]` is metadata-aware.** A .NET `byte[]` is ambiguous in DB2 - it can back a real `BLOB` column or a fixed/variable binary column (e.g. the `CHAR(16) FOR BIT DATA` this codebase already uses to round-trip `Guid`). `Db2BulkArrayBinder` looks up the destination column's catalog type (via `Db2DbTypeNameToDb2TypeResolver`) when the value is `byte[]`, falling back to the CLR-type-based `TypeToDb2TypeResolver` only when no destination metadata is available.
- **Avoided two obsolete `DB2Type` members.** `DB2Type.Char1` and `DB2Type.IntervalDayFraction` are marked `[Obsolete]` in the provider ("incompatibility between the IBM Data Server Provider for .NET and the Client SDK IBM Informix .NET Provider"). `TypeToDb2TypeResolver` maps `char → DB2Type.Char` and `TimeSpan → DB2Type.Time` instead, consistent with this codebase's existing `DbTypeToDb2StringNameResolver`/`Db2DbTypeNameToClientTypeResolver` conventions.
- **Parameter-marker cap.** `MaxBindableParametersCount = 32_767`, matching DB2's documented maximum parameter markers per SQL statement (same order of magnitude as Oracle's 65,535 cap in `OracleBulkArrayBinder`).
- **Existing DB2-specific behavior preserved.** Unlike Oracle's simpler `CreateOracleBulkArrayBinder` helpers, the new `CreateDb2BulkArrayBinder` helpers in `Base/WriteToServer.cs` keep this project's existing `excludeField` support and the destination-field-exists filtering that the synchronous `DB2BulkCopy` path already had, so behavior for the async path stays consistent with the sync path.

## Files changed

**New:**
- `RepoDb.Db2/RepoDb.Db2/Resolvers/TypeToDb2TypeResolver.cs`
- `RepoDb.Db2/RepoDb.Db2/Resolvers/Db2DbTypeNameToDb2TypeResolver.cs`
- `RepoDb.Extensions/RepoDb.Db2.BulkOperations/RepoDb.Db2.BulkOperations/Db2BulkArrayBinder.cs`
- `RepoDb.Extensions/RepoDb.Db2.BulkOperations/RepoDb.Db2.BulkOperations/Db2BulkArrayBinderColumnMappingCollection.cs`

**Modified:**
- `RepoDb.Extensions/RepoDb.Db2.BulkOperations/RepoDb.Db2.BulkOperations/Base/WriteToServer.cs` - the three `WriteToServerAsyncInternal` overloads now build and use `Db2BulkArrayBinder` for real async execution instead of `Task.Run(() => bulkCopy.WriteToServer(...))`.

## Testing

- `RepoDb.Db2`, `RepoDb.Db2.BulkOperations`, and `RepoDb.Db2.BulkOperations.IntegrationTests` all build clean (net8.0/net9.0/net10.0).
- Full `RepoDb.Db2.BulkOperations.IntegrationTests` suite against a live DB2 12.1 instance: **590/590 passed, 0 failed.**
- Manually reproduced and verified the fix for the `ArrayBindCount` corruption bug with standalone repros against the live server (plain `VARCHAR` array-bind, `CHAR(n) FOR BIT DATA` array-bind, and the final multi-row `VALUES` approach).
