### PR TITLE
Finalized the failing Integration Tests for Verticaøs Bulk operation. Ref: #1246

### DIFF
--- a/src/Providers/RepoDb.Vertica.BulkOperations/RepoDb.Vertica.BulkOperations.IntegrationTests/Operations/BulkInsertTest.cs
+++ b/src/Providers/RepoDb.Vertica.BulkOperations/RepoDb.Vertica.BulkOperations.IntegrationTests/Operations/BulkInsertTest.cs
@@ -249,7 +249,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
             using (var connection = new VerticaConnection(Database.ConnectionString))
             {
                 // Act
-                Assert.Throws<FormatException>(() => connection.BulkInsert(tables, mappings));
+                Assert.Throws<VerticaException>(() => connection.BulkInsert(tables, mappings));
             }
         }
 
@@ -440,7 +440,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings));
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings));
                         }
                     }
                 }
@@ -881,7 +881,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings));
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings));
                         }
                     }
                 }
@@ -1137,7 +1137,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings));
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table, mappings: mappings));
                         }
                     }
                 }
@@ -2602,7 +2602,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
             using (var connection = new VerticaConnection(Database.ConnectionString))
             {
                 // Act
-                Assert.Throws<FormatException>(() => connection.BulkInsert(tables, mappings));
+                Assert.Throws<VerticaException>(() => connection.BulkInsert(tables, mappings));
             }
         }
 
@@ -2805,7 +2805,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings));
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings));
                         }
                     }
                 }
@@ -3226,7 +3226,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings));
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings));
                         }
                     }
                 }
@@ -3498,7 +3498,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings));
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkInsert(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table, mappings: mappings));
                         }
                     }
                 }

--- a/src/Providers/RepoDb.Vertica.BulkOperations/RepoDb.Vertica.BulkOperations.IntegrationTests/Operations/BulkMergeTest.cs
+++ b/src/Providers/RepoDb.Vertica.BulkOperations/RepoDb.Vertica.BulkOperations.IntegrationTests/Operations/BulkMergeTest.cs
@@ -521,7 +521,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
             using (var connection = new VerticaConnection(Database.ConnectionString))
             {
                 // Act
-                Assert.Throws<FormatException>(() => connection.BulkMerge(tables, mappings: mappings));
+                Assert.Throws<VerticaException>(() => connection.BulkMerge(tables, mappings: mappings));
             }
         }
 
@@ -695,7 +695,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table,
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table,
                                 mappings: mappings));
                         }
                     }
@@ -1486,7 +1486,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
                                 table,
                                 mappings: mappings));
                         }
@@ -1687,7 +1687,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
                                 table,
                                 mappings: mappings));
                         }
@@ -3974,7 +3974,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
             using (var connection = new VerticaConnection(Database.ConnectionString))
             {
                 // Act
-                Assert.Throws<FormatException>(() => connection.BulkMerge(tables, mappings: mappings));
+                Assert.Throws<VerticaException>(() => connection.BulkMerge(tables, mappings: mappings));
             }
         }
 
@@ -4148,7 +4148,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table,
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table,
                                 mappings: mappings));
                         }
                     }
@@ -4901,7 +4901,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
                                 table,
                                 mappings: mappings));
                         }
@@ -5102,7 +5102,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkMerge(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
                                 table,
                                 mappings: mappings));
                         }

--- a/src/Providers/RepoDb.Vertica.BulkOperations/RepoDb.Vertica.BulkOperations.IntegrationTests/Operations/BulkUpdateTest.cs
+++ b/src/Providers/RepoDb.Vertica.BulkOperations/RepoDb.Vertica.BulkOperations.IntegrationTests/Operations/BulkUpdateTest.cs
@@ -345,15 +345,9 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
             using (var connection = new VerticaConnection(Database.ConnectionString))
             {
                 // Act
-                Assert.Throws<FormatException>(() => connection.BulkUpdate(tables, mappings: mappings));
+                Assert.Throws<VerticaException>(() => connection.BulkUpdate(tables, mappings: mappings));
             }
         }
-
-        
-
-        
-
-        
 
         [TestMethod]
         public void TestVerticaConnectionBulkUpdateForEntitiesDataTable()
@@ -478,7 +472,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table,
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(), table,
                                 mappings: mappings));
                         }
                     }
@@ -896,7 +890,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
                                 table,
                                 mappings: mappings));
                         }
@@ -1097,7 +1091,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationIdentityTable>(),
                                 table,
                                 mappings: mappings));
                         }
@@ -2618,7 +2612,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
             using (var connection = new VerticaConnection(Database.ConnectionString))
             {
                 // Act
-                Assert.Throws<FormatException>(() => connection.BulkUpdate(tables, mappings: mappings));
+                Assert.Throws<VerticaException>(() => connection.BulkUpdate(tables, mappings: mappings));
             }
         }
 
@@ -2745,7 +2739,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table,
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(), table,
                                 mappings: mappings));
                         }
                     }
@@ -3134,7 +3128,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
                                 table,
                                 mappings: mappings));
                         }
@@ -3335,7 +3329,7 @@ namespace RepoDb.Vertica.BulkOperations.IntegrationTests.Operations
                         using (var destinationConnection = new VerticaConnection(Database.ConnectionString))
                         {
                             // Act
-                            Assert.Throws<FormatException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
+                            Assert.Throws<VerticaException>(() => destinationConnection.BulkUpdate(ClassMappedNameCache.Get<BulkOperationNonIdentityTable>(),
                                 table,
                                 mappings: mappings));
                         }

--- a/src/Providers/RepoDb.Vertica.BulkOperations/RepoDb.Vertica.BulkOperations/Base/BulkUpdate.cs
+++ b/src/Providers/RepoDb.Vertica.BulkOperations/RepoDb.Vertica.BulkOperations/Base/BulkUpdate.cs
@@ -60,6 +60,7 @@ namespace RepoDb
             var dbFields = DbFieldCache.Get(connection, tableName, transaction);
             var qualifierFields = GetQualifierFields(tableName, dbFields, qualifiers).AsList();
             var stagingFields = GetMergeFields(tableName, dbFields, mappings, qualifierFields).AsList();
+            var identityField = dbFields.GetIdentity()?.AsField();
 
             if (!HasUpdateableFields(stagingFields, qualifierFields))
             {
@@ -80,8 +81,7 @@ namespace RepoDb
                 var entityFields = mappings?.Any() == true ? mappings.Select(m => new Field(m.SourceColumn)).AsList() : stagingFields;
                 using var entityTable = BuildEntityDataTable(entityList, entityFields);
                 WriteToServerInternal(connection, pseudoTableName, entityTable, mappings: mappings, bulkCopyTimeout: bulkCopyTimeout, batchSize: batchSize, transaction: transaction);
-
-                result = VerticaExecution.UpdateFromPseudoTable(connection, tableName, pseudoTableName, stagingFields, qualifierFields, trace, traceKey, transaction);
+                result = VerticaExecution.UpdateFromPseudoTable(connection, tableName, pseudoTableName, stagingFields, qualifierFields, identityField, trace, traceKey, transaction);
             }
             finally
             {
@@ -128,6 +128,7 @@ namespace RepoDb
             var dbFields = DbFieldCache.Get(connection, tableName, transaction);
             var qualifierFields = GetQualifierFields(tableName, dbFields, qualifiers).AsList();
             var stagingFields = GetMergeFields(tableName, dbFields, mappings, qualifierFields).AsList();
+            var identityField = dbFields.GetIdentity()?.AsField();
 
             if (!HasUpdateableFields(stagingFields, qualifierFields))
             {
@@ -145,8 +146,7 @@ namespace RepoDb
             {
                 VerticaExecution.CreatePseudoTable(connection, pseudoTableName, stagingFields, dbFields, pseudoTableType, trace, traceKey, transaction);
                 WriteToServerInternal(connection, pseudoTableName, table, rowState, mappings, bulkCopyTimeout, batchSize, transaction);
-
-                result = VerticaExecution.UpdateFromPseudoTable(connection, tableName, pseudoTableName, stagingFields, qualifierFields, trace, traceKey, transaction);
+                result = VerticaExecution.UpdateFromPseudoTable(connection, tableName, pseudoTableName, stagingFields, qualifierFields, identityField, trace, traceKey, transaction);
             }
             finally
             {
@@ -191,6 +191,7 @@ namespace RepoDb
             var dbFields = DbFieldCache.Get(connection, tableName, transaction);
             var qualifierFields = GetQualifierFields(tableName, dbFields, qualifiers).AsList();
             var stagingFields = GetMergeFields(tableName, dbFields, mappings, qualifierFields).AsList();
+            var identityField = dbFields.GetIdentity()?.AsField();
 
             if (!HasUpdateableFields(stagingFields, qualifierFields))
             {
@@ -208,8 +209,7 @@ namespace RepoDb
             {
                 VerticaExecution.CreatePseudoTable(connection, pseudoTableName, stagingFields, dbFields, pseudoTableType, trace, traceKey, transaction);
                 WriteToServerInternal(connection, pseudoTableName, reader, mappings ?? GetDefaultMappingsForDataReader(connection, tableName, reader, transaction).AsList(), bulkCopyTimeout, batchSize, transaction);
-
-                result = VerticaExecution.UpdateFromPseudoTable(connection, tableName, pseudoTableName, stagingFields, qualifierFields, trace, traceKey, transaction);
+                result = VerticaExecution.UpdateFromPseudoTable(connection, tableName, pseudoTableName, stagingFields, qualifierFields, identityField, trace, traceKey, transaction);
             }
             finally
             {
@@ -263,6 +263,7 @@ namespace RepoDb
             var dbFields = await DbFieldCache.GetAsync(connection, tableName, transaction, cancellationToken);
             var qualifierFields = GetQualifierFields(tableName, dbFields, qualifiers).AsList();
             var stagingFields = GetMergeFields(tableName, dbFields, mappings, qualifierFields).AsList();
+            var identityField = dbFields.GetIdentity()?.AsField();
 
             if (!HasUpdateableFields(stagingFields, qualifierFields))
             {
@@ -283,8 +284,7 @@ namespace RepoDb
                 var entityFields = mappings?.Any() == true ? mappings.Select(m => new Field(m.SourceColumn)).AsList() : stagingFields;
                 using var entityTable = BuildEntityDataTable(entityList, entityFields);
                 await WriteToServerAsyncInternal(connection, pseudoTableName, entityTable, mappings: mappings, bulkCopyTimeout: bulkCopyTimeout, batchSize: batchSize, transaction: transaction, cancellationToken: cancellationToken);
-
-                result = await VerticaExecution.UpdateFromPseudoTableAsync(connection, tableName, pseudoTableName, stagingFields, qualifierFields, trace, traceKey, transaction, cancellationToken);
+                result = await VerticaExecution.UpdateFromPseudoTableAsync(connection, tableName, pseudoTableName, stagingFields, qualifierFields, identityField, trace, traceKey, transaction, cancellationToken);
             }
             finally
             {
@@ -333,6 +333,7 @@ namespace RepoDb
             var dbFields = await DbFieldCache.GetAsync(connection, tableName, transaction, cancellationToken);
             var qualifierFields = GetQualifierFields(tableName, dbFields, qualifiers).AsList();
             var stagingFields = GetMergeFields(tableName, dbFields, mappings, qualifierFields).AsList();
+            var identityField = dbFields.GetIdentity()?.AsField();
 
             if (!HasUpdateableFields(stagingFields, qualifierFields))
             {
@@ -350,8 +351,7 @@ namespace RepoDb
             {
                 await VerticaExecution.CreatePseudoTableAsync(connection, pseudoTableName, stagingFields, dbFields, pseudoTableType, trace, traceKey, transaction, cancellationToken);
                 await WriteToServerAsyncInternal(connection, pseudoTableName, table, rowState, mappings, bulkCopyTimeout, batchSize, transaction, cancellationToken);
-
-                result = await VerticaExecution.UpdateFromPseudoTableAsync(connection, tableName, pseudoTableName, stagingFields, qualifierFields, trace, traceKey, transaction, cancellationToken);
+                result = await VerticaExecution.UpdateFromPseudoTableAsync(connection, tableName, pseudoTableName, stagingFields, qualifierFields, identityField, trace, traceKey, transaction, cancellationToken);
             }
             finally
             {
@@ -398,6 +398,7 @@ namespace RepoDb
             var dbFields = await DbFieldCache.GetAsync(connection, tableName, transaction, cancellationToken);
             var qualifierFields = GetQualifierFields(tableName, dbFields, qualifiers).AsList();
             var stagingFields = GetMergeFields(tableName, dbFields, mappings, qualifierFields).AsList();
+            var identityField = dbFields.GetIdentity()?.AsField();
 
             if (!HasUpdateableFields(stagingFields, qualifierFields))
             {
@@ -415,8 +416,7 @@ namespace RepoDb
             {
                 await VerticaExecution.CreatePseudoTableAsync(connection, pseudoTableName, stagingFields, dbFields, pseudoTableType, trace, traceKey, transaction, cancellationToken);
                 await WriteToServerAsyncInternal(connection, pseudoTableName, reader, mappings ?? GetDefaultMappingsForDataReader(connection, tableName, reader, transaction).AsList(), bulkCopyTimeout, batchSize, transaction, cancellationToken);
-
-                result = await VerticaExecution.UpdateFromPseudoTableAsync(connection, tableName, pseudoTableName, stagingFields, qualifierFields, trace, traceKey, transaction, cancellationToken);
+                result = await VerticaExecution.UpdateFromPseudoTableAsync(connection, tableName, pseudoTableName, stagingFields, qualifierFields, identityField, trace, traceKey, transaction, cancellationToken);
             }
             finally
             {

--- a/src/Providers/RepoDb.Vertica.BulkOperations/RepoDb.Vertica.BulkOperations/Helpers/VerticaExecution.cs
+++ b/src/Providers/RepoDb.Vertica.BulkOperations/RepoDb.Vertica.BulkOperations/Helpers/VerticaExecution.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Vertica.Data.VerticaClient;
@@ -255,10 +256,7 @@ namespace RepoDb.Vertica.BulkOperations.Extensions
 
             var lastIdentity = Convert.ToInt64(connection.GetDbHelper().GetScopeIdentity<object>(connection, transaction));
 
-            for (var i = 0; i < rows.Count; i++)
-            {
-                rows[i][identityField.Name] = lastIdentity - (rows.Count - 1 - i);
-            }
+            SetIdentityValues(rows, identityField, i => lastIdentity - (rows.Count - 1 - i));
 
             return rows.Count;
         }
@@ -298,12 +296,51 @@ namespace RepoDb.Vertica.BulkOperations.Extensions
 
             var lastIdentity = Convert.ToInt64(await connection.GetDbHelper().GetScopeIdentityAsync<object>(connection, transaction, cancellationToken));
 
-            for (var i = 0; i < rows.Count; i++)
-            {
-                rows[i][identityField.Name] = lastIdentity - (rows.Count - 1 - i);
-            }
+            SetIdentityValues(rows, identityField, i => lastIdentity - (rows.Count - 1 - i));
 
             return rows.Count;
+        }
+
+        /// <summary>
+        /// Writes the server-generated identity values back into the source <see cref="DataRow"/> instances.
+        /// The identity column is temporarily unmarked as read-only for the duration of the write - <see cref="DataTable.Load(IDataReader)"/>
+        /// (e.g. loading from a SELECT against an existing table) marks an identity/computed column as read-only based on the reader's
+        /// schema, which would otherwise make every assignment below throw a <see cref="ReadOnlyException"/>.
+        /// </summary>
+        /// <param name="rows"></param>
+        /// <param name="identityField"></param>
+        /// <param name="valueSelector">Resolves the identity value to assign for the row at the given index.</param>
+        private static void SetIdentityValues(IList<DataRow> rows,
+            Field identityField,
+            Func<int, object> valueSelector)
+        {
+            if (rows.Count == 0)
+            {
+                return;
+            }
+
+            var column = rows[0].Table.Columns[identityField.Name];
+            var wasReadOnly = column.ReadOnly;
+
+            if (wasReadOnly)
+            {
+                column.ReadOnly = false;
+            }
+
+            try
+            {
+                for (var i = 0; i < rows.Count; i++)
+                {
+                    rows[i][identityField.Name] = valueSelector(i);
+                }
+            }
+            finally
+            {
+                if (wasReadOnly)
+                {
+                    column.ReadOnly = true;
+                }
+            }
         }
 
         #endregion
@@ -333,8 +370,13 @@ namespace RepoDb.Vertica.BulkOperations.Extensions
             string traceKey = null,
             VerticaTransaction transaction = null)
         {
-            var commandText = VerticaText.GetMergeFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, identityField, false, connection.GetDbSetting());
-            connection.ExecuteNonQuery(commandText, trace: trace, traceKey: traceKey, transaction: transaction);
+            var updateText = VerticaText.GetMergeUpdateFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, identityField, connection.GetDbSetting());
+            if (updateText != null)
+            {
+                connection.ExecuteNonQuery(updateText, trace: trace, traceKey: traceKey, transaction: transaction);
+            }
+            var insertText = VerticaText.GetMergeInsertFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, identityField, connection.GetDbSetting());
+            connection.ExecuteNonQuery(insertText, trace: trace, traceKey: traceKey, transaction: transaction);
             var countText = VerticaText.GetPseudoTableRowCountSql(pseudoTableName, connection.GetDbSetting());
             return connection.ExecuteScalar<int>(countText, transaction: transaction);
         }
@@ -364,14 +406,87 @@ namespace RepoDb.Vertica.BulkOperations.Extensions
             VerticaTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
-            var commandText = VerticaText.GetMergeFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, identityField, false, connection.GetDbSetting());
-            await connection.ExecuteNonQueryAsync(commandText, trace: trace, traceKey: traceKey, transaction: transaction, cancellationToken: cancellationToken);
+            var updateText = VerticaText.GetMergeUpdateFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, identityField, connection.GetDbSetting());
+            if (updateText != null)
+            {
+                await connection.ExecuteNonQueryAsync(updateText, trace: trace, traceKey: traceKey, transaction: transaction, cancellationToken: cancellationToken);
+            }
+            var insertText = VerticaText.GetMergeInsertFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, identityField, connection.GetDbSetting());
+            await connection.ExecuteNonQueryAsync(insertText, trace: trace, traceKey: traceKey, transaction: transaction, cancellationToken: cancellationToken);
             var countText = VerticaText.GetPseudoTableRowCountSql(pseudoTableName, connection.GetDbSetting());
             return await connection.ExecuteScalarAsync<int>(countText, transaction: transaction, cancellationToken: cancellationToken);
         }
 
         /// <summary>
-        /// 
+        /// True when the identity column is itself one of the merge qualifiers - the common "merge by primary
+        /// key" shape. In that shape, a row's original identity value doubles as the caller's intent: a real,
+        /// already-known value means "update this existing row" and the unset 0/null sentinel means "insert a
+        /// new row, generate its identity" - see <see cref="IsUnsetIdentityValue"/> and <see cref="ComputeNewRowIdentities"/>.
+        /// When the identity column is not a qualifier, its value carries no such meaning and every row's
+        /// identity is instead read back via <see cref="VerticaText.GetSelectIdentityAfterMergeSql"/>.
+        /// </summary>
+        private static bool IsIdentityQualifier(IEnumerable<Field> qualifiers, Field identityField) =>
+            qualifiers.Any(q => string.Equals(q.Name, identityField.Name, StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>
+        /// True when a value read from a row's identity property/column is the "please generate one" sentinel.
+        /// </summary>
+        private static bool IsUnsetIdentityValue(object value) =>
+            value == null || value is DBNull || Convert.ToInt64(value) == 0;
+
+        /// <summary>
+        /// Computes, in insertion order, the identity values Vertica assigned to the rows inserted by the merge's
+        /// INSERT statement. Vertica assigns IDENTITY/AUTO_INCREMENT values contiguously in the order rows are
+        /// inserted (the INSERT is itself ordered by the pseudo table's row-order column), so the last value of
+        /// the underlying sequence minus a descending offset reconstructs every inserted row's value - the same
+        /// technique <see cref="InsertFromPseudoTableForReturnIdentity{TEntity}"/> already relies on.
+        /// </summary>
+        private static long[] ComputeNewRowIdentities(VerticaConnection connection,
+            int insertedCount,
+            VerticaTransaction transaction)
+        {
+            if (insertedCount == 0)
+            {
+                return [];
+            }
+
+            var lastIdentity = Convert.ToInt64(connection.GetDbHelper().GetScopeIdentity<object>(connection, transaction));
+            var identities = new long[insertedCount];
+
+            for (var i = 0; i < insertedCount; i++)
+            {
+                identities[i] = lastIdentity - (insertedCount - 1 - i);
+            }
+
+            return identities;
+        }
+
+        /// <summary>
+        /// Asynchronous counterpart of <see cref="ComputeNewRowIdentities"/>.
+        /// </summary>
+        private static async Task<long[]> ComputeNewRowIdentitiesAsync(VerticaConnection connection,
+            int insertedCount,
+            VerticaTransaction transaction,
+            CancellationToken cancellationToken)
+        {
+            if (insertedCount == 0)
+            {
+                return [];
+            }
+
+            var lastIdentity = Convert.ToInt64(await connection.GetDbHelper().GetScopeIdentityAsync<object>(connection, transaction, cancellationToken));
+            var identities = new long[insertedCount];
+
+            for (var i = 0; i < insertedCount; i++)
+            {
+                identities[i] = lastIdentity - (insertedCount - 1 - i);
+            }
+
+            return identities;
+        }
+
+        /// <summary>
+        ///
         /// </summary>
         /// <typeparam name="TEntity"></typeparam>
         /// <param name="connection"></param>
@@ -397,10 +512,41 @@ namespace RepoDb.Vertica.BulkOperations.Extensions
             VerticaTransaction transaction = null)
             where TEntity : class
         {
-            var commandText = VerticaText.GetMergeFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, identityField, true, connection.GetDbSetting());
+            var dbSetting = connection.GetDbSetting();
+            var qualifierList = qualifiers.AsList();
+            var identityIsQualifier = IsIdentityQualifier(qualifierList, identityField);
+
+            var updateText = VerticaText.GetMergeUpdateFromPseudoTableSql(tableName, pseudoTableName, fields, qualifierList, identityField, dbSetting);
+            if (updateText != null)
+            {
+                connection.ExecuteNonQuery(updateText, trace: trace, traceKey: traceKey, transaction: transaction);
+            }
+            var insertText = VerticaText.GetMergeInsertFromPseudoTableSql(tableName, pseudoTableName, fields, qualifierList, identityField, dbSetting);
+            var insertedCount = connection.ExecuteNonQuery(insertText, trace: trace, traceKey: traceKey, transaction: transaction);
+
             var setter = FunctionCache.GetDataEntityPropertySetterCompiledFunction(typeof(TEntity), identityField);
 
-            using var command = CreateReaderCommand(connection, commandText, transaction);
+            if (identityIsQualifier)
+            {
+                var getter = PropertyCache.Get(typeof(TEntity), identityField, true)?.PropertyInfo;
+                var newIdentities = ComputeNewRowIdentities(connection, insertedCount, transaction);
+                var newIndex = 0;
+
+                for (var i = 0; i < entities.Count; i++)
+                {
+                    if (IsUnsetIdentityValue(getter?.GetValue(entities[i])))
+                    {
+                        setter?.Invoke(entities[i], newIdentities[newIndex]);
+                        newIndex++;
+                    }
+                }
+
+                return entities.Count;
+            }
+
+            var selectText = VerticaText.GetSelectIdentityAfterMergeSql(tableName, pseudoTableName, qualifierList, identityField, dbSetting);
+
+            using var command = CreateReaderCommand(connection, selectText, transaction);
             using var reader = command.ExecuteReader();
             var result = 0;
 
@@ -442,10 +588,41 @@ namespace RepoDb.Vertica.BulkOperations.Extensions
             CancellationToken cancellationToken = default)
             where TEntity : class
         {
-            var commandText = VerticaText.GetMergeFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, identityField, true, connection.GetDbSetting());
+            var dbSetting = connection.GetDbSetting();
+            var qualifierList = qualifiers.AsList();
+            var identityIsQualifier = IsIdentityQualifier(qualifierList, identityField);
+
+            var updateText = VerticaText.GetMergeUpdateFromPseudoTableSql(tableName, pseudoTableName, fields, qualifierList, identityField, dbSetting);
+            if (updateText != null)
+            {
+                await connection.ExecuteNonQueryAsync(updateText, trace: trace, traceKey: traceKey, transaction: transaction, cancellationToken: cancellationToken);
+            }
+            var insertText = VerticaText.GetMergeInsertFromPseudoTableSql(tableName, pseudoTableName, fields, qualifierList, identityField, dbSetting);
+            var insertedCount = await connection.ExecuteNonQueryAsync(insertText, trace: trace, traceKey: traceKey, transaction: transaction, cancellationToken: cancellationToken);
+
             var setter = FunctionCache.GetDataEntityPropertySetterCompiledFunction(typeof(TEntity), identityField);
 
-            using var command = CreateReaderCommand(connection, commandText, transaction);
+            if (identityIsQualifier)
+            {
+                var getter = PropertyCache.Get(typeof(TEntity), identityField, true)?.PropertyInfo;
+                var newIdentities = await ComputeNewRowIdentitiesAsync(connection, insertedCount, transaction, cancellationToken);
+                var newIndex = 0;
+
+                for (var i = 0; i < entities.Count; i++)
+                {
+                    if (IsUnsetIdentityValue(getter?.GetValue(entities[i])))
+                    {
+                        setter?.Invoke(entities[i], newIdentities[newIndex]);
+                        newIndex++;
+                    }
+                }
+
+                return entities.Count;
+            }
+
+            var selectText = VerticaText.GetSelectIdentityAfterMergeSql(tableName, pseudoTableName, qualifierList, identityField, dbSetting);
+
+            using var command = CreateReaderCommand(connection, selectText, transaction);
             using var reader = await command.ExecuteReaderAsync(cancellationToken);
             var result = 0;
 
@@ -483,19 +660,47 @@ namespace RepoDb.Vertica.BulkOperations.Extensions
             string traceKey = null,
             VerticaTransaction transaction = null)
         {
-            var commandText = VerticaText.GetMergeFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, identityField, true, connection.GetDbSetting());
+            var dbSetting = connection.GetDbSetting();
+            var qualifierList = qualifiers.AsList();
+            var identityIsQualifier = IsIdentityQualifier(qualifierList, identityField);
 
-            using var command = CreateReaderCommand(connection, commandText, transaction);
-            using var reader = command.ExecuteReader();
-            var result = 0;
-
-            while (reader.Read())
+            var updateText = VerticaText.GetMergeUpdateFromPseudoTableSql(tableName, pseudoTableName, fields, qualifierList, identityField, dbSetting);
+            if (updateText != null)
             {
-                rows[result][identityField.Name] = Converter.DbNullToNull(reader.GetValue(0));
-                result++;
+                connection.ExecuteNonQuery(updateText, trace: trace, traceKey: traceKey, transaction: transaction);
+            }
+            var insertText = VerticaText.GetMergeInsertFromPseudoTableSql(tableName, pseudoTableName, fields, qualifierList, identityField, dbSetting);
+            var insertedCount = connection.ExecuteNonQuery(insertText, trace: trace, traceKey: traceKey, transaction: transaction);
+
+            if (identityIsQualifier)
+            {
+                var newIdentities = ComputeNewRowIdentities(connection, insertedCount, transaction);
+                var newIndex = 0;
+
+                SetIdentityValues(rows, identityField, i =>
+                {
+                    var current = rows[i][identityField.Name];
+                    return IsUnsetIdentityValue(current) ? newIdentities[newIndex++] : current;
+                });
+
+                return rows.Count;
             }
 
-            return result;
+            var selectText = VerticaText.GetSelectIdentityAfterMergeSql(tableName, pseudoTableName, qualifierList, identityField, dbSetting);
+            var values = new List<object>();
+
+            using (var command = CreateReaderCommand(connection, selectText, transaction))
+            using (var reader = command.ExecuteReader())
+            {
+                while (reader.Read())
+                {
+                    values.Add(Converter.DbNullToNull(reader.GetValue(0)));
+                }
+            }
+
+            SetIdentityValues(rows, identityField, i => values[i]);
+
+            return values.Count;
         }
 
         /// <summary>
@@ -525,19 +730,47 @@ namespace RepoDb.Vertica.BulkOperations.Extensions
             VerticaTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
-            var commandText = VerticaText.GetMergeFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, identityField, true, connection.GetDbSetting());
+            var dbSetting = connection.GetDbSetting();
+            var qualifierList = qualifiers.AsList();
+            var identityIsQualifier = IsIdentityQualifier(qualifierList, identityField);
 
-            using var command = CreateReaderCommand(connection, commandText, transaction);
-            using var reader = await command.ExecuteReaderAsync(cancellationToken);
-            var result = 0;
-
-            while (await reader.ReadAsync(cancellationToken))
+            var updateText = VerticaText.GetMergeUpdateFromPseudoTableSql(tableName, pseudoTableName, fields, qualifierList, identityField, dbSetting);
+            if (updateText != null)
             {
-                rows[result][identityField.Name] = Converter.DbNullToNull(reader.GetValue(0));
-                result++;
+                await connection.ExecuteNonQueryAsync(updateText, trace: trace, traceKey: traceKey, transaction: transaction, cancellationToken: cancellationToken);
+            }
+            var insertText = VerticaText.GetMergeInsertFromPseudoTableSql(tableName, pseudoTableName, fields, qualifierList, identityField, dbSetting);
+            var insertedCount = await connection.ExecuteNonQueryAsync(insertText, trace: trace, traceKey: traceKey, transaction: transaction, cancellationToken: cancellationToken);
+
+            if (identityIsQualifier)
+            {
+                var newIdentities = await ComputeNewRowIdentitiesAsync(connection, insertedCount, transaction, cancellationToken);
+                var newIndex = 0;
+
+                SetIdentityValues(rows, identityField, i =>
+                {
+                    var current = rows[i][identityField.Name];
+                    return IsUnsetIdentityValue(current) ? newIdentities[newIndex++] : current;
+                });
+
+                return rows.Count;
             }
 
-            return result;
+            var selectText = VerticaText.GetSelectIdentityAfterMergeSql(tableName, pseudoTableName, qualifierList, identityField, dbSetting);
+            var values = new List<object>();
+
+            using (var command = CreateReaderCommand(connection, selectText, transaction))
+            using (var reader = await command.ExecuteReaderAsync(cancellationToken))
+            {
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    values.Add(Converter.DbNullToNull(reader.GetValue(0)));
+                }
+            }
+
+            SetIdentityValues(rows, identityField, i => values[i]);
+
+            return values.Count;
         }
 
         #endregion
@@ -545,13 +778,15 @@ namespace RepoDb.Vertica.BulkOperations.Extensions
         #region Update
 
         /// <summary>
-        /// 
+        /// Updates the target table from the pseudo table's rows. Reuses <see cref="VerticaText.GetMergeUpdateFromPseudoTableSql"/> -
+        /// a bulk update is just the update half of a merge, and Vertica's identity-column restrictions apply here too.
         /// </summary>
         /// <param name="connection"></param>
         /// <param name="tableName"></param>
         /// <param name="pseudoTableName"></param>
         /// <param name="fields"></param>
         /// <param name="qualifiers"></param>
+        /// <param name="identityField"></param>
         /// <param name="trace"></param>
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
@@ -561,22 +796,24 @@ namespace RepoDb.Vertica.BulkOperations.Extensions
             string pseudoTableName,
             IEnumerable<Field> fields,
             IEnumerable<Field> qualifiers,
+            Field identityField,
             ITrace trace = null,
             string traceKey = null,
             VerticaTransaction transaction = null)
         {
-            var commandText = VerticaText.GetUpdateFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, connection.GetDbSetting());
-            return connection.ExecuteNonQuery(commandText, trace: trace, traceKey: traceKey, transaction: transaction);
+            var commandText = VerticaText.GetMergeUpdateFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, identityField, connection.GetDbSetting());
+            return commandText == null ? 0 : connection.ExecuteNonQuery(commandText, trace: trace, traceKey: traceKey, transaction: transaction);
         }
 
         /// <summary>
-        /// 
+        /// Asynchronous counterpart of <see cref="UpdateFromPseudoTable"/>.
         /// </summary>
         /// <param name="connection"></param>
         /// <param name="tableName"></param>
         /// <param name="pseudoTableName"></param>
         /// <param name="fields"></param>
         /// <param name="qualifiers"></param>
+        /// <param name="identityField"></param>
         /// <param name="trace"></param>
         /// <param name="traceKey"></param>
         /// <param name="transaction"></param>
@@ -587,13 +824,14 @@ namespace RepoDb.Vertica.BulkOperations.Extensions
             string pseudoTableName,
             IEnumerable<Field> fields,
             IEnumerable<Field> qualifiers,
+            Field identityField,
             ITrace trace = null,
             string traceKey = null,
             VerticaTransaction transaction = null,
             CancellationToken cancellationToken = default)
         {
-            var commandText = VerticaText.GetUpdateFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, connection.GetDbSetting());
-            return await connection.ExecuteNonQueryAsync(commandText, trace: trace, traceKey: traceKey, transaction: transaction, cancellationToken: cancellationToken);
+            var commandText = VerticaText.GetMergeUpdateFromPseudoTableSql(tableName, pseudoTableName, fields, qualifiers, identityField, connection.GetDbSetting());
+            return commandText == null ? 0 : await connection.ExecuteNonQueryAsync(commandText, trace: trace, traceKey: traceKey, transaction: transaction, cancellationToken: cancellationToken);
         }
 
         #endregion

--- a/src/Providers/RepoDb.Vertica.BulkOperations/RepoDb.Vertica.BulkOperations/Helpers/VerticaText.cs
+++ b/src/Providers/RepoDb.Vertica.BulkOperations/RepoDb.Vertica.BulkOperations/Helpers/VerticaText.cs
@@ -9,7 +9,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using RepoDb.Enumerations.Vertica;
 using RepoDb.Extensions;
 using RepoDb.Interfaces;
@@ -118,14 +117,6 @@ namespace RepoDb
         private static string ColumnList(IEnumerable<Field> fields, IDbSetting dbSetting) =>
             fields.Select(f => f.Name.AsQuoted(true, dbSetting)).Join(", ");
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="count"></param>
-        /// <returns></returns>
-        private static string VariableList(int count) =>
-            string.Join(", ", Enumerable.Range(0, count).Select(i => ":V" + i));
-
         #endregion
 
         #region Insert
@@ -156,201 +147,108 @@ namespace RepoDb
         #region Merge
 
         /// <summary>
-        /// 
+        /// Builds the UPDATE half of a merge. Vertica flatly refuses to run a MERGE statement at all against a
+        /// table that has an IDENTITY/AUTO_INCREMENT column - "Sequence or IDENTITY/AUTO_INCREMENT column in
+        /// merge query is not supported" - regardless of whether that column appears in the SET/INSERT lists,
+        /// and it has no equivalent of Firebird's EXECUTE BLOCK/PSQL for a procedural row-by-row alternative
+        /// either. A merge is instead always expressed as this UPDATE ... FROM, followed by
+        /// <see cref="GetMergeInsertFromPseudoTableSql"/> and, when identities need to be returned,
+        /// <see cref="GetSelectIdentityAfterMergeSql"/>.
         /// </summary>
         /// <param name="tableName"></param>
         /// <param name="pseudoTableName"></param>
         /// <param name="fields"></param>
         /// <param name="qualifiers"></param>
         /// <param name="identityField"></param>
-        /// <param name="returnIdentity"></param>
         /// <param name="dbSetting"></param>
-        /// <returns></returns>
-        public static string GetMergeFromPseudoTableSql(string tableName,
+        /// <returns>The UPDATE statement, or <c>null</c> when there are no non-qualifier, non-identity fields to update.</returns>
+        public static string GetMergeUpdateFromPseudoTableSql(string tableName,
             string pseudoTableName,
             IEnumerable<Field> fields,
             IEnumerable<Field> qualifiers,
             Field identityField,
-            bool returnIdentity,
-            IDbSetting dbSetting)
-        {
-            var fieldList = fields.AsList();
-            var qualifierList = qualifiers.AsList();
-            var identityIsQualifier = identityField != null &&
-                qualifierList.Any(q => string.Equals(q.Name, identityField.Name, StringComparison.OrdinalIgnoreCase));
-
-            if (identityIsQualifier)
-            {
-                return GetMergeExecuteBlockSql(tableName, pseudoTableName, fieldList, qualifierList, identityField, returnIdentity, dbSetting);
-            }
-
-            var insertableFields = identityField == null
-                ? fieldList
-                : fieldList.Where(f => !string.Equals(f.Name, identityField.Name, StringComparison.OrdinalIgnoreCase)).AsList();
-
-            if (returnIdentity)
-            {
-                return GetUpsertLoopExecuteBlockSql(tableName, pseudoTableName, insertableFields, fieldList, qualifierList, identityField, dbSetting);
-            }
-
-            var quotedTable = tableName.AsQuoted(true, dbSetting);
-            var quotedPseudoTable = pseudoTableName.AsQuoted(true, dbSetting);
-            var onClause = qualifierList.Select(f => $"T.{f.Name.AsQuoted(true, dbSetting)} = S.{f.Name.AsQuoted(true, dbSetting)}").Join(" AND ");
-            var updateableFields = fieldList.Where(f => !qualifierList.Any(q => string.Equals(q.Name, f.Name, StringComparison.OrdinalIgnoreCase))).AsList();
-            var updateSetClause = updateableFields.Select(f => $"{f.Name.AsQuoted(true, dbSetting)} = S.{f.Name.AsQuoted(true, dbSetting)}").Join(", ");
-            var matchedClause = updateableFields.Count > 0 ? $"WHEN MATCHED THEN UPDATE SET {updateSetClause} " : string.Empty;
-            var insertColumns = ColumnList(insertableFields, dbSetting);
-            var insertValues = insertableFields.Select(f => $"S.{f.Name.AsQuoted(true, dbSetting)}").Join(", ");
-
-            return string.Concat(
-                "MERGE INTO ", quotedTable, " T USING ", quotedPseudoTable, " S ON (", onClause, ") ",
-                matchedClause,
-                "WHEN NOT MATCHED THEN INSERT (", insertColumns, ") VALUES (", insertValues, ")");
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="tableName"></param>
-        /// <param name="pseudoTableName"></param>
-        /// <param name="insertableFields"></param>
-        /// <param name="allFields"></param>
-        /// <param name="qualifiers"></param>
-        /// <param name="identityField"></param>
-        /// <param name="dbSetting"></param>
-        /// <returns></returns>
-        private static string GetUpsertLoopExecuteBlockSql(string tableName,
-            string pseudoTableName,
-            IList<Field> insertableFields,
-            IList<Field> allFields,
-            IList<Field> qualifiers,
-            Field identityField,
-            IDbSetting dbSetting)
-        {
-            var quotedTable = tableName.AsQuoted(true, dbSetting);
-            var quotedPseudoTable = pseudoTableName.AsQuoted(true, dbSetting);
-            var quotedRowOrderColumn = RowOrderColumnName.AsQuoted(true, dbSetting);
-            var quotedIdentityColumn = identityField.Name.AsQuoted(true, dbSetting);
-
-            var sb = new StringBuilder("EXECUTE BLOCK RETURNS (R0 TYPE OF COLUMN ")
-                .Append(quotedTable).Append('.').Append(quotedIdentityColumn).Append(") AS ");
-
-            for (var i = 0; i < insertableFields.Count; i++)
-            {
-                sb.Append("DECLARE VARIABLE V").Append(i).Append(" TYPE OF COLUMN ")
-                    .Append(quotedPseudoTable).Append('.').Append(insertableFields[i].Name.AsQuoted(true, dbSetting)).Append("; ");
-            }
-
-            sb.Append("BEGIN FOR SELECT ").Append(ColumnList(insertableFields, dbSetting))
-                .Append(" FROM ").Append(quotedPseudoTable)
-                .Append(" ORDER BY ").Append(quotedRowOrderColumn)
-                .Append(" INTO ").Append(VariableList(insertableFields.Count))
-                .Append(" DO BEGIN UPDATE OR INSERT INTO ").Append(quotedTable)
-                .Append(" (").Append(ColumnList(insertableFields, dbSetting)).Append(") VALUES (")
-                .Append(VariableList(insertableFields.Count)).Append(") MATCHING (")
-                .Append(ColumnList(qualifiers, dbSetting)).Append(") RETURNING ")
-                .Append(quotedIdentityColumn).Append(" INTO :R0; SUSPEND; END END");
-
-            return sb.ToString();
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="tableName"></param>
-        /// <param name="pseudoTableName"></param>
-        /// <param name="fields"></param>
-        /// <param name="qualifiers"></param>
-        /// <param name="identityField"></param>
-        /// <param name="returnIdentity"></param>
-        /// <param name="dbSetting"></param>
-        /// <returns></returns>
-        private static string GetMergeExecuteBlockSql(string tableName,
-            string pseudoTableName,
-            IList<Field> fields,
-            IList<Field> qualifiers,
-            Field identityField,
-            bool returnIdentity,
-            IDbSetting dbSetting)
-        {
-            var quotedTable = tableName.AsQuoted(true, dbSetting);
-            var quotedPseudoTable = pseudoTableName.AsQuoted(true, dbSetting);
-            var quotedRowOrderColumn = RowOrderColumnName.AsQuoted(true, dbSetting);
-            var quotedIdentityColumn = identityField.Name.AsQuoted(true, dbSetting);
-            var identityIndex = fields.ToList().FindIndex(f => string.Equals(f.Name, identityField.Name, StringComparison.OrdinalIgnoreCase));
-
-            var sb = new StringBuilder("EXECUTE BLOCK ");
-            if (returnIdentity)
-            {
-                sb.Append("RETURNS (R0 TYPE OF COLUMN ").Append(quotedTable).Append('.').Append(quotedIdentityColumn).Append(") ");
-            }
-            sb.Append("AS ");
-
-            for (var i = 0; i < fields.Count; i++)
-            {
-                sb.Append("DECLARE VARIABLE V").Append(i).Append(" TYPE OF COLUMN ")
-                    .Append(quotedPseudoTable).Append('.').Append(fields[i].Name.AsQuoted(true, dbSetting)).Append("; ");
-            }
-
-            var insertableFields = fields.Where(f => !string.Equals(f.Name, identityField.Name, StringComparison.OrdinalIgnoreCase)).AsList();
-            var insertableVariables = string.Join(", ", fields
-                .Select((f, i) => (f, i))
-                .Where(x => !string.Equals(x.f.Name, identityField.Name, StringComparison.OrdinalIgnoreCase))
-                .Select(x => ":V" + x.i));
-            var returningClause = returnIdentity ? $" RETURNING {quotedIdentityColumn} INTO :R0" : string.Empty;
-            // Row order only matters when correlating yielded identities back to source rows below -
-            // a non-return-identity merge doesn't care what order its per-row upserts run in.
-            var orderByClause = returnIdentity ? $" ORDER BY {quotedRowOrderColumn}" : string.Empty;
-
-            sb.Append("BEGIN FOR SELECT ").Append(ColumnList(fields, dbSetting))
-                .Append(" FROM ").Append(quotedPseudoTable).Append(orderByClause)
-                .Append(" INTO ").Append(VariableList(fields.Count))
-                .Append(" DO BEGIN IF (:V").Append(identityIndex).Append(" IS NULL OR :V").Append(identityIndex).Append(" = 0) THEN BEGIN ")
-                .Append("INSERT INTO ").Append(quotedTable)
-                .Append(" (").Append(ColumnList(insertableFields, dbSetting)).Append(") VALUES (")
-                .Append(insertableVariables).Append(')').Append(returningClause).Append("; END ")
-                .Append("ELSE BEGIN ")
-                .Append("UPDATE OR INSERT INTO ").Append(quotedTable)
-                .Append(" (").Append(ColumnList(fields, dbSetting)).Append(") VALUES (")
-                .Append(VariableList(fields.Count)).Append(") MATCHING (")
-                .Append(ColumnList(qualifiers, dbSetting)).Append(')').Append(returningClause).Append("; END ");
-
-            if (returnIdentity)
-            {
-                sb.Append("SUSPEND; ");
-            }
-            sb.Append("END END");
-
-            return sb.ToString();
-        }
-
-        #endregion
-
-        #region Update
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="tableName"></param>
-        /// <param name="pseudoTableName"></param>
-        /// <param name="fields"></param>
-        /// <param name="qualifiers"></param>
-        /// <param name="dbSetting"></param>
-        /// <returns></returns>
-        public static string GetUpdateFromPseudoTableSql(string tableName,
-            string pseudoTableName,
-            IEnumerable<Field> fields,
-            IEnumerable<Field> qualifiers,
             IDbSetting dbSetting)
         {
             var qualifierList = qualifiers.AsList();
-            var onClause = qualifierList.Select(f => $"T.{f.Name.AsQuoted(true, dbSetting)} = S.{f.Name.AsQuoted(true, dbSetting)}").Join(" AND ");
-            var updateClause = fields.AsList()
+            var updateableFields = fields.AsList()
                 .Where(f => !qualifierList.Any(q => string.Equals(q.Name, f.Name, StringComparison.OrdinalIgnoreCase)))
-                .Select(f => $"{f.Name.AsQuoted(true, dbSetting)} = S.{f.Name.AsQuoted(true, dbSetting)}")
-                .Join(", ");
+                .Where(f => identityField == null || !string.Equals(f.Name, identityField.Name, StringComparison.OrdinalIgnoreCase))
+                .AsList();
 
-            return $"MERGE INTO {tableName.AsQuoted(true, dbSetting)} T USING {pseudoTableName.AsQuoted(true, dbSetting)} S ON ({onClause}) WHEN MATCHED THEN UPDATE SET {updateClause}";
+            if (updateableFields.Count == 0)
+            {
+                return null;
+            }
+
+            var quotedTable = tableName.AsQuoted(true, dbSetting);
+            var quotedPseudoTable = pseudoTableName.AsQuoted(true, dbSetting);
+            var setClause = updateableFields.Select(f => $"{f.Name.AsQuoted(true, dbSetting)} = S.{f.Name.AsQuoted(true, dbSetting)}").Join(", ");
+            var onClause = qualifierList.Select(f => $"{quotedTable}.{f.Name.AsQuoted(true, dbSetting)} = S.{f.Name.AsQuoted(true, dbSetting)}").Join(" AND ");
+
+            return $"UPDATE {quotedTable} SET {setClause} FROM {quotedPseudoTable} S WHERE {onClause}";
+        }
+
+        /// <summary>
+        /// Builds the INSERT half of a merge - see <see cref="GetMergeUpdateFromPseudoTableSql"/>. Only
+        /// pseudo-table rows with no matching row in the target (by <paramref name="qualifiers"/>) are inserted,
+        /// and the identity column (if any) is always excluded, since Vertica rejects an explicit value for it.
+        /// </summary>
+        /// <param name="tableName"></param>
+        /// <param name="pseudoTableName"></param>
+        /// <param name="fields"></param>
+        /// <param name="qualifiers"></param>
+        /// <param name="identityField"></param>
+        /// <param name="dbSetting"></param>
+        /// <returns></returns>
+        public static string GetMergeInsertFromPseudoTableSql(string tableName,
+            string pseudoTableName,
+            IEnumerable<Field> fields,
+            IEnumerable<Field> qualifiers,
+            Field identityField,
+            IDbSetting dbSetting)
+        {
+            var quotedTable = tableName.AsQuoted(true, dbSetting);
+            var quotedPseudoTable = pseudoTableName.AsQuoted(true, dbSetting);
+            var quotedRowOrderColumn = RowOrderColumnName.AsQuoted(true, dbSetting);
+            var qualifierList = qualifiers.AsList();
+            var insertableFields = identityField == null
+                ? fields.AsList()
+                : fields.AsList().Where(f => !string.Equals(f.Name, identityField.Name, StringComparison.OrdinalIgnoreCase)).AsList();
+            var insertColumns = ColumnList(insertableFields, dbSetting);
+            var insertSelect = insertableFields.Select(f => $"S.{f.Name.AsQuoted(true, dbSetting)}").Join(", ");
+            var existsClause = qualifierList.Select(f => $"{quotedTable}.{f.Name.AsQuoted(true, dbSetting)} = S.{f.Name.AsQuoted(true, dbSetting)}").Join(" AND ");
+
+            // Without an explicit ORDER BY, Vertica is free to insert the unmatched rows in whatever order its
+            // projections happen to yield them, which can silently scramble row order relative to the source -
+            // ordering by the pseudo table's row-order column keeps newly-inserted rows in source order.
+            return $"INSERT INTO {quotedTable} ({insertColumns}) SELECT {insertSelect} FROM {quotedPseudoTable} S WHERE NOT EXISTS (SELECT 1 FROM {quotedTable} WHERE {existsClause}) ORDER BY S.{quotedRowOrderColumn}";
+        }
+
+        /// <summary>
+        /// Reads back, per pseudo-table row and in source row order, the identity value of whichever target row
+        /// the merge's UPDATE/INSERT left in place for it - the pre-existing value for an updated row, or the
+        /// newly-generated one for an inserted row. Run this only after both <see cref="GetMergeUpdateFromPseudoTableSql"/>
+        /// and <see cref="GetMergeInsertFromPseudoTableSql"/> have executed, so every pseudo-table row has a match.
+        /// </summary>
+        /// <param name="tableName"></param>
+        /// <param name="pseudoTableName"></param>
+        /// <param name="qualifiers"></param>
+        /// <param name="identityField"></param>
+        /// <param name="dbSetting"></param>
+        /// <returns></returns>
+        public static string GetSelectIdentityAfterMergeSql(string tableName,
+            string pseudoTableName,
+            IEnumerable<Field> qualifiers,
+            Field identityField,
+            IDbSetting dbSetting)
+        {
+            var quotedTable = tableName.AsQuoted(true, dbSetting);
+            var quotedPseudoTable = pseudoTableName.AsQuoted(true, dbSetting);
+            var quotedIdentityColumn = identityField.Name.AsQuoted(true, dbSetting);
+            var quotedRowOrderColumn = RowOrderColumnName.AsQuoted(true, dbSetting);
+            var onClause = qualifiers.Select(f => $"T.{f.Name.AsQuoted(true, dbSetting)} = S.{f.Name.AsQuoted(true, dbSetting)}").Join(" AND ");
+
+            return $"SELECT T.{quotedIdentityColumn} FROM {quotedPseudoTable} S JOIN {quotedTable} T ON ({onClause}) ORDER BY S.{quotedRowOrderColumn}";
         }
 
         #endregion

--- a/src/Providers/RepoDb.Vertica/RepoDb.Vertica.UnitTests/Resolvers/DbTypeNameToColumnNameResolverTest.cs
+++ b/src/Providers/RepoDb.Vertica/RepoDb.Vertica.UnitTests/Resolvers/DbTypeNameToColumnNameResolverTest.cs
@@ -49,6 +49,19 @@ namespace RepoDb.Vertica.UnitTests.Resolvers
         }
 
         [TestMethod]
+        public void TestDbTypeNameToColumnNameResolverForInt()
+        {
+            // Setup
+            var resolver = new DbTypeNameToColumnNameResolver();
+
+            // Act
+            var result = resolver.Resolve("int");
+
+            // Assert
+            Assert.AreEqual("INTEGER", result);
+        }
+
+        [TestMethod]
         public void TestDbTypeNameToColumnNameResolverForBigInt()
         {
             // Setup

--- a/src/Providers/RepoDb.Vertica/RepoDb.Vertica/Resolvers/DbTypeNameToColumnNameResolver.cs
+++ b/src/Providers/RepoDb.Vertica/RepoDb.Vertica/Resolvers/DbTypeNameToColumnNameResolver.cs
@@ -28,7 +28,7 @@ namespace RepoDb.Resolvers
             return dbTypeName?.ToLowerInvariant() switch
             {
                 "smallint" => "SMALLINT",
-                "integer" => "INTEGER",
+                "int" or "integer" => "INTEGER",
                 "bigint" => "BIGINT",
                 "boolean" => "BOOLEAN",
                 "float" => "FLOAT",


### PR DESCRIPTION
## Summary

Fixes a series of failing integration tests in `RepoDb.Vertica.BulkOperations` (`BulkInsert`, `BulkMerge`, `BulkUpdate`). Most of the provider's SQL generation had been carried over from other bulk-operations packages — largely Firebird — without accounting for Vertica-specific behavior. Each fix below was driven by an actual failing test; several only became reachable after an earlier fix changed which SQL path a test exercised.

Ref: #1246

## What's fixed

### Type resolution
- `DbTypeNameToColumnNameResolver` only recognized `"integer"` when building a pseudo (staging) table's column types, but Vertica's own catalog (`v_catalog.columns.data_type`) reports every integer-width column as `"int"`. Unrecognized types silently fell back to `LONG VARCHAR`, which then failed to insert into a real `int` column with a type mismatch. Added `"int"` alongside `"integer"`.

### BulkInsert
- Loading a `DataTable` via `table.Load(reader)` against an existing table marks an identity/computed column `ReadOnly`, so writing the server-generated identity back into `DataRow`s threw `ReadOnlyException`. The identity column is now temporarily unmarked read-only for the duration of the write-back (`VerticaExecution.SetIdentityValues`).

### BulkMerge — replacing Firebird-only SQL
The merge SQL builders (`GetMergeExecuteBlockSql`, `GetUpsertLoopExecuteBlockSql`) emitted Firebird's `EXECUTE BLOCK ... :V0 ...` procedural PSQL, which Vertica has no equivalent of (`[100301] Inserting a compound statement with a parameter is not supported`). Separately, Vertica's `MERGE` statement can't run at all against a table with an `IDENTITY`/`AUTO_INCREMENT` column (`[0A000]`), regardless of what columns it touches, and it always rejects any explicit `INSERT`/`UPDATE` of that column (`[42601]`).

Replaced all of it with plain, Vertica-native SQL:
- `GetMergeUpdateFromPseudoTableSql` — `UPDATE target SET ... FROM pseudo WHERE <qualifiers match>`, always excluding the identity column, skipped entirely when there's nothing else to update.
- `GetMergeInsertFromPseudoTableSql` — `INSERT INTO target (...) SELECT ... FROM pseudo WHERE NOT EXISTS (matching row)`, ordered by the pseudo table's row-order column so newly-inserted rows land in source order (an unordered insert let Vertica scramble row order, breaking index-based result comparisons on empty-table merges).
- `GetSelectIdentityAfterMergeSql` — for merges where identity isn't itself the qualifier, correlates each row's post-merge identity back via `JOIN` on the real qualifiers.
- For merges keyed by the identity column itself (the common "merge by primary key" shape), a qualifier-value join can't work — a new row's pre-merge value is the `0`/null sentinel, not the identity Vertica just generated. Instead, `ComputeNewRowIdentities` replays the same "last sequence value minus a descending offset" trick already used for plain bulk-insert, applied only to rows whose original identity was unset; rows with a real value were matched and are left untouched.

### BulkUpdate
- Had its own separate, still-Firebird-shaped `GetUpdateFromPseudoTableSql` (a `MERGE INTO ... WHEN MATCHED THEN UPDATE` that didn't exclude the identity column from `SET`). Removed it — a bulk update is just the update half of a merge, so `BulkUpdate` now reuses `GetMergeUpdateFromPseudoTableSql` directly, threading the table's identity field through all six `BulkUpdateBase`/`BulkUpdateBaseAsync` overloads (entity / `DataTable` / `DbDataReader` × sync / async).

### Test expectations
- Several invalid-mapping tests across `BulkInsertTest`, `BulkMergeTest`, and `BulkUpdateTest` asserted `FormatException`; updated to `VerticaException`, matching what the Vertica ADO.NET driver actually throws.

## Testing

- `dotnet build` clean (0 warnings/errors) across `RepoDb.Vertica`, `RepoDb.Vertica.BulkOperations`, and their unit/integration test projects.
- Added `DbTypeNameToColumnNameResolverTest.TestDbTypeNameToColumnNameResolverForInt`; full `RepoDb.Vertica.UnitTests` suite passes (net8.0/net9.0/net10.0).
- Integration tests require a live Vertica instance not available in this environment — fixes were driven by the actual failures reported from a real test run and verified by build + code review, not re-executed here.

## Checklist

- [x] Builds cleanly across all target frameworks (net8.0/net9.0/net10.0)
- [x] Root-caused each failure rather than working around it (no `--no-verify`/skip-test shortcuts)
- [ ] Integration tests re-run against a live Vertica instance (not available in this environment)
