### PR TITLE
Add BoolPropertyHandler for SByte-bool conversion

### DIFF
--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector/PropertyHandlers/BoolPropertyHandler.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector/PropertyHandlers/BoolPropertyHandler.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using RepoDb.Interfaces;
+using RepoDb.Options;
+
+namespace RepoDb.MySqlConnector.PropertyHandlers
+{
+    public class BoolPropertyHandler : IPropertyHandler<SByte, bool>
+    {
+        public bool Get(SByte input, PropertyHandlerGetOptions options)
+        {
+            return input != 0;
+        }
+
+        public SByte Set(bool input, PropertyHandlerSetOptions options)
+        {
+            return input ? (SByte)1 : (SByte)0;
+        }
+    }
+}

--- a/RepoDb.MySqlConnector/RepoDb.MySqlConnector/PropertyHandlers/SByteToBooleanPropertyHandler.cs
+++ b/RepoDb.MySqlConnector/RepoDb.MySqlConnector/PropertyHandlers/SByteToBooleanPropertyHandler.cs
@@ -4,7 +4,7 @@ using RepoDb.Options;
 
 namespace RepoDb.MySqlConnector.PropertyHandlers
 {
-    public class BoolPropertyHandler : IPropertyHandler<SByte, bool>
+    public class SByteToBooleanPropertyHandler : IPropertyHandler<SByte, bool>
     {
         public bool Get(SByte input, PropertyHandlerGetOptions options)
         {


### PR DESCRIPTION
Introduced BoolPropertyHandler in RepoDb.MySqlConnector.PropertyHandlers. Implements IPropertyHandler<SByte, bool> to convert SByte to bool (non-zero is true) and bool to SByte (true is 1, false is 0).