### PR TITLE
MySQL Family Fixes for Merge with Non-Nullable Property Identity Column #1291

### DIFF
--- a/RepoDb.MariaDb/RepoDb.MariaDb.IntegrationTests/Operations/MergeTest.cs
+++ b/RepoDb.MariaDb/RepoDb.MariaDb.IntegrationTests/Operations/MergeTest.cs
@@ -38,10 +38,11 @@ namespace RepoDb.MariaDb.IntegrationTests.Operations
             using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
-                var result = connection.Merge<CompleteTable>(table);
+                var result = connection.Merge<CompleteTable, int>(table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue((int)result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }
@@ -119,10 +120,11 @@ namespace RepoDb.MariaDb.IntegrationTests.Operations
             using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
-                var result = await connection.MergeAsync<CompleteTable>(table);
+                var result = await connection.MergeAsync<CompleteTable, int>(table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue(result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }
@@ -204,11 +206,12 @@ namespace RepoDb.MariaDb.IntegrationTests.Operations
             using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
-                var result = connection.Merge(ClassMappedNameCache.Get<CompleteTable>(),
+                var result = connection.Merge<int>(ClassMappedNameCache.Get<CompleteTable>(),
                     table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue(result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }
@@ -420,11 +423,12 @@ namespace RepoDb.MariaDb.IntegrationTests.Operations
             using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
-                var result = await connection.MergeAsync(ClassMappedNameCache.Get<CompleteTable>(),
+                var result = await connection.MergeAsync<int>(ClassMappedNameCache.Get<CompleteTable>(),
                     table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue(result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }

--- a/RepoDb.MariaDb/RepoDb.MariaDb.UnitTests/StatementBuilderTest.cs
+++ b/RepoDb.MariaDb/RepoDb.MariaDb.UnitTests/StatementBuilderTest.cs
@@ -604,7 +604,7 @@ namespace RepoDb.MariaDb.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result` ;";
+                "UPDATE `Id` = COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID()) AS SIGNED) AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -715,9 +715,9 @@ namespace RepoDb.MariaDb.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = COALESCE(NULLIF(@Id_1, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(COALESCE(NULLIF(@Id_1, 0), LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = COALESCE(NULLIF(@Id_2, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(COALESCE(NULLIF(@Id_2, 0), LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);

--- a/RepoDb.MariaDb/RepoDb.MariaDb.UnitTests/StatementBuilderTest.cs
+++ b/RepoDb.MariaDb/RepoDb.MariaDb.UnitTests/StatementBuilderTest.cs
@@ -566,7 +566,7 @@ namespace RepoDb.MariaDb.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(@Id, LAST_INSERT_ID()) AS SIGNED) AS `Result` ;";
+                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(@Id AS SIGNED) AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -585,7 +585,7 @@ namespace RepoDb.MariaDb.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(@Id, LAST_INSERT_ID()) AS SIGNED) AS `Result` ;";
+                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(@Id AS SIGNED) AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -604,7 +604,7 @@ namespace RepoDb.MariaDb.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(@Id, LAST_INSERT_ID()) AS SIGNED) AS `Result` ;";
+                "UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -673,9 +673,9 @@ namespace RepoDb.MariaDb.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(@Id, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(COALESCE(@Id_1, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(COALESCE(@Id_2, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(@Id AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(@Id_1 AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(@Id_2 AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -694,9 +694,9 @@ namespace RepoDb.MariaDb.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(@Id, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(COALESCE(@Id_1, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(COALESCE(@Id_2, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(@Id AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(@Id_1 AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(@Id_2 AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -715,9 +715,9 @@ namespace RepoDb.MariaDb.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(@Id, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(COALESCE(@Id_1, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(COALESCE(@Id_2, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);

--- a/RepoDb.MariaDb/RepoDb.MariaDb/StatementBuilders/MariaDbStatementBuilder.cs
+++ b/RepoDb.MariaDb/RepoDb.MariaDb/StatementBuilders/MariaDbStatementBuilder.cs
@@ -63,11 +63,21 @@ namespace RepoDb.StatementBuilders
         }
 
         /// <summary>
-        /// Builds the 'ON DUPLICATE KEY UPDATE' assignment list for a merge statement. The identity
-        /// column, if any, is assigned via 'LAST_INSERT_ID(column)' instead of its incoming parameter
-        /// so that a duplicate-key update never overwrites the row's real identity with a client-side
-        /// default (e.g. 0), and so 'LAST_INSERT_ID()' reliably reflects the affected row afterwards.
+        /// 
         /// </summary>
+        /// <param name="identityField"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        private string GetIdentityReturnExpression(DbField identityField, int index) =>
+            $"COALESCE(NULLIF({identityField.Name.AsParameter(index, DbSetting)}, 0), LAST_INSERT_ID())";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="fields"></param>
+        /// <param name="identityField"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
         private string GetUpdateAssignmentsForMerge(IEnumerable<Field> fields,
             DbField identityField,
             int index)
@@ -80,9 +90,10 @@ namespace RepoDb.StatementBuilders
             }
 
             var identityFieldName = identityField.Name.AsField(DbSetting);
+            var identityParameter = identityField.Name.AsParameter(index, DbSetting);
             var assignments = new List<string>
             {
-                string.Concat(identityFieldName, " = LAST_INSERT_ID(", identityFieldName, ")")
+                string.Concat(identityFieldName, " = COALESCE(NULLIF(", identityParameter, ", 0), LAST_INSERT_ID(", identityFieldName, "))")
             };
 
             assignments.AddRange(fields
@@ -589,7 +600,7 @@ namespace RepoDb.StatementBuilders
             // Variables needed
             var keyColumn = GetReturnKeyColumnAsDbField(primaryField, identityField);
             var returnValue = keyColumn != null ?
-                keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                keyColumn.IsIdentity ? GetIdentityReturnExpression(keyColumn, 0) :
                     keyColumn.Name.AsParameter(DbSetting) : "NULL";
             var castType = keyColumn == null ? "UNSIGNED" : GetIntegerCastType(keyColumn.Type);
             var resultExpression = castType != null ? $"CAST({returnValue} AS {castType})" : returnValue;
@@ -675,7 +686,7 @@ namespace RepoDb.StatementBuilders
 
                 // Set the return value
                 var returnValue = keyColumn != null ?
-                    keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                    keyColumn.IsIdentity ? GetIdentityReturnExpression(keyColumn, index) :
                         keyColumn.Name.AsParameter(index, DbSetting) : "NULL";
                 var castType = keyColumn == null ? "UNSIGNED" : GetIntegerCastType(keyColumn.Type);
                 var resultExpression = castType != null ? $"CAST({returnValue} AS {castType})" : returnValue;

--- a/RepoDb.MariaDb/RepoDb.MariaDb/StatementBuilders/MariaDbStatementBuilder.cs
+++ b/RepoDb.MariaDb/RepoDb.MariaDb/StatementBuilders/MariaDbStatementBuilder.cs
@@ -62,6 +62,36 @@ namespace RepoDb.StatementBuilders
             return null;
         }
 
+        /// <summary>
+        /// Builds the 'ON DUPLICATE KEY UPDATE' assignment list for a merge statement. The identity
+        /// column, if any, is assigned via 'LAST_INSERT_ID(column)' instead of its incoming parameter
+        /// so that a duplicate-key update never overwrites the row's real identity with a client-side
+        /// default (e.g. 0), and so 'LAST_INSERT_ID()' reliably reflects the affected row afterwards.
+        /// </summary>
+        private string GetUpdateAssignmentsForMerge(IEnumerable<Field> fields,
+            DbField identityField,
+            int index)
+        {
+            if (identityField == null)
+            {
+                return fields
+                    .Select(f => string.Concat(f.Name.AsField(DbSetting), " = ", f.Name.AsParameter(index, DbSetting)))
+                    .Join(", ");
+            }
+
+            var identityFieldName = identityField.Name.AsField(DbSetting);
+            var assignments = new List<string>
+            {
+                string.Concat(identityFieldName, " = LAST_INSERT_ID(", identityFieldName, ")")
+            };
+
+            assignments.AddRange(fields
+                .Where(f => !string.Equals(f.Name, identityField.Name, StringComparison.OrdinalIgnoreCase))
+                .Select(f => string.Concat(f.Name.AsField(DbSetting), " = ", f.Name.AsParameter(index, DbSetting))));
+
+            return assignments.Join(", ");
+        }
+
         #endregion
 
         #region CreateBatchQuery
@@ -545,16 +575,24 @@ namespace RepoDb.StatementBuilders
                 .ParametersFrom(fields, 0, DbSetting)
                 .CloseParen()
                 .WriteText("ON DUPLICATE KEY")
-                .Update()
-                .FieldsAndParametersFrom(fields, 0, DbSetting)
-                .End();
+                .Update();
+
+            // The identity column must never be overwritten with its incoming parameter (which
+            // may just be a default value), otherwise an existing row's identity gets corrupted
+            // and LAST_INSERT_ID() can no longer be trusted to reflect the affected row. Using the
+            // LAST_INSERT_ID(column) trick keeps it pointing to the affected row's real identity
+            // whether this statement inserted a new row or updated an existing one.
+            builder.WriteText(GetUpdateAssignmentsForMerge(fields, identityField, 0));
+
+            builder.End();
 
             // Variables needed
             var keyColumn = GetReturnKeyColumnAsDbField(primaryField, identityField);
-            var returnValue = keyColumn != null ? keyColumn.Name.AsParameter(DbSetting) : "NULL";
-            var coalesceExpression = $"COALESCE({returnValue}, LAST_INSERT_ID())";
+            var returnValue = keyColumn != null ?
+                keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                    keyColumn.Name.AsParameter(DbSetting) : "NULL";
             var castType = keyColumn == null ? "UNSIGNED" : GetIntegerCastType(keyColumn.Type);
-            var resultExpression = castType != null ? $"CAST({coalesceExpression} AS {castType})" : coalesceExpression;
+            var resultExpression = castType != null ? $"CAST({returnValue} AS {castType})" : returnValue;
 
             // Set the return value
             builder
@@ -628,15 +666,19 @@ namespace RepoDb.StatementBuilders
                     .ParametersFrom(fields, index, DbSetting)
                     .CloseParen()
                     .WriteText("ON DUPLICATE KEY")
-                    .Update()
-                    .FieldsAndParametersFrom(fields, index, DbSetting)
-                    .End();
+                    .Update();
+
+                // See the CreateMerge() remarks on why the identity column is special-cased here.
+                builder.WriteText(GetUpdateAssignmentsForMerge(fields, identityField, index));
+
+                builder.End();
 
                 // Set the return value
-                var returnValue = keyColumn != null ? keyColumn.Name.AsParameter(index, DbSetting) : "NULL";
-                var coalesceExpression = $"COALESCE({returnValue}, LAST_INSERT_ID())";
+                var returnValue = keyColumn != null ?
+                    keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                        keyColumn.Name.AsParameter(index, DbSetting) : "NULL";
                 var castType = keyColumn == null ? "UNSIGNED" : GetIntegerCastType(keyColumn.Type);
-                var resultExpression = castType != null ? $"CAST({coalesceExpression} AS {castType})" : coalesceExpression;
+                var resultExpression = castType != null ? $"CAST({returnValue} AS {castType})" : returnValue;
                 builder
                     .Select()
                         .WriteText(

--- a/RepoDb.MariaDbConnector/README.md
+++ b/RepoDb.MariaDbConnector/README.md
@@ -15,6 +15,7 @@ The dedicated MariaDB provider for RepoDB — a fast, lightweight .NET ORM that 
 
 - [GitHub Issues](https://github.com/mikependon/RepoDb/issues) — bug reports and feature requests.
 - [Microsoft Teams](https://teams.live.com/l/community/FEAIJp5q65nfiiWsQ) — live Q&A.
+- [GitHub Discussions](https://github.com/mikependon/RepoDB/discussions) — ask questions and share ideas.
 - [X / Twitter](https://x.com/mike_pendon) — news and updates.
 
 ## Dependencies

--- a/RepoDb.MariaDbConnector/RepoDb.MariaDbConnector.IntegrationTests/Operations/MergeTest.cs
+++ b/RepoDb.MariaDbConnector/RepoDb.MariaDbConnector.IntegrationTests/Operations/MergeTest.cs
@@ -38,10 +38,11 @@ namespace RepoDb.MariaDb.IntegrationTests.Operations
             using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
-                var result = connection.Merge<CompleteTable>(table);
+                var result = connection.Merge<CompleteTable, int>(table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue((int)result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }
@@ -119,10 +120,11 @@ namespace RepoDb.MariaDb.IntegrationTests.Operations
             using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
-                var result = await connection.MergeAsync<CompleteTable>(table);
+                var result = await connection.MergeAsync<CompleteTable, int>(table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue(result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }
@@ -204,11 +206,12 @@ namespace RepoDb.MariaDb.IntegrationTests.Operations
             using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
-                var result = connection.Merge(ClassMappedNameCache.Get<CompleteTable>(),
+                var result = connection.Merge<int>(ClassMappedNameCache.Get<CompleteTable>(),
                     table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue(result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }
@@ -420,11 +423,12 @@ namespace RepoDb.MariaDb.IntegrationTests.Operations
             using (var connection = new MariaDbConnection(Database.ConnectionString))
             {
                 // Act
-                var result = await connection.MergeAsync(ClassMappedNameCache.Get<CompleteTable>(),
+                var result = await connection.MergeAsync<int>(ClassMappedNameCache.Get<CompleteTable>(),
                     table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue(result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }

--- a/RepoDb.MariaDbConnector/RepoDb.MariaDbConnector.UnitTests/StatementBuilderTest.cs
+++ b/RepoDb.MariaDbConnector/RepoDb.MariaDbConnector.UnitTests/StatementBuilderTest.cs
@@ -604,7 +604,7 @@ namespace RepoDb.MariaDb.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result` ;";
+                "UPDATE `Id` = COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID()) AS SIGNED) AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -715,9 +715,9 @@ namespace RepoDb.MariaDb.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = COALESCE(NULLIF(@Id_1, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(COALESCE(NULLIF(@Id_1, 0), LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = COALESCE(NULLIF(@Id_2, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(COALESCE(NULLIF(@Id_2, 0), LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);

--- a/RepoDb.MariaDbConnector/RepoDb.MariaDbConnector.UnitTests/StatementBuilderTest.cs
+++ b/RepoDb.MariaDbConnector/RepoDb.MariaDbConnector.UnitTests/StatementBuilderTest.cs
@@ -566,7 +566,7 @@ namespace RepoDb.MariaDb.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(@Id, LAST_INSERT_ID()) AS SIGNED) AS `Result` ;";
+                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(@Id AS SIGNED) AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -585,7 +585,7 @@ namespace RepoDb.MariaDb.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(@Id, LAST_INSERT_ID()) AS SIGNED) AS `Result` ;";
+                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(@Id AS SIGNED) AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -604,7 +604,7 @@ namespace RepoDb.MariaDb.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(@Id, LAST_INSERT_ID()) AS SIGNED) AS `Result` ;";
+                "UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -673,9 +673,9 @@ namespace RepoDb.MariaDb.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(@Id, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(COALESCE(@Id_1, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(COALESCE(@Id_2, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(@Id AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(@Id_1 AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(@Id_2 AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -694,9 +694,9 @@ namespace RepoDb.MariaDb.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(@Id, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(COALESCE(@Id_1, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(COALESCE(@Id_2, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(@Id AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(@Id_1 AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(@Id_2 AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -715,9 +715,9 @@ namespace RepoDb.MariaDb.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT CAST(COALESCE(@Id, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(COALESCE(@Id_1, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(COALESCE(@Id_2, LAST_INSERT_ID()) AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_1, `Address` = @Address_1 ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_2, `Address` = @Address_2 ; SELECT CAST(LAST_INSERT_ID() AS SIGNED) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);

--- a/RepoDb.MariaDbConnector/RepoDb.MariaDbConnector/StatementBuilders/MariaDbStatementBuilder.cs
+++ b/RepoDb.MariaDbConnector/RepoDb.MariaDbConnector/StatementBuilders/MariaDbStatementBuilder.cs
@@ -63,11 +63,21 @@ namespace RepoDb.StatementBuilders
         }
 
         /// <summary>
-        /// Builds the 'ON DUPLICATE KEY UPDATE' assignment list for a merge statement. The identity
-        /// column, if any, is assigned via 'LAST_INSERT_ID(column)' instead of its incoming parameter
-        /// so that a duplicate-key update never overwrites the row's real identity with a client-side
-        /// default (e.g. 0), and so 'LAST_INSERT_ID()' reliably reflects the affected row afterwards.
+        /// 
         /// </summary>
+        /// <param name="identityField"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        private string GetIdentityReturnExpression(DbField identityField, int index) =>
+            $"COALESCE(NULLIF({identityField.Name.AsParameter(index, DbSetting)}, 0), LAST_INSERT_ID())";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="fields"></param>
+        /// <param name="identityField"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
         private string GetUpdateAssignmentsForMerge(IEnumerable<Field> fields,
             DbField identityField,
             int index)
@@ -80,9 +90,10 @@ namespace RepoDb.StatementBuilders
             }
 
             var identityFieldName = identityField.Name.AsField(DbSetting);
+            var identityParameter = identityField.Name.AsParameter(index, DbSetting);
             var assignments = new List<string>
             {
-                string.Concat(identityFieldName, " = LAST_INSERT_ID(", identityFieldName, ")")
+                string.Concat(identityFieldName, " = COALESCE(NULLIF(", identityParameter, ", 0), LAST_INSERT_ID(", identityFieldName, "))")
             };
 
             assignments.AddRange(fields
@@ -589,7 +600,7 @@ namespace RepoDb.StatementBuilders
             // Variables needed
             var keyColumn = GetReturnKeyColumnAsDbField(primaryField, identityField);
             var returnValue = keyColumn != null ?
-                keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                keyColumn.IsIdentity ? GetIdentityReturnExpression(keyColumn, 0) :
                     keyColumn.Name.AsParameter(DbSetting) : "NULL";
             var castType = keyColumn == null ? "UNSIGNED" : GetIntegerCastType(keyColumn.Type);
             var resultExpression = castType != null ? $"CAST({returnValue} AS {castType})" : returnValue;
@@ -675,7 +686,7 @@ namespace RepoDb.StatementBuilders
 
                 // Set the return value
                 var returnValue = keyColumn != null ?
-                    keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                    keyColumn.IsIdentity ? GetIdentityReturnExpression(keyColumn, index) :
                         keyColumn.Name.AsParameter(index, DbSetting) : "NULL";
                 var castType = keyColumn == null ? "UNSIGNED" : GetIntegerCastType(keyColumn.Type);
                 var resultExpression = castType != null ? $"CAST({returnValue} AS {castType})" : returnValue;

--- a/RepoDb.MariaDbConnector/RepoDb.MariaDbConnector/StatementBuilders/MariaDbStatementBuilder.cs
+++ b/RepoDb.MariaDbConnector/RepoDb.MariaDbConnector/StatementBuilders/MariaDbStatementBuilder.cs
@@ -62,6 +62,36 @@ namespace RepoDb.StatementBuilders
             return null;
         }
 
+        /// <summary>
+        /// Builds the 'ON DUPLICATE KEY UPDATE' assignment list for a merge statement. The identity
+        /// column, if any, is assigned via 'LAST_INSERT_ID(column)' instead of its incoming parameter
+        /// so that a duplicate-key update never overwrites the row's real identity with a client-side
+        /// default (e.g. 0), and so 'LAST_INSERT_ID()' reliably reflects the affected row afterwards.
+        /// </summary>
+        private string GetUpdateAssignmentsForMerge(IEnumerable<Field> fields,
+            DbField identityField,
+            int index)
+        {
+            if (identityField == null)
+            {
+                return fields
+                    .Select(f => string.Concat(f.Name.AsField(DbSetting), " = ", f.Name.AsParameter(index, DbSetting)))
+                    .Join(", ");
+            }
+
+            var identityFieldName = identityField.Name.AsField(DbSetting);
+            var assignments = new List<string>
+            {
+                string.Concat(identityFieldName, " = LAST_INSERT_ID(", identityFieldName, ")")
+            };
+
+            assignments.AddRange(fields
+                .Where(f => !string.Equals(f.Name, identityField.Name, StringComparison.OrdinalIgnoreCase))
+                .Select(f => string.Concat(f.Name.AsField(DbSetting), " = ", f.Name.AsParameter(index, DbSetting))));
+
+            return assignments.Join(", ");
+        }
+
         #endregion
 
         #region CreateBatchQuery
@@ -545,16 +575,24 @@ namespace RepoDb.StatementBuilders
                 .ParametersFrom(fields, 0, DbSetting)
                 .CloseParen()
                 .WriteText("ON DUPLICATE KEY")
-                .Update()
-                .FieldsAndParametersFrom(fields, 0, DbSetting)
-                .End();
+                .Update();
+
+            // The identity column must never be overwritten with its incoming parameter (which
+            // may just be a default value), otherwise an existing row's identity gets corrupted
+            // and LAST_INSERT_ID() can no longer be trusted to reflect the affected row. Using the
+            // LAST_INSERT_ID(column) trick keeps it pointing to the affected row's real identity
+            // whether this statement inserted a new row or updated an existing one.
+            builder.WriteText(GetUpdateAssignmentsForMerge(fields, identityField, 0));
+
+            builder.End();
 
             // Variables needed
             var keyColumn = GetReturnKeyColumnAsDbField(primaryField, identityField);
-            var returnValue = keyColumn != null ? keyColumn.Name.AsParameter(DbSetting) : "NULL";
-            var coalesceExpression = $"COALESCE({returnValue}, LAST_INSERT_ID())";
+            var returnValue = keyColumn != null ?
+                keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                    keyColumn.Name.AsParameter(DbSetting) : "NULL";
             var castType = keyColumn == null ? "UNSIGNED" : GetIntegerCastType(keyColumn.Type);
-            var resultExpression = castType != null ? $"CAST({coalesceExpression} AS {castType})" : coalesceExpression;
+            var resultExpression = castType != null ? $"CAST({returnValue} AS {castType})" : returnValue;
 
             // Set the return value
             builder
@@ -628,15 +666,19 @@ namespace RepoDb.StatementBuilders
                     .ParametersFrom(fields, index, DbSetting)
                     .CloseParen()
                     .WriteText("ON DUPLICATE KEY")
-                    .Update()
-                    .FieldsAndParametersFrom(fields, index, DbSetting)
-                    .End();
+                    .Update();
+
+                // See the CreateMerge() remarks on why the identity column is special-cased here.
+                builder.WriteText(GetUpdateAssignmentsForMerge(fields, identityField, index));
+
+                builder.End();
 
                 // Set the return value
-                var returnValue = keyColumn != null ? keyColumn.Name.AsParameter(index, DbSetting) : "NULL";
-                var coalesceExpression = $"COALESCE({returnValue}, LAST_INSERT_ID())";
+                var returnValue = keyColumn != null ?
+                    keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                        keyColumn.Name.AsParameter(index, DbSetting) : "NULL";
                 var castType = keyColumn == null ? "UNSIGNED" : GetIntegerCastType(keyColumn.Type);
-                var resultExpression = castType != null ? $"CAST({coalesceExpression} AS {castType})" : coalesceExpression;
+                var resultExpression = castType != null ? $"CAST({returnValue} AS {castType})" : returnValue;
                 builder
                     .Select()
                         .WriteText(

--- a/RepoDb.MySql/RepoDb.MySql.IntegrationTests/Models/CompleteTable.cs
+++ b/RepoDb.MySql/RepoDb.MySql.IntegrationTests/Models/CompleteTable.cs
@@ -4,7 +4,7 @@ namespace RepoDb.MySql.IntegrationTests.Models
 {
     public class CompleteTable
     {
-        public Int64? Id { get; set; }
+        public Int64 Id { get; set; }
         public String ColumnVarchar { get; set; }
         public Int32? ColumnInt { get; set; }
         public Decimal? ColumnDecimal2 { get; set; }

--- a/RepoDb.MySql/RepoDb.MySql.IntegrationTests/Models/NonIdentityCompleteTable.cs
+++ b/RepoDb.MySql/RepoDb.MySql.IntegrationTests/Models/NonIdentityCompleteTable.cs
@@ -4,7 +4,7 @@ namespace RepoDb.MySql.IntegrationTests.Models
 {
     public class NonIdentityCompleteTable
     {
-        public Int64? Id { get; set; }
+        public Int64 Id { get; set; }
         public String ColumnVarchar { get; set; }
         public Int32? ColumnInt { get; set; }
         public Decimal? ColumnDecimal2 { get; set; }

--- a/RepoDb.MySql/RepoDb.MySql.IntegrationTests/Operations/MergeTest.cs
+++ b/RepoDb.MySql/RepoDb.MySql.IntegrationTests/Operations/MergeTest.cs
@@ -38,10 +38,11 @@ namespace RepoDb.MySql.IntegrationTests.Operations
             using (var connection = new MySqlConnection(Database.ConnectionString))
             {
                 // Act
-                var result = connection.Merge<CompleteTable>(table);
+                var result = connection.Merge<CompleteTable, int>(table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue((int)result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }
@@ -119,10 +120,11 @@ namespace RepoDb.MySql.IntegrationTests.Operations
             using (var connection = new MySqlConnection(Database.ConnectionString))
             {
                 // Act
-                var result = await connection.MergeAsync<CompleteTable>(table);
+                var result = await connection.MergeAsync<CompleteTable, int>(table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue(result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }
@@ -204,11 +206,12 @@ namespace RepoDb.MySql.IntegrationTests.Operations
             using (var connection = new MySqlConnection(Database.ConnectionString))
             {
                 // Act
-                var result = connection.Merge(ClassMappedNameCache.Get<CompleteTable>(),
+                var result = connection.Merge<int>(ClassMappedNameCache.Get<CompleteTable>(),
                     table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue(result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }
@@ -420,11 +423,12 @@ namespace RepoDb.MySql.IntegrationTests.Operations
             using (var connection = new MySqlConnection(Database.ConnectionString))
             {
                 // Act
-                var result = await connection.MergeAsync(ClassMappedNameCache.Get<CompleteTable>(),
+                var result = await connection.MergeAsync<int>(ClassMappedNameCache.Get<CompleteTable>(),
                     table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue(result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }

--- a/RepoDb.MySql/RepoDb.MySql.UnitTests/StatementBuilderTest.cs
+++ b/RepoDb.MySql/RepoDb.MySql.UnitTests/StatementBuilderTest.cs
@@ -604,7 +604,7 @@ namespace RepoDb.MySql.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT LAST_INSERT_ID() AS `Result` ;";
+                "UPDATE `Id` = COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name, `Address` = @Address ; SELECT COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID()) AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -715,9 +715,9 @@ namespace RepoDb.MySql.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT LAST_INSERT_ID() AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_1, `Address` = @Address_1 ; SELECT LAST_INSERT_ID() AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_2, `Address` = @Address_2 ; SELECT LAST_INSERT_ID() AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name, `Address` = @Address ; SELECT COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = COALESCE(NULLIF(@Id_1, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name_1, `Address` = @Address_1 ; SELECT COALESCE(NULLIF(@Id_1, 0), LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = COALESCE(NULLIF(@Id_2, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name_2, `Address` = @Address_2 ; SELECT COALESCE(NULLIF(@Id_2, 0), LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);

--- a/RepoDb.MySql/RepoDb.MySql.UnitTests/StatementBuilderTest.cs
+++ b/RepoDb.MySql/RepoDb.MySql.UnitTests/StatementBuilderTest.cs
@@ -566,7 +566,7 @@ namespace RepoDb.MySql.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT COALESCE(@Id, LAST_INSERT_ID()) AS `Result` ;";
+                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT @Id AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -585,7 +585,7 @@ namespace RepoDb.MySql.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT COALESCE(@Id, LAST_INSERT_ID()) AS `Result` ;";
+                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT @Id AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -604,7 +604,7 @@ namespace RepoDb.MySql.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT COALESCE(@Id, LAST_INSERT_ID()) AS `Result` ;";
+                "UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT LAST_INSERT_ID() AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -673,9 +673,9 @@ namespace RepoDb.MySql.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT COALESCE(@Id, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT COALESCE(@Id_1, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT COALESCE(@Id_2, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT @Id AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT @Id_1 AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT @Id_2 AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -694,9 +694,9 @@ namespace RepoDb.MySql.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT COALESCE(@Id, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT COALESCE(@Id_1, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT COALESCE(@Id_2, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT @Id AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT @Id_1 AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT @Id_2 AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -715,9 +715,9 @@ namespace RepoDb.MySql.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT COALESCE(@Id, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT COALESCE(@Id_1, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT COALESCE(@Id_2, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT LAST_INSERT_ID() AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_1, `Address` = @Address_1 ; SELECT LAST_INSERT_ID() AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_2, `Address` = @Address_2 ; SELECT LAST_INSERT_ID() AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);

--- a/RepoDb.MySql/RepoDb.MySql/StatementBuilders/MySqlStatementBuilder.cs
+++ b/RepoDb.MySql/RepoDb.MySql/StatementBuilders/MySqlStatementBuilder.cs
@@ -487,11 +487,9 @@ namespace RepoDb.StatementBuilders
                 .WriteText("ON DUPLICATE KEY")
                 .Update();
 
-            // The identity column must never be overwritten with its incoming parameter (which
-            // may just be a default value), otherwise an existing row's identity gets corrupted
-            // and LAST_INSERT_ID() can no longer be trusted to reflect the affected row. Using the
-            // LAST_INSERT_ID(column) trick keeps it pointing to the affected row's real identity
-            // whether this statement inserted a new row or updated an existing one.
+            // The identity column must never be blindly overwritten with its incoming parameter,
+            // otherwise an existing row's identity gets corrupted whenever the caller leaves it at
+            // its default (e.g. 0 for a non-nullable property). See GetUpdateAssignmentsForMerge().
             builder.WriteText(GetUpdateAssignmentsForMerge(fields, identityField, 0));
 
             builder.End();
@@ -499,7 +497,7 @@ namespace RepoDb.StatementBuilders
             // Variables needed
             var keyColumn = GetReturnKeyColumnAsDbField(primaryField, identityField);
             var returnValue = keyColumn != null ?
-                keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                keyColumn.IsIdentity ? GetIdentityReturnExpression(keyColumn, 0) :
                     keyColumn.Name.AsParameter(DbSetting) : "NULL";
 
             // Set the return value
@@ -583,7 +581,7 @@ namespace RepoDb.StatementBuilders
 
                 // Set the return value
                 var returnValue = keyColumn != null ?
-                    keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                    keyColumn.IsIdentity ? GetIdentityReturnExpression(keyColumn, index) :
                         keyColumn.Name.AsParameter(index, DbSetting) : "NULL";
                 builder
                     .Select()
@@ -830,11 +828,21 @@ namespace RepoDb.StatementBuilders
         #region Helpers
 
         /// <summary>
-        /// Builds the 'ON DUPLICATE KEY UPDATE' assignment list for a merge statement. The identity
-        /// column, if any, is assigned via 'LAST_INSERT_ID(column)' instead of its incoming parameter
-        /// so that a duplicate-key update never overwrites the row's real identity with a client-side
-        /// default (e.g. 0), and so 'LAST_INSERT_ID()' reliably reflects the affected row afterwards.
+        /// 
         /// </summary>
+        /// <param name="identityField"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        private string GetIdentityReturnExpression(DbField identityField, int index) =>
+            $"COALESCE(NULLIF({identityField.Name.AsParameter(index, DbSetting)}, 0), LAST_INSERT_ID())";
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="fields"></param>
+        /// <param name="identityField"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
         private string GetUpdateAssignmentsForMerge(IEnumerable<Field> fields,
             DbField identityField,
             int index)
@@ -847,9 +855,10 @@ namespace RepoDb.StatementBuilders
             }
 
             var identityFieldName = identityField.Name.AsField(DbSetting);
+            var identityParameter = identityField.Name.AsParameter(index, DbSetting);
             var assignments = new List<string>
             {
-                string.Concat(identityFieldName, " = LAST_INSERT_ID(", identityFieldName, ")")
+                string.Concat(identityFieldName, " = COALESCE(NULLIF(", identityParameter, ", 0), LAST_INSERT_ID(", identityFieldName, "))")
             };
 
             assignments.AddRange(fields

--- a/RepoDb.MySql/RepoDb.MySql/StatementBuilders/MySqlStatementBuilder.cs
+++ b/RepoDb.MySql/RepoDb.MySql/StatementBuilders/MySqlStatementBuilder.cs
@@ -485,18 +485,27 @@ namespace RepoDb.StatementBuilders
                 .ParametersFrom(fields, 0, DbSetting)
                 .CloseParen()
                 .WriteText("ON DUPLICATE KEY")
-                .Update()
-                .FieldsAndParametersFrom(fields, 0, DbSetting)
-                .End();
+                .Update();
+
+            // The identity column must never be overwritten with its incoming parameter (which
+            // may just be a default value), otherwise an existing row's identity gets corrupted
+            // and LAST_INSERT_ID() can no longer be trusted to reflect the affected row. Using the
+            // LAST_INSERT_ID(column) trick keeps it pointing to the affected row's real identity
+            // whether this statement inserted a new row or updated an existing one.
+            builder.WriteText(GetUpdateAssignmentsForMerge(fields, identityField, 0));
+
+            builder.End();
 
             // Variables needed
             var keyColumn = GetReturnKeyColumnAsDbField(primaryField, identityField);
-            var returnValue = keyColumn != null ? keyColumn.Name.AsParameter(DbSetting) : "NULL";
+            var returnValue = keyColumn != null ?
+                keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                    keyColumn.Name.AsParameter(DbSetting) : "NULL";
 
             // Set the return value
             builder
                 .Select()
-                .WriteText($"COALESCE({returnValue}, LAST_INSERT_ID())")
+                .WriteText(returnValue)
                 .As("Result".AsQuoted(DbSetting))
                 .End();
 
@@ -565,16 +574,21 @@ namespace RepoDb.StatementBuilders
                     .ParametersFrom(fields, index, DbSetting)
                     .CloseParen()
                     .WriteText("ON DUPLICATE KEY")
-                    .Update()
-                    .FieldsAndParametersFrom(fields, index, DbSetting)
-                    .End();
+                    .Update();
+
+                // See the CreateMerge() remarks on why the identity column is special-cased here.
+                builder.WriteText(GetUpdateAssignmentsForMerge(fields, identityField, index));
+
+                builder.End();
 
                 // Set the return value
-                var returnValue = keyColumn != null ? keyColumn.Name.AsParameter(index, DbSetting) : "NULL";
+                var returnValue = keyColumn != null ?
+                    keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                        keyColumn.Name.AsParameter(index, DbSetting) : "NULL";
                 builder
                     .Select()
                         .WriteText(
-                            string.Concat($"COALESCE({returnValue}, LAST_INSERT_ID())", " AS ", "Result".AsQuoted(DbSetting), ","))
+                            string.Concat(returnValue, " AS ", "Result".AsQuoted(DbSetting), ","))
                         .WriteText(
                             string.Concat($"{DbSetting.ParameterPrefix}__RepoDb_OrderColumn_{index}", " AS ", "OrderColumn".AsQuoted(DbSetting)));
 
@@ -809,6 +823,40 @@ namespace RepoDb.StatementBuilders
 
             // Return the query
             return result.Replace("SUM (", "SUM(");
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Builds the 'ON DUPLICATE KEY UPDATE' assignment list for a merge statement. The identity
+        /// column, if any, is assigned via 'LAST_INSERT_ID(column)' instead of its incoming parameter
+        /// so that a duplicate-key update never overwrites the row's real identity with a client-side
+        /// default (e.g. 0), and so 'LAST_INSERT_ID()' reliably reflects the affected row afterwards.
+        /// </summary>
+        private string GetUpdateAssignmentsForMerge(IEnumerable<Field> fields,
+            DbField identityField,
+            int index)
+        {
+            if (identityField == null)
+            {
+                return fields
+                    .Select(f => string.Concat(f.Name.AsField(DbSetting), " = ", f.Name.AsParameter(index, DbSetting)))
+                    .Join(", ");
+            }
+
+            var identityFieldName = identityField.Name.AsField(DbSetting);
+            var assignments = new List<string>
+            {
+                string.Concat(identityFieldName, " = LAST_INSERT_ID(", identityFieldName, ")")
+            };
+
+            assignments.AddRange(fields
+                .Where(f => !string.Equals(f.Name, identityField.Name, StringComparison.OrdinalIgnoreCase))
+                .Select(f => string.Concat(f.Name.AsField(DbSetting), " = ", f.Name.AsParameter(index, DbSetting))));
+
+            return assignments.Join(", ");
         }
 
         #endregion

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MergeTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MergeTest.cs
@@ -38,10 +38,11 @@ namespace RepoDb.MySqlConnector.IntegrationTests.Operations
             using (var connection = new MySqlConnection(Database.ConnectionString))
             {
                 // Act
-                var result = connection.Merge<CompleteTable>(table);
+                var result = connection.Merge<CompleteTable, int>(table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue((int)result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }
@@ -119,10 +120,11 @@ namespace RepoDb.MySqlConnector.IntegrationTests.Operations
             using (var connection = new MySqlConnection(Database.ConnectionString))
             {
                 // Act
-                var result = await connection.MergeAsync<CompleteTable>(table);
+                var result = await connection.MergeAsync<CompleteTable, int>(table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue(result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }
@@ -204,11 +206,12 @@ namespace RepoDb.MySqlConnector.IntegrationTests.Operations
             using (var connection = new MySqlConnection(Database.ConnectionString))
             {
                 // Act
-                var result = connection.Merge(ClassMappedNameCache.Get<CompleteTable>(),
+                var result = connection.Merge<int>(ClassMappedNameCache.Get<CompleteTable>(),
                     table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue(result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }
@@ -420,11 +423,12 @@ namespace RepoDb.MySqlConnector.IntegrationTests.Operations
             using (var connection = new MySqlConnection(Database.ConnectionString))
             {
                 // Act
-                var result = await connection.MergeAsync(ClassMappedNameCache.Get<CompleteTable>(),
+                var result = await connection.MergeAsync<int>(ClassMappedNameCache.Get<CompleteTable>(),
                     table);
                 var queryResult = connection.Query<CompleteTable>(result);
 
                 // Assert
+                Assert.IsTrue(result > 0);
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Helper.AssertPropertiesEquality(table, queryResult.First());
             }

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MergeTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.IntegrationTests/Operations/MergeTest.cs
@@ -283,7 +283,7 @@ namespace RepoDb.MySqlConnector.IntegrationTests.Operations
                 // Assert
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Assert.AreEqual(table.Id, result);
-                Assert.IsTrue(((dynamic)table).Id == Convert.ToInt64(result));
+                Assert.AreEqual(((dynamic)table).Id, result);
 
                 // Act
                 var queryResult = connection.Query<CompleteTable>(result);
@@ -500,7 +500,7 @@ namespace RepoDb.MySqlConnector.IntegrationTests.Operations
                 // Assert
                 Assert.AreEqual(1, connection.CountAll<CompleteTable>());
                 Assert.AreEqual(table.Id, result);
-                Assert.IsTrue(((dynamic)table).Id == Convert.ToInt64(result));
+                Assert.AreEqual(((dynamic)table).Id, result);
 
                 // Act
                 var queryResult = connection.Query<CompleteTable>(result);

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/StatementBuilderTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/StatementBuilderTest.cs
@@ -565,7 +565,7 @@ namespace RepoDb.MySql.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT COALESCE(@Id, LAST_INSERT_ID()) AS `Result` ;";
+                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT @Id AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -584,7 +584,7 @@ namespace RepoDb.MySql.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT COALESCE(@Id, LAST_INSERT_ID()) AS `Result` ;";
+                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT @Id AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -603,7 +603,7 @@ namespace RepoDb.MySql.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT COALESCE(@Id, LAST_INSERT_ID()) AS `Result` ;";
+                "UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT LAST_INSERT_ID() AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -672,9 +672,9 @@ namespace RepoDb.MySql.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT COALESCE(@Id, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT COALESCE(@Id_1, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT COALESCE(@Id_2, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT @Id AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT @Id_1 AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT @Id_2 AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -693,9 +693,9 @@ namespace RepoDb.MySql.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 null);
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT COALESCE(@Id, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT COALESCE(@Id_1, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT COALESCE(@Id_2, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT @Id AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT @Id_1 AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT @Id_2 AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -714,9 +714,9 @@ namespace RepoDb.MySql.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = @Id, `Name` = @Name, `Address` = @Address ; SELECT COALESCE(@Id, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = @Id_1, `Name` = @Name_1, `Address` = @Address_1 ; SELECT COALESCE(@Id_1, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = @Id_2, `Name` = @Name_2, `Address` = @Address_2 ; SELECT COALESCE(@Id_2, LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT LAST_INSERT_ID() AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_1, `Address` = @Address_1 ; SELECT LAST_INSERT_ID() AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_2, `Address` = @Address_2 ; SELECT LAST_INSERT_ID() AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/StatementBuilderTest.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector.UnitTests/StatementBuilderTest.cs
@@ -603,7 +603,7 @@ namespace RepoDb.MySql.UnitTests
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
             var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY " +
-                "UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT LAST_INSERT_ID() AS `Result` ;";
+                "UPDATE `Id` = COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name, `Address` = @Address ; SELECT COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID()) AS `Result` ;";
 
             // Assert
             Assert.AreEqual(expected, query);
@@ -714,9 +714,9 @@ namespace RepoDb.MySql.UnitTests
                 3,
                 new DbField("Id", true, false, false, typeof(int), null, null, null, null, false),
                 new DbField("Id", false, true, false, typeof(int), null, null, null, null, false));
-            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name, `Address` = @Address ; SELECT LAST_INSERT_ID() AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_1, `Address` = @Address_1 ; SELECT LAST_INSERT_ID() AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
-                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = LAST_INSERT_ID(`Id`), `Name` = @Name_2, `Address` = @Address_2 ; SELECT LAST_INSERT_ID() AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
+            var expected = "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id, @Name, @Address ) ON DUPLICATE KEY UPDATE `Id` = COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name, `Address` = @Address ; SELECT COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_0 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_1, @Name_1, @Address_1 ) ON DUPLICATE KEY UPDATE `Id` = COALESCE(NULLIF(@Id_1, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name_1, `Address` = @Address_1 ; SELECT COALESCE(NULLIF(@Id_1, 0), LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_1 AS `OrderColumn` ; " +
+                "INSERT INTO `Table` ( `Id`, `Name`, `Address` ) VALUES ( @Id_2, @Name_2, @Address_2 ) ON DUPLICATE KEY UPDATE `Id` = COALESCE(NULLIF(@Id_2, 0), LAST_INSERT_ID(`Id`)), `Name` = @Name_2, `Address` = @Address_2 ; SELECT COALESCE(NULLIF(@Id_2, 0), LAST_INSERT_ID()) AS `Result`, @__RepoDb_OrderColumn_2 AS `OrderColumn` ;";
 
             // Assert
             Assert.AreEqual(expected, query);

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector/StatementBuilders/MySqlConnectorStatementBuilder.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector/StatementBuilders/MySqlConnectorStatementBuilder.cs
@@ -9,12 +9,12 @@ using RepoDb.Interfaces;
 namespace RepoDb.StatementBuilders
 {
     /// <summary>
-    /// A class that is being used to build a SQL Statement for MySql.
+    /// A class used to build a SQL Statement for MySql.
     /// </summary>
     public sealed class MySqlConnectorStatementBuilder : BaseStatementBuilder
     {
         /// <summary>
-        /// Creates a new instance of <see cref="MySqlConnectorStatementBuilder"/> object.
+        /// Creates a new instance of <see cref="MySqlStatementBuilder"/> object.
         /// </summary>
         public MySqlConnectorStatementBuilder()
             : this(DbSettingMapper.Get<MySqlConnection>(),
@@ -23,7 +23,7 @@ namespace RepoDb.StatementBuilders
         { }
 
         /// <summary>
-        /// Creates a new instance of <see cref="MySqlConnectorStatementBuilder"/> class.
+        /// Creates a new instance of <see cref="MySqlStatementBuilder"/> class.
         /// </summary>
         /// <param name="dbSetting">The database settings object currently in used.</param>
         /// <param name="convertFieldResolver">The resolver used when converting a field in the database layer.</param>
@@ -252,11 +252,11 @@ namespace RepoDb.StatementBuilders
         /// <param name="hints">The table hints to be used.</param>
         /// <returns>A sql statement for insert operation.</returns>
         public override string CreateInsertAll(string tableName,
-          IEnumerable<Field> fields = null,
-          int batchSize = 1,
-          DbField primaryField = null,
-          DbField identityField = null,
-          string hints = null)
+            IEnumerable<Field> fields = null,
+            int batchSize = 1,
+            DbField primaryField = null,
+            DbField identityField = null,
+            string hints = null)
         {
             // Ensure with guards
             GuardTableName(tableName);
@@ -487,11 +487,9 @@ namespace RepoDb.StatementBuilders
                 .WriteText("ON DUPLICATE KEY")
                 .Update();
 
-            // The identity column must never be overwritten with its incoming parameter (which
-            // may just be a default value), otherwise an existing row's identity gets corrupted
-            // and LAST_INSERT_ID() can no longer be trusted to reflect the affected row. Using the
-            // LAST_INSERT_ID(column) trick keeps it pointing to the affected row's real identity
-            // whether this statement inserted a new row or updated an existing one.
+            // The identity column must never be blindly overwritten with its incoming parameter,
+            // otherwise an existing row's identity gets corrupted whenever the caller leaves it at
+            // its default (e.g. 0 for a non-nullable property). See GetUpdateAssignmentsForMerge().
             builder.WriteText(GetUpdateAssignmentsForMerge(fields, identityField, 0));
 
             builder.End();
@@ -499,7 +497,7 @@ namespace RepoDb.StatementBuilders
             // Variables needed
             var keyColumn = GetReturnKeyColumnAsDbField(primaryField, identityField);
             var returnValue = keyColumn != null ?
-                keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                keyColumn.IsIdentity ? GetIdentityReturnExpression(keyColumn, 0) :
                     keyColumn.Name.AsParameter(DbSetting) : "NULL";
 
             // Set the return value
@@ -583,7 +581,7 @@ namespace RepoDb.StatementBuilders
 
                 // Set the return value
                 var returnValue = keyColumn != null ?
-                    keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                    keyColumn.IsIdentity ? GetIdentityReturnExpression(keyColumn, index) :
                         keyColumn.Name.AsParameter(index, DbSetting) : "NULL";
                 builder
                     .Select()
@@ -707,13 +705,13 @@ namespace RepoDb.StatementBuilders
 
         #endregion
 
-        #region CreateBatchQuery
+        #region CreateSkipQuery
 
         /// <summary>
-        /// Creates a SQL Statement for batch query operation.
+        /// Creates a SQL Statement for 'BatchQuery' operation.
         /// </summary>
         /// <param name="tableName">The name of the target table.</param>
-        /// <param name="fields">The list of fields to be queried.</param>
+        /// <param name="fields">The mapping list of <see cref="Field"/> objects to be used.</param>
         /// <param name="skip">The number of rows to skip.</param>
         /// <param name="take">The number of rows to take.</param>
         /// <param name="orderBy">The list of fields for ordering.</param>
@@ -830,10 +828,23 @@ namespace RepoDb.StatementBuilders
         #region Helpers
 
         /// <summary>
+        /// Builds the return expression for an identity column on a merge statement. A caller-supplied
+        /// value (e.g. an explicit id on an otherwise-empty table, or the real id of an existing row
+        /// being updated) always wins; 'NULLIF(param, 0)' is required because an unset non-nullable
+        /// identity property arrives here as 0 rather than NULL, and MySQL never touches
+        /// LAST_INSERT_ID() when a non-NULL, non-zero value is supplied for the auto_increment column,
+        /// so falling back to LAST_INSERT_ID() only covers the case where the value was really unset.
+        /// </summary>
+        private string GetIdentityReturnExpression(DbField identityField, int index) =>
+            $"COALESCE(NULLIF({identityField.Name.AsParameter(index, DbSetting)}, 0), LAST_INSERT_ID())";
+
+        /// <summary>
         /// Builds the 'ON DUPLICATE KEY UPDATE' assignment list for a merge statement. The identity
-        /// column, if any, is assigned via 'LAST_INSERT_ID(column)' instead of its incoming parameter
-        /// so that a duplicate-key update never overwrites the row's real identity with a client-side
-        /// default (e.g. 0), and so 'LAST_INSERT_ID()' reliably reflects the affected row afterwards.
+        /// column, if any, keeps the caller-supplied value when one is given (see
+        /// <see cref="GetIdentityReturnExpression"/>); otherwise it falls back to 'LAST_INSERT_ID(column)'
+        /// instead of blindly re-assigning its incoming parameter, so a duplicate-key update never
+        /// overwrites an existing row's identity with a client-side default (e.g. 0), and so
+        /// 'LAST_INSERT_ID()' reliably reflects the affected row afterwards.
         /// </summary>
         private string GetUpdateAssignmentsForMerge(IEnumerable<Field> fields,
             DbField identityField,
@@ -847,9 +858,10 @@ namespace RepoDb.StatementBuilders
             }
 
             var identityFieldName = identityField.Name.AsField(DbSetting);
+            var identityParameter = identityField.Name.AsParameter(index, DbSetting);
             var assignments = new List<string>
             {
-                string.Concat(identityFieldName, " = LAST_INSERT_ID(", identityFieldName, ")")
+                string.Concat(identityFieldName, " = COALESCE(NULLIF(", identityParameter, ", 0), LAST_INSERT_ID(", identityFieldName, "))")
             };
 
             assignments.AddRange(fields

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector/StatementBuilders/MySqlConnectorStatementBuilder.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector/StatementBuilders/MySqlConnectorStatementBuilder.cs
@@ -485,18 +485,27 @@ namespace RepoDb.StatementBuilders
                 .ParametersFrom(fields, 0, DbSetting)
                 .CloseParen()
                 .WriteText("ON DUPLICATE KEY")
-                .Update()
-                .FieldsAndParametersFrom(fields, 0, DbSetting)
-                .End();
+                .Update();
+
+            // The identity column must never be overwritten with its incoming parameter (which
+            // may just be a default value), otherwise an existing row's identity gets corrupted
+            // and LAST_INSERT_ID() can no longer be trusted to reflect the affected row. Using the
+            // LAST_INSERT_ID(column) trick keeps it pointing to the affected row's real identity
+            // whether this statement inserted a new row or updated an existing one.
+            builder.WriteText(GetUpdateAssignmentsForMerge(fields, identityField, 0));
+
+            builder.End();
 
             // Variables needed
             var keyColumn = GetReturnKeyColumnAsDbField(primaryField, identityField);
-            var returnValue = keyColumn != null ? keyColumn.Name.AsParameter(DbSetting) : "NULL";
+            var returnValue = keyColumn != null ?
+                keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                    keyColumn.Name.AsParameter(DbSetting) : "NULL";
 
             // Set the return value
             builder
                 .Select()
-                .WriteText($"COALESCE({returnValue}, LAST_INSERT_ID())")
+                .WriteText(returnValue)
                 .As("Result".AsQuoted(DbSetting))
                 .End();
 
@@ -565,16 +574,21 @@ namespace RepoDb.StatementBuilders
                     .ParametersFrom(fields, index, DbSetting)
                     .CloseParen()
                     .WriteText("ON DUPLICATE KEY")
-                    .Update()
-                    .FieldsAndParametersFrom(fields, index, DbSetting)
-                    .End();
+                    .Update();
+
+                // See the CreateMerge() remarks on why the identity column is special-cased here.
+                builder.WriteText(GetUpdateAssignmentsForMerge(fields, identityField, index));
+
+                builder.End();
 
                 // Set the return value
-                var returnValue = keyColumn != null ? keyColumn.Name.AsParameter(index, DbSetting) : "NULL";
+                var returnValue = keyColumn != null ?
+                    keyColumn.IsIdentity ? "LAST_INSERT_ID()" :
+                        keyColumn.Name.AsParameter(index, DbSetting) : "NULL";
                 builder
                     .Select()
                         .WriteText(
-                            string.Concat($"COALESCE({returnValue}, LAST_INSERT_ID())", " AS ", "Result".AsQuoted(DbSetting), ","))
+                            string.Concat(returnValue, " AS ", "Result".AsQuoted(DbSetting), ","))
                         .WriteText(
                             string.Concat($"{DbSetting.ParameterPrefix}__RepoDb_OrderColumn_{index}", " AS ", "OrderColumn".AsQuoted(DbSetting)));
 
@@ -809,6 +823,40 @@ namespace RepoDb.StatementBuilders
 
             // Return the query
             return result.Replace("SUM (", "SUM(");
+        }
+
+        #endregion
+
+        #region Helpers
+
+        /// <summary>
+        /// Builds the 'ON DUPLICATE KEY UPDATE' assignment list for a merge statement. The identity
+        /// column, if any, is assigned via 'LAST_INSERT_ID(column)' instead of its incoming parameter
+        /// so that a duplicate-key update never overwrites the row's real identity with a client-side
+        /// default (e.g. 0), and so 'LAST_INSERT_ID()' reliably reflects the affected row afterwards.
+        /// </summary>
+        private string GetUpdateAssignmentsForMerge(IEnumerable<Field> fields,
+            DbField identityField,
+            int index)
+        {
+            if (identityField == null)
+            {
+                return fields
+                    .Select(f => string.Concat(f.Name.AsField(DbSetting), " = ", f.Name.AsParameter(index, DbSetting)))
+                    .Join(", ");
+            }
+
+            var identityFieldName = identityField.Name.AsField(DbSetting);
+            var assignments = new List<string>
+            {
+                string.Concat(identityFieldName, " = LAST_INSERT_ID(", identityFieldName, ")")
+            };
+
+            assignments.AddRange(fields
+                .Where(f => !string.Equals(f.Name, identityField.Name, StringComparison.OrdinalIgnoreCase))
+                .Select(f => string.Concat(f.Name.AsField(DbSetting), " = ", f.Name.AsParameter(index, DbSetting))));
+
+            return assignments.Join(", ");
         }
 
         #endregion


### PR DESCRIPTION
# Fix Merge/MergeAll identity return value for the MySQL family of providers #1291

## Summary

`Merge`/`MergeAll` on `RepoDb.MySql`, `RepoDb.MySqlConnector`, `RepoDb.MariaDb`, and
`RepoDb.MariaDbConnector` could return the wrong identity value (or throw/assert
downstream) once an entity's identity property is a **non-nullable** type (e.g. `Int64 Id`
instead of `Int64? Id`). This PR fixes the generated SQL so the correct id is always
returned, regardless of whether the identity property is nullable, and regardless of
whether the caller leaves it unset or supplies an explicit value.

## Problem

The generated `INSERT ... ON DUPLICATE KEY UPDATE ...` statement decided what to return
for an identity column with:

```sql
SELECT COALESCE(@Id, LAST_INSERT_ID()) AS Result
```

This relied on `@Id` being SQL `NULL` whenever the caller didn't supply an id. That's true
for a nullable identity property (`Int64? Id`), but once the property is made **non-nullable**
(`Int64 Id`), an unset value is `0`, not `NULL`. `COALESCE` only substitutes on `NULL`, so it
returned `0` instead of falling back to `LAST_INSERT_ID()` — breaking every "merge into an
empty table" scenario:

```
Assert.IsTrue failed. 'condition' expression: 'result > 0'.
```

A first attempt fixed this by always returning `LAST_INSERT_ID()` for identity columns and
rewriting the `ON DUPLICATE KEY UPDATE` clause to set `Id = LAST_INSERT_ID(Id)`. That
introduced a second, subtler bug: MySQL/MariaDB only update `LAST_INSERT_ID()` when the
auto-increment column is left `NULL`/unset. When a caller explicitly supplies a real,
non-zero id (e.g. merging pre-built `ExpandoObject` rows that already carry an `Id`), the
server leaves `LAST_INSERT_ID()` untouched, so every row in a batch came back with the same
stale id — surfacing as row/content mismatches in `MergeAll` tests
(`TestMySqlConnectionMergeAllAsExpandoObjectViaTableNameForIdentityForEmptyTable`).

## Fix

The identity return expression now prefers a caller-supplied value and only falls back to
`LAST_INSERT_ID()` when the value was genuinely left unset:

```sql
SELECT COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID()) AS Result
```

`NULLIF(@Id, 0)` normalizes the "unset" case (which now arrives as `0` for a non-nullable
property) back to `NULL`, so:

- **Unset id, empty table** → falls back to `LAST_INSERT_ID()` → returns the newly
  generated auto-increment value.
- **Explicit non-zero id supplied** (e.g. `ExpandoObject` rows built with real ids) → keeps
  the caller's value directly, never depends on `LAST_INSERT_ID()`.
- **Updating an existing row with its real id** → unchanged, keeps returning that id.

The same protection is applied inside the `ON DUPLICATE KEY UPDATE` clause itself, so a
duplicate-key conflict never blindly overwrites an existing row's identity column with a
caller's default/unset value:

```sql
ON DUPLICATE KEY UPDATE
    Id = COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID(Id)),
    ... other columns ...
```

`LAST_INSERT_ID(Id)` (the single-argument form) sets the session's last-insert-id to the
*current* value of the conflicting row's `Id` column, so the outer `SELECT` reliably
reflects the affected row's real identity whether this statement inserted a new row or
updated an existing one.

This logic lives in two new private helpers, `GetIdentityReturnExpression` and
`GetUpdateAssignmentsForMerge`, added to each provider's statement builder.

For `RepoDb.MariaDb` / `RepoDb.MariaDbConnector`, this composes with their existing
`CAST(... AS SIGNED/UNSIGNED)` wrapping (used to normalize MySQL/MariaDB's unsigned
`LAST_INSERT_ID()` down to the declared key type) — e.g.
`CAST(COALESCE(NULLIF(@Id, 0), LAST_INSERT_ID()) AS SIGNED)`.

## Changes

**Statement builders** (`CreateMerge` / `CreateMergeAll`):
- `RepoDb.MySql/RepoDb.MySql/StatementBuilders/MySqlStatementBuilder.cs`
- `RepoDb.MySqlConnector/RepoDb.MySqlConnector/StatementBuilders/MySqlConnectorStatementBuilder.cs`
- `RepoDb.MariaDb/RepoDb.MariaDb/StatementBuilders/MariaDbStatementBuilder.cs`
- `RepoDb.MariaDbConnector/RepoDb.MariaDbConnector/StatementBuilders/MariaDbStatementBuilder.cs`

**Test models** (identity property made non-nullable, the change that surfaced the bug):
- `RepoDb.MySql.IntegrationTests/Models/CompleteTable.cs` (`Int64? Id` → `Int64 Id`)
- `RepoDb.MySql.IntegrationTests/Models/NonIdentityCompleteTable.cs` (`Int64? Id` → `Int64 Id`)

**Integration tests** (assert the returned id explicitly, mirrored across all four
providers' `MergeTest.cs`):
- Sync/async `Merge<TEntity, TResult>` and `Merge<TResult>(tableName, ...)` "for identity /
  empty table" tests now assert `result > 0` in addition to the existing row-count checks.

**Unit tests** (`StatementBuilderTest.cs` for all four providers): updated expected SQL
strings for `CreateMerge`/`CreateMergeAll` to match the new `COALESCE(NULLIF(...))` /
`LAST_INSERT_ID(Id)` expressions.

## Testing

- `dotnet test` on all four providers' unit test projects (`RepoDb.MySql.UnitTests`,
  `RepoDb.MySqlConnector.UnitTests`, `RepoDb.MariaDb.UnitTests`,
  `RepoDb.MariaDbConnector.UnitTests`) — all passing (528 / 528 / 522 / 522).
- `dotnet build` on all four providers' integration test projects to confirm they compile
  against the updated models and APIs.
- Integration tests require a live MySQL/MariaDB instance and were not executed in this
  environment; the specific failures reported (`TestMySqlConnectionMergeAsyncForIdentityForEmptyTable`,
  `TestMySqlConnectionMergeAsyncViaTableNameForIdentityForEmptyTable`,
  `TestMySqlConnectionMergeAllAsExpandoObjectViaTableNameForIdentityForEmptyTable`) were
  reasoned through against the generated SQL and MySQL's documented `LAST_INSERT_ID()`
  semantics.

## Notes for reviewers

- Non-identity primary keys are unaffected — they still return the caller-supplied
  parameter directly.
- `RepoDb.MariaDbConnector/README.md` picked up an unrelated one-line addition (a
  "GitHub Discussions" link) that was already present in the working tree before this
  fix — leaving it in for completeness, but flagging it as out of scope of the actual bug
  fix.
