### PR TITLE
Enterprise Benchmark

### DIFF
--- a/src/Shared/RepoDb.Benchmarks/README.md
+++ b/src/Shared/RepoDb.Benchmarks/README.md
@@ -1,0 +1,111 @@
+# 📊 RepoDB Benchmarks
+
+Independent, reproducible performance benchmarks comparing RepoDB against the most widely used .NET ORMs, across every database provider RepoDB supports.
+
+-----
+
+## 🎯 Intentions
+
+Benchmarks are easy to game and hard to trust. Our goal here is the opposite: give the .NET community — and the enterprise companies evaluating RepoDB for production workloads — a **transparent, unbiased, and reproducible** way to compare data access libraries.
+
+To keep results honest, we hold ourselves to a few principles:
+
+- **🔬 Same rules for everyone** — Every ORM benchmarked runs the same operation, against the same schema, same dataset size, and same hardware/database instance, in the same run.
+- **📖 Open methodology** — The benchmark code lives in this repository. Nothing is hidden; anyone can read it, question it, or challenge it.
+- **🧪 Real, runnable code** — Every number is backed by a [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) project you can clone and run yourself against your own infrastructure.
+- **🙅 No cherry-picking** — We report the standard operations (CRUD, batch, and bulk) rather than hand-picking the scenarios where RepoDB happens to look best.
+- **🔓 Community-auditable** — If you believe a benchmark is unfair to RepoDB or to another ORM, open an issue or a PR. Corrections are welcome and expected.
+
+We built RepoDB because we believe developers deserve fast, low-overhead data access without giving up productivity. These benchmarks exist to prove that claim, not just state it.
+
+## 📁 List of Projects with Benchmark
+
+Each supported database provider has its own dedicated benchmark project. This list grows as RepoDB extends support to more providers.
+
+| Provider | Project | Status |
+|---|---|---|
+| 🟦 SQL Server | [RepoDb.Benchmarks.SqlServer](RepoDb.Benchmarks.SqlServer) | ✅ Available |
+| 🐘 PostgreSQL | [RepoDb.Benchmarks.PostgreSql](RepoDb.Benchmarks.PostgreSql) | ✅ Available |
+| ⚙️ Shared infrastructure | [RepoDb.Benchmarks.Core](RepoDb.Benchmarks.Core) | Common models, base classes, and configurations shared across all providers |
+
+> More providers (MySQL, SQLite, Oracle, DB2, ClickHouse, and others already supported by RepoDB) will be added here over time. Contributions that add a new provider's benchmark project are very welcome.
+
+## ⚗️ Benchmarking Process
+
+All benchmarks are built on top of [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet), the de-facto standard for .NET micro-benchmarking, which handles process isolation, warm-up, and statistical rigor for us.
+
+1. **🏗️ Setup** — Each provider spins up (or reuses) a real database instance, creates the schema, and seeds it with data via `DatabaseHelper`.
+2. **🥇 Bootstrap** — A single "throwaway" call per ORM is issued before measurement starts, so JIT warm-up and connection pool initialization don't skew the first real result.
+3. **📏 Measurement** — BenchmarkDotNet runs each `[Benchmark]` method through its own configured iterations and warm-up count, executing every ORM under identical conditions within the same process run.
+4. **🧹 Cleanup** — Data is truncated/reset between benchmark classes so every ORM starts from the same baseline.
+5. **📈 Reporting** — Results are emitted as BenchmarkDotNet reports (Markdown, HTML, and console tables) under `BenchmarkDotNet.Artifacts`, including mean, error, standard deviation, and allocated memory.
+
+To run a benchmark project yourself, spin up the target database provider with the repository's root [docker-compose.yml](../../../docker-compose.yml), then run the matching benchmark project:
+
+```bash
+# 🟦 SQL Server
+docker compose up -d mssql
+cd RepoDb.Benchmarks.SqlServer
+dotnet run -c Release
+
+# 🐘 PostgreSQL
+docker compose up -d postgresql
+cd RepoDb.Benchmarks.PostgreSql
+dotnet run -c Release
+```
+
+> ⚠️ Always run benchmarks in `Release` configuration. Debug builds produce misleading results.
+
+Connection strings default to a local Dockerized instance, but can be overridden via the `REPODB_CONSTR` environment variable (and `REPODB_CONSTR_POSTGRESDB` for the PostgreSQL admin connection) if your container uses different credentials or a different host/port.
+
+## 🥊 ORMs Benchmarked
+
+| ORM | Style | NuGet |
+|---|---|---|
+| 🧩 **RepoDb** | Hybrid-ORM (fluent + raw SQL) | [RepoDb](https://www.nuget.org/packages/RepoDb) |
+| 🥤 **Dapper** | Micro-ORM (raw SQL + mapping) | [Dapper](https://www.nuget.org/packages/Dapper) |
+| 🏢 **Entity Framework Core** | Full-featured ORM | [Microsoft.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore) |
+| 🔗 **Linq2Db** | LINQ-first ORM | [linq2db](https://www.nuget.org/packages/linq2db) |
+| 🐝 **NHibernate** | Full-featured ORM | [NHibernate](https://www.nuget.org/packages/NHibernate) |
+
+Each ORM is exercised through its own idiomatic API (e.g., `DbContext` for EF Core, `Connection.Query` for Dapper, `Connection.QueryAll` for RepoDB) rather than forcing a shared abstraction, so every library is measured doing what it does best.
+
+> 📌 Not every ORM supports every database provider. Only the ORMs that officially support a given provider are included in that provider's benchmark project — so the list above may vary slightly from one provider to another.
+
+## 🛠️ Operations
+
+Benchmarks are grouped by operation category so you can compare libraries on the workload that matters to you:
+
+- **✏️ CRUD** — Single/first-record reads (`GetFirst`), full-table reads (`GetAll`), and row updates (`UpdateAll`).
+- **📦 Batch** — Multi-row operations executed as a set (e.g., `UpdateAll` across N rows) rather than one-row-at-a-time.
+- **🚛 Bulk** — Native bulk operations (e.g., `BulkInsertAll`, `BulkUpdateAll`) that leverage provider-specific bulk-copy mechanisms for very large datasets — a category most general-purpose ORMs don't support natively.
+
+Row counts are parameterized (typically `10`, `100`, and `1000`) so you can see how each ORM scales as dataset size grows, not just how it performs at a single fixed size.
+
+## ⚖️ Pros and Cons
+
+No ORM is universally "best" — each makes different trade-offs. Here's how they generally compare based on these benchmarks:
+
+| ORM | Pros | Cons |
+|---|---|---|
+| 🧩 **RepoDb** | Near-ADO.NET performance, native bulk operation support, low memory allocation, minimal setup | Smaller community than EF Core; less "magic" (by design) |
+| 🥤 **Dapper** | Extremely lightweight, very fast for raw SQL | No native bulk operations; more manual SQL to write |
+| 🏢 **EF Core** | Rich change tracking, migrations, LINQ provider, huge ecosystem | Higher overhead on reads/writes, larger memory footprint, slower on batch/bulk workloads |
+| 🔗 **Linq2Db** | Fast LINQ-to-SQL translation, low overhead | Smaller community, fewer bulk-operation conveniences than RepoDB |
+| 🐝 **NHibernate** | Mature, feature-rich (caching, mapping strategies) | Heaviest overhead of the group, steeper learning curve |
+
+> 📌 Exact numbers vary by hardware, database engine, and dataset size — always run the benchmarks against your own target environment before drawing conclusions for production use.
+
+-----
+
+## 🤝 Contributions
+
+Found a way to make a comparison fairer, more complete, or want to add a new provider? Contributions are very welcome.
+
+- Add a new provider by following the pattern in [RepoDb.Benchmarks.SqlServer](RepoDb.Benchmarks.SqlServer) or [RepoDb.Benchmarks.PostgreSql](RepoDb.Benchmarks.PostgreSql).
+- File a [new issue](https://github.com/mikependon/RepoDb/issues/new) if you spot a methodology concern.
+- Read the main [contributing guide](../../../CONTRIBUTING.md) before submitting a PR.
+
+## 📜 License
+
+[Apache-2.0](http://apache.org/licenses/LICENSE-2.0.html) — Copyright © 2018 [Michael Camara Pendon](https://x.com/mike_pendon)

--- a/src/Shared/RepoDb.Benchmarks/README.md
+++ b/src/Shared/RepoDb.Benchmarks/README.md
@@ -18,6 +18,20 @@ To keep results honest, we hold ourselves to a few principles:
 
 We built RepoDB because we believe developers deserve fast, low-overhead data access without giving up productivity. These benchmarks exist to prove that claim, not just state it.
 
+## 🏢 Enterprise Notice
+
+The numbers published alongside this repository are produced on infrastructure local to the RepoDB project (e.g., local Docker containers, CI runners, contributor machines). They are a useful signal, but they are **not** a substitute for validating performance in your own environment.
+
+Hardware, network topology, database configuration, cloud provider, virtualization/container overhead, and data volume all materially affect ORM performance — and none of these match between our environment and yours.
+
+If your organization is evaluating RepoDB for production use, we strongly recommend that you:
+
+- **🖥️ Run the benchmarks yourself** — Clone this repository and execute the relevant benchmark project(s) against infrastructure that mirrors your production environment.
+- **📐 Use your own data shape** — Adjust row counts, schema, and data types to reflect your actual workload rather than relying solely on the defaults used here.
+- **🚫 Avoid bias from our environment** — Treat any numbers you see in this README, in issues, or in marketing material as a starting point for your own investigation, not as a guarantee of the performance you'll see in your own environment.
+
+This is by design: the benchmarking code is fully open (see [Benchmarking Process](#️-benchmarking-process) below) specifically so it can be independently reproduced, rather than taken on faith.
+
 ## 📁 List of Projects with Benchmark
 
 Each supported database provider has its own dedicated benchmark project. This list grows as RepoDB extends support to more providers.

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/BaseBenchmark.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/BaseBenchmark.cs
@@ -1,0 +1,37 @@
+﻿#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Data;
+
+namespace RepoDb.Benchmarks.Core
+{
+    public abstract class BaseBenchmark
+    {
+        private const int BeforeAndAfterStepsCount = 2;
+
+        protected const int ElementsCount =
+            (
+                Configurations.DefaultsConstants.DefaultIterationCount *
+                Configurations.DefaultsConstants.DefaultUnrollFactor
+            ) +
+            Configurations.DefaultsConstants.DefaultWarmupCount +
+            BeforeAndAfterStepsCount;
+
+        protected int CurrentId;
+
+        public abstract void Cleanup();
+
+        public abstract void IterationSetup();
+
+        protected abstract void BaseSetup();
+
+        protected abstract void Bootstrap();
+
+        protected abstract IDbConnection GetConnection();
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/BenchmarkConfig.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/BenchmarkConfig.cs
@@ -1,0 +1,50 @@
+﻿#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Order;
+
+namespace RepoDb.Benchmarks.Core.Configurations
+{
+    public class BenchmarkConfig : ManualConfig
+    {
+        public BenchmarkConfig()
+        {
+            AddLogger(ConsoleLogger.Default);
+            AddExporter(MarkdownExporter.GitHub);
+            AddDiagnoser(MemoryDiagnoser.Default);
+
+            AddColumn(new OrmColumn());
+            AddColumn(TargetMethodColumn.Method);
+            AddColumn(StatisticColumn.Mean);
+            AddColumn(StatisticColumn.StdDev);
+            AddColumn(StatisticColumn.Error);
+            AddColumn(BaselineRatioColumn.RatioMean);
+            AddColumn(StatisticColumn.Min);
+            AddColumn(StatisticColumn.Max);
+
+            AddColumnProvider(DefaultColumnProviders.Metrics);
+
+            var job = Job.ShortRun
+                .WithLaunchCount(DefaultsConstants.DefaultLaunchCount)
+                .WithWarmupCount(DefaultsConstants.DefaultWarmupCount)
+                .WithUnrollFactor(DefaultsConstants.DefaultUnrollFactor)
+                .WithIterationCount(DefaultsConstants.DefaultIterationCount);
+
+            AddJob(job);
+
+            Orderer = new DefaultOrderer(SummaryOrderPolicy.FastestToSlowest);
+            Options |= ConfigOptions.JoinSummary | ConfigOptions.StopOnFirstError;
+        }
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/BenchmarkConfigWitRows.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/BenchmarkConfigWitRows.cs
@@ -1,0 +1,20 @@
+﻿#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using BenchmarkDotNet.Columns;
+
+namespace RepoDb.Benchmarks.Core.Configurations
+{
+    public class BenchmarkConfigWitRows : BenchmarkConfig
+    {
+        public BenchmarkConfigWitRows()
+        {
+            AddColumn(new ParamColumn("Rows"));
+        }
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/DefaultsConstants.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/DefaultsConstants.cs
@@ -1,0 +1,33 @@
+﻿#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+namespace RepoDb.Benchmarks.Core.Configurations
+{
+    public class DefaultsConstants
+    {
+        /// <summary>
+        /// How many times we should launch process with target benchmark.
+        /// </summary>
+        public const int DefaultLaunchCount = 1;
+
+        /// <summary>
+        /// How many warmup iterations should be performed.
+        /// </summary>
+        public const int DefaultWarmupCount = 2;
+
+        /// <summary>
+        /// How many times the benchmark method will be invoked per one iteration of a generated loop.
+        /// </summary>
+        public const int DefaultUnrollFactor = 500;
+
+        /// <summary>
+        /// How many target iterations should be performed.
+        /// </summary>
+        public const int DefaultIterationCount = 10;
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/OrmColumn.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/OrmColumn.cs
@@ -1,0 +1,40 @@
+﻿#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.ComponentModel;
+using System.Reflection;
+using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+
+namespace RepoDb.Benchmarks.Core.Configurations
+{
+    public sealed class OrmColumn : IColumn
+    {
+        public string Id => nameof(OrmColumn);
+        public string ColumnName { get; } = "ORM";
+        public string Legend => "The object/relational mapper being tested";
+
+        public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
+        public string GetValue(Summary summary, BenchmarkCase benchmarkCase)
+        {
+            var type = benchmarkCase.Descriptor.WorkloadMethod.DeclaringType;
+            return type?.GetCustomAttribute<DescriptionAttribute>()?.Description ?? type?.Name.Replace("Benchmarks", string.Empty);
+        }
+
+        public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style) => GetValue(summary, benchmarkCase);
+
+        public bool IsAvailable(Summary summary) => true;
+        public bool AlwaysShow => true;
+        public ColumnCategory Category => ColumnCategory.Job;
+        public int PriorityInCategory => -10;
+        public bool IsNumeric => false;
+        public UnitType UnitType => UnitType.Dimensionless;
+        public override string ToString() => ColumnName;
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Models/Person.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Models/Person.cs
@@ -1,0 +1,24 @@
+﻿#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace RepoDb.Benchmarks.Core.Models
+{
+    [Table("Person")]
+    public class Person
+    {
+        [Key]
+        public virtual long Id { get; set; }
+        public virtual string Name { get; set; }
+        public virtual int Age { get; set; }
+        public virtual DateTime CreatedDateUtc { get; set; }
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/RepoDb.Benchmarks.Core.csproj
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/RepoDb.Benchmarks.Core.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Title>RepoDb.Benchmarks.Core</Title>
+    <AssemblyName>RepoDb.Benchmarks.Core</AssemblyName>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <LangVersion>preview</LangVersion>
+    <Nullable>annotations</Nullable>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Remove="System.Linq.Async" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Providers\RepoDb.Core\RepoDb\RepoDb.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Configurations/BenchmarkConfig.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Configurations/BenchmarkConfig.cs
@@ -9,7 +9,6 @@
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
-using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
@@ -37,7 +36,6 @@ namespace RepoDb.Benchmarks.PostgreSql.Configurations
             AddColumnProvider(DefaultColumnProviders.Metrics);
 
             var job = Job.ShortRun
-                .WithRuntime(CoreRuntime.Core60) 
                 .WithLaunchCount(DefaultConstants.DefaultLaunchCount)
                 .WithWarmupCount(DefaultConstants.DefaultWarmupCount)
                 .WithUnrollFactor(DefaultConstants.DefaultUnrollFactor)

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Dapper/DapperBaseBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Dapper/DapperBaseBenchmarks.cs
@@ -9,13 +9,12 @@
 using System.ComponentModel;
 using BenchmarkDotNet.Attributes;
 using Dapper;
-using RepoDb.Benchmarks.PostgreSql.Configurations;
 using RepoDb.Benchmarks.PostgreSql.Models;
 
 namespace RepoDb.Benchmarks.PostgreSql.Dapper
 {
-    [Description(OrmNameConstants.Dapper)]
-    public class DapperBaseBenchmarks : BaseBenchmark
+    [Description("Dapper")]
+    public class DapperBaseBenchmarks : PostgreSqlBenchmark
     {
         [GlobalSetup]
         public void Setup() => BaseSetup();

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/EFCore/EFCoreBaseBenchmarks .cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/EFCore/EFCoreBaseBenchmarks .cs
@@ -10,14 +10,13 @@ using System.ComponentModel;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Microsoft.EntityFrameworkCore;
-using RepoDb.Benchmarks.PostgreSql.Configurations;
-using RepoDb.Benchmarks.PostgreSql.Models;
+using RepoDb.Benchmarks.PostgreSql.EFCore.Models;
 using RepoDb.Benchmarks.PostgreSql.Setup;
 
 namespace RepoDb.Benchmarks.PostgreSql.EFCore
 {
-    [Description(OrmNameConstants.EFCore)]
-    public class EFCoreBaseBenchmarks : BaseBenchmark
+    [Description("EFCore")]
+    public class EFCoreBaseBenchmarks : PostgreSqlBenchmark
     {
         [GlobalSetup]
         public void Setup() => BaseSetup();

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/EFCore/GetAllEFCoreBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/EFCore/GetAllEFCoreBenchmarks.cs
@@ -9,7 +9,7 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using Microsoft.EntityFrameworkCore;
-using RepoDb.Benchmarks.PostgreSql.Models;
+using RepoDb.Benchmarks.PostgreSql.EFCore.Models;
 using RepoDb.Benchmarks.PostgreSql.Setup;
 
 namespace RepoDb.Benchmarks.PostgreSql.EFCore

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/EFCore/GetFirstEFCoreBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/EFCore/GetFirstEFCoreBenchmarks.cs
@@ -9,6 +9,7 @@
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Microsoft.EntityFrameworkCore;
+using RepoDb.Benchmarks.PostgreSql.EFCore.Models;
 using RepoDb.Benchmarks.PostgreSql.Models;
 using RepoDb.Benchmarks.PostgreSql.Setup;
 

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/EFCore/Models/EFCoreContext.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/EFCore/Models/EFCoreContext.cs
@@ -1,0 +1,30 @@
+#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using Microsoft.EntityFrameworkCore;
+using RepoDb.Benchmarks.PostgreSql.Models;
+
+namespace RepoDb.Benchmarks.PostgreSql.EFCore.Models
+{
+    public class EFCoreContext : DbContext
+    {
+        private readonly string connectionString;
+
+        public EFCoreContext(string connectionString) => this.connectionString = connectionString;
+
+        public DbSet<Person> Persons { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) => optionsBuilder.UseNpgsql(connectionString);
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Person>()
+                .ToTable("Person");
+        }
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Linq2db/Linq2dbBaseBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Linq2db/Linq2dbBaseBenchmarks.cs
@@ -11,13 +11,12 @@ using System.Linq;
 using BenchmarkDotNet.Attributes;
 using DataModels;
 using LinqToDB;
-using RepoDb.Benchmarks.PostgreSql.Configurations;
 using RepoDb.Benchmarks.PostgreSql.Setup;
 
 namespace RepoDb.Benchmarks.PostgreSql.Linq2db
 {
-    [Description(OrmNameConstants.Linq2db)]
-    public class Linq2dbBaseBenchmarks : BaseBenchmark
+    [Description("Linq2db")]
+    public class Linq2dbBaseBenchmarks : PostgreSqlBenchmark
     {
         [GlobalSetup]
         public void Setup() => BaseSetup();

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/NHibernate/Models/PersonMap.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/NHibernate/Models/PersonMap.cs
@@ -1,0 +1,25 @@
+#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using NHibernate.Mapping.ByCode.Conformist;
+using RepoDb.Benchmarks.PostgreSql.Models;
+
+namespace RepoDb.Benchmarks.PostgreSql.NHibernate.Models
+{
+    public class PersonMap : ClassMapping<Person>
+    {
+        public PersonMap()
+        {
+            Table("\"Person\"");
+            Id(x => x.Id, mapper => mapper.Column(x => x.Name("\"Id\"")));
+            Property(x => x.Name, mapper => mapper.Column(x => x.Name("\"Name\"")));
+            Property(x => x.Age, mapper => mapper.Column(x => x.Name("\"Age\"")));
+            Property(x => x.CreatedDateUtc, mapper => mapper.Column(x => x.Name("\"CreatedDateUtc\"")));
+        }
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/NHibernate/NHibernateBaseBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/NHibernate/NHibernateBaseBenchmarks.cs
@@ -12,14 +12,13 @@ using NHibernate;
 using NHibernate.Cfg;
 using NHibernate.Dialect;
 using NHibernate.Mapping.ByCode;
-using RepoDb.Benchmarks.PostgreSql.Configurations;
-using RepoDb.Benchmarks.PostgreSql.Models;
+using RepoDb.Benchmarks.PostgreSql.NHibernate.Models;
 using RepoDb.Benchmarks.PostgreSql.Setup;
 
 namespace RepoDb.Benchmarks.PostgreSql.NHibernate
 {
-    [Description(OrmNameConstants.NHibernate)]
-    public class NHibernateBaseBenchmarks : BaseBenchmark
+    [Description("NHibernate")]
+    public class NHibernateBaseBenchmarks : PostgreSqlBenchmark
     {
         protected ISessionFactory SessionFactory;
 

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/PostgreSqlBenchmark.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/PostgreSqlBenchmark.cs
@@ -1,0 +1,33 @@
+#region Copyright Attributions
+
+// Copyright (c) 2026 Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Data;
+using BenchmarkDotNet.Attributes;
+using Npgsql;
+using RepoDb.Benchmarks.Core;
+using RepoDb.Benchmarks.PostgreSql.Setup;
+
+namespace RepoDb.Benchmarks.PostgreSql
+{
+    public abstract class PostgreSqlBenchmark : BaseBenchmark
+    {
+        [GlobalCleanup]
+        public override void Cleanup() => DatabaseHelper.Cleanup();
+
+        [IterationSetup]
+        public override void IterationSetup() => CurrentId++;
+
+        protected override void BaseSetup()
+        {
+            DatabaseHelper.Initialize(ElementsCount);
+            Bootstrap();
+        }
+
+        protected override IDbConnection GetConnection() => new NpgsqlConnection(DatabaseHelper.ConnectionString);
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Program.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Program.cs
@@ -6,10 +6,9 @@
 
 #endregion
 
+using System.Reflection;
 using BenchmarkDotNet.Running;
-using RepoDb.Benchmarks.PostgreSql.Configurations;
-using RepoDb.Benchmarks.PostgreSql.Dapper;
-using RepoDb.Benchmarks.PostgreSql.RepoDb;
+using RepoDb.Benchmarks.Core.Configurations;
 
 namespace RepoDb.Benchmarks.PostgreSql
 {
@@ -17,10 +16,7 @@ namespace RepoDb.Benchmarks.PostgreSql
     {
         private static void Main(string[] args)
         {
-            var switcher = new BenchmarkSwitcher(typeof(BenchmarkConfig).Assembly);
-            //switcher.RunAll(new BenchmarkConfigWitRows());
-
-            //For single run.
+            var switcher = new BenchmarkSwitcher(Assembly.GetExecutingAssembly());
             switcher.Run(args, new BenchmarkConfigWitRows());
         }
     }

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/RepoDb.Benchmarks.PostgreSql.csproj
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/RepoDb.Benchmarks.PostgreSql.csproj
@@ -8,15 +8,15 @@
     <Nullable>annotations</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
-    <PackageReference Include="Dapper" Version="2.1.21" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="Dapper" Version="2.1.79" />
     <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-    <PackageReference Include="linq2db" Version="5.3.2" />
-    <PackageReference Include="linq2db.PostgreSQL" Version="5.3.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.0" />
-    <PackageReference Include="NHibernate" Version="5.4.9" />
-    <PackageReference Include="Npgsql" Version="7.0.7" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.0" />
+    <PackageReference Include="linq2db" Version="6.4.0" />
+    <PackageReference Include="linq2db.PostgreSQL" Version="6.4.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageReference Include="NHibernate" Version="5.7.0" />
+    <PackageReference Include="Npgsql" Version="10.0.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Providers\RepoDb.PostgreSql\RepoDb.PostgreSql\RepoDb.PostgreSql.csproj" />

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/RepoDb.Benchmarks.PostgreSql.csproj
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/RepoDb.Benchmarks.PostgreSql.csproj
@@ -6,7 +6,18 @@
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>
     <Nullable>annotations</Nullable>
+    <Optimize>true</Optimize>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Configurations\**" />
+    <EmbeddedResource Remove="Configurations\**" />
+    <None Remove="Configurations\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="BaseBenchmark.cs" />
+    <Compile Remove="Models\EFCoreContext.cs" />
+    <Compile Remove="Models\PersonMap.cs" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Dapper" Version="2.1.79" />
@@ -20,5 +31,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Providers\RepoDb.PostgreSql\RepoDb.PostgreSql\RepoDb.PostgreSql.csproj" />
+    <ProjectReference Include="..\RepoDb.Benchmarks.Core\RepoDb.Benchmarks.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/RepoDb/RepoDbBaseBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/RepoDb/RepoDbBaseBenchmarks.cs
@@ -10,13 +10,12 @@ using System;
 using System.ComponentModel;
 using System.Data;
 using BenchmarkDotNet.Attributes;
-using RepoDb.Benchmarks.PostgreSql.Configurations;
 using RepoDb.Benchmarks.PostgreSql.Models;
 
 namespace RepoDb.Benchmarks.PostgreSql.RepoDb
 {
-    [Description(OrmNameConstants.RepoDB)]
-    public class RepoDbBaseBenchmarks : BaseBenchmark
+    [Description("RepoDB")]
+    public class RepoDbBaseBenchmarks : PostgreSqlBenchmark
     {
         [GlobalSetup]
         public void Setup()

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Configurations/BenchmarkConfig.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Configurations/BenchmarkConfig.cs
@@ -9,7 +9,6 @@
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
-using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
@@ -37,7 +36,6 @@ namespace RepoDb.Benchmarks.SqlServer.Configurations
             AddColumnProvider(DefaultColumnProviders.Metrics);
 
             var job = Job.ShortRun
-                .WithRuntime(CoreRuntime.Core60) 
                 .WithLaunchCount(DefaultsConstants.DefaultLaunchCount)
                 .WithWarmupCount(DefaultsConstants.DefaultWarmupCount)
                 .WithUnrollFactor(DefaultsConstants.DefaultUnrollFactor)

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Dapper/DapperBaseBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Dapper/DapperBaseBenchmarks.cs
@@ -9,13 +9,12 @@
 using System.ComponentModel;
 using BenchmarkDotNet.Attributes;
 using Dapper;
-using RepoDb.Benchmarks.SqlServer.Configurations;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.Core.Models;
 
 namespace RepoDb.Benchmarks.SqlServer.Dapper
 {
-    [Description(OrmNameConstants.Dapper)]
-    public class DapperBaseBenchmarks : BaseBenchmark
+    [Description("Dapper")]
+    public class DapperBaseBenchmarks : SqlServerBenchmark
     {
         [GlobalSetup]
         public void Setup() => BaseSetup();

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Dapper/GetAllDapperBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Dapper/GetAllDapperBenchmarks.cs
@@ -10,7 +10,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using Dapper;
 using Dapper.Contrib.Extensions;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.Core.Models;
 
 namespace RepoDb.Benchmarks.SqlServer.Dapper
 {

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Dapper/GetFirstDapperBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Dapper/GetFirstDapperBenchmarks.cs
@@ -9,7 +9,7 @@
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Dapper;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.Core.Models;
 
 namespace RepoDb.Benchmarks.SqlServer.Dapper
 {

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Dapper/UpdateAllDapperBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Dapper/UpdateAllDapperBenchmarks.cs
@@ -13,7 +13,7 @@ using BenchmarkDotNet.Attributes;
 using Dapper;
 using Dapper.Contrib.Extensions;
 using Microsoft.Data.SqlClient;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.Core.Models;
 using RepoDb.Benchmarks.SqlServer.Setup;
 
 namespace RepoDb.Benchmarks.SqlServer.Dapper

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/EFCore/EFCoreBaseBenchmarks .cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/EFCore/EFCoreBaseBenchmarks .cs
@@ -10,14 +10,13 @@ using System.ComponentModel;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Microsoft.EntityFrameworkCore;
-using RepoDb.Benchmarks.SqlServer.Configurations;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.SqlServer.EFCore.Models;
 using RepoDb.Benchmarks.SqlServer.Setup;
 
 namespace RepoDb.Benchmarks.SqlServer.EFCore
 {
-    [Description(OrmNameConstants.EFCore)]
-    public class EFCoreBaseBenchmarks : BaseBenchmark
+    [Description("EFCore")]
+    public class EFCoreBaseBenchmarks : SqlServerBenchmark
     {
         [GlobalSetup]
         public void Setup() => BaseSetup();

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/EFCore/GetAllEFCoreBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/EFCore/GetAllEFCoreBenchmarks.cs
@@ -9,7 +9,7 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using Microsoft.EntityFrameworkCore;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.SqlServer.EFCore.Models;
 using RepoDb.Benchmarks.SqlServer.Setup;
 
 namespace RepoDb.Benchmarks.SqlServer.EFCore

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/EFCore/GetFirstEFCoreBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/EFCore/GetFirstEFCoreBenchmarks.cs
@@ -9,7 +9,8 @@
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Microsoft.EntityFrameworkCore;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.Core.Models;
+using RepoDb.Benchmarks.SqlServer.EFCore.Models;
 using RepoDb.Benchmarks.SqlServer.Setup;
 
 namespace RepoDb.Benchmarks.SqlServer.EFCore

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/EFCore/Models/EFCoreContext.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/EFCore/Models/EFCoreContext.cs
@@ -1,0 +1,31 @@
+﻿#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using Microsoft.EntityFrameworkCore;
+using RepoDb;
+using RepoDb.Benchmarks.Core.Models;
+
+namespace RepoDb.Benchmarks.SqlServer.EFCore.Models
+{
+    public class EFCoreContext : DbContext
+    {
+        private readonly string connectionString;
+
+        public EFCoreContext(string connectionString) => this.connectionString = connectionString;
+
+        public DbSet<Person> Persons { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) => optionsBuilder.UseSqlServer(connectionString);
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Person>()
+                .ToTable("Person");
+        }
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Linq2db/GetAllLinq2dbBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Linq2db/GetAllLinq2dbBenchmarks.cs
@@ -1,0 +1,29 @@
+#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+
+namespace RepoDb.Benchmarks.SqlServer.Linq2db
+{
+    public class GetAllLinq2dbBenchmarks : Linq2dbBaseBenchmarks
+    {
+        private readonly Consumer consumer = new();
+
+        [Benchmark]
+        public void SelectAll()
+        {
+            using var db = GetDb();
+
+            var persons = from p in db.People select p;
+
+            persons.Consume(consumer);
+        }
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Linq2db/GetFirstLinq2dbBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Linq2db/GetFirstLinq2dbBenchmarks.cs
@@ -1,0 +1,24 @@
+#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using BenchmarkDotNet.Attributes;
+using DataModels;
+
+namespace RepoDb.Benchmarks.SqlServer.Linq2db
+{
+    public class GetFirstLinq2dbBenchmarks : Linq2dbBaseBenchmarks
+    {
+        [Benchmark]
+        public Person Find()
+        {
+            using var db = GetDb();
+
+            return db.People.Find(CurrentId);
+        }
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Linq2db/Linq2dbBaseBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Linq2db/Linq2dbBaseBenchmarks.cs
@@ -1,0 +1,39 @@
+#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.ComponentModel;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using DataModels;
+using LinqToDB;
+using RepoDb.Benchmarks.SqlServer.Setup;
+
+namespace RepoDb.Benchmarks.SqlServer.Linq2db
+{
+    [Description("Linq2db")]
+    public class Linq2dbBaseBenchmarks : SqlServerBenchmark
+    {
+        [GlobalSetup]
+        public void Setup() => BaseSetup();
+
+        protected override void Bootstrap()
+        {
+            using var db = GetDb();
+
+            db.People.Select(x => x.Id == CurrentId).ToList();
+        }
+
+        protected static RepoDbDB GetDb()
+        {
+            var options = new DataOptions();
+            options = options.UseSqlServer(DatabaseHelper.ConnectionString);
+
+            return new RepoDbDB(options);
+        }
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Linq2db/Models/PersonDatabase.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Linq2db/Models/PersonDatabase.cs
@@ -1,0 +1,66 @@
+#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Linq;
+
+using LinqToDB;
+using LinqToDB.Mapping;
+
+namespace DataModels
+{
+	public partial class RepoDbDB : LinqToDB.Data.DataConnection
+	{
+		public ITable<Person> People => this.GetTable<Person>();
+
+		partial void InitMappingSchema()
+		{
+		}
+
+		public RepoDbDB()
+		{
+			InitDataContext();
+			InitMappingSchema();
+		}
+
+		public RepoDbDB(string configuration)
+			: base(configuration)
+		{
+			InitDataContext();
+			InitMappingSchema();
+		}
+
+		public RepoDbDB(DataOptions options)
+			: base(options)
+		{
+			InitDataContext();
+			InitMappingSchema();
+		}
+
+		partial void InitDataContext  ();
+		partial void InitMappingSchema();
+	}
+
+	[Table(Schema="dbo", Name="Person")]
+	public partial class Person
+	{
+		[PrimaryKey, Identity] public long     Id             { get; set; } // bigint
+		[Column,     NotNull ] public string   Name           { get; set; } // nvarchar(128)
+		[Column,     NotNull ] public int      Age            { get; set; } // int
+		[Column,     NotNull ] public DateTime CreatedDateUtc { get; set; } // datetime2(5)
+	}
+
+	public static partial class TableExtensions
+	{
+		public static Person Find(this ITable<Person> table, long Id)
+		{
+			return table.FirstOrDefault(t =>
+				t.Id == Id);
+		}
+	}
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Linq2db/UpdateAllLinq2dbBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Linq2db/UpdateAllLinq2dbBenchmarks.cs
@@ -1,0 +1,47 @@
+#region Copyright Attributions
+
+// Copyright (c) 2026 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using DataModels;
+using LinqToDB;
+
+namespace RepoDb.Benchmarks.SqlServer.Linq2db
+{
+    public class UpdateAllLinq2dbBenchmarks : Linq2dbBaseBenchmarks
+    {
+        private readonly List<Person> persons = new();
+
+        [Params(10, 100, 1000)]
+        public int Rows { get; set; }
+
+        protected override void Bootstrap()
+        {
+            using var db = GetDb();
+
+            foreach (var person in (from p in db.People select p).Take(Rows))
+            {
+                person.CreatedDateUtc = DateTime.UtcNow;
+                persons.Add(person);
+            }
+        }
+
+        [Benchmark]
+        public void UpdateAll()
+        {
+            using var db = GetDb();
+
+            foreach (var person in persons)
+            {
+                db.Update(person);
+            }
+        }
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/NHibernate/GetAllNHibernateBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/NHibernate/GetAllNHibernateBenchmarks.cs
@@ -9,7 +9,7 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
 using NHibernate.Transform;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.Core.Models;
 
 namespace RepoDb.Benchmarks.SqlServer.NHibernate
 {

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/NHibernate/GetFirstNHibernateBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/NHibernate/GetFirstNHibernateBenchmarks.cs
@@ -9,7 +9,7 @@
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using NHibernate.Transform;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.Core.Models;
 
 namespace RepoDb.Benchmarks.SqlServer.NHibernate
 {

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/NHibernate/Models/PersonMap.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/NHibernate/Models/PersonMap.cs
@@ -1,0 +1,24 @@
+﻿#region Copyright Attributions
+
+// Copyright (c) 2020 SergerGood and Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using NHibernate.Mapping.ByCode.Conformist;
+using RepoDb.Benchmarks.Core.Models;
+
+namespace RepoDb.Benchmarks.SqlServer.NHibernate.Models
+{
+    public class PersonMap : ClassMapping<Person>
+    {
+        public PersonMap()
+        {
+            Id(x => x.Id);
+            Property(x => x.Name);
+            Property(x => x.Age);
+            Property(x => x.CreatedDateUtc);
+        }
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/NHibernate/NHibernateBaseBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/NHibernate/NHibernateBaseBenchmarks.cs
@@ -12,14 +12,13 @@ using NHibernate;
 using NHibernate.Cfg;
 using NHibernate.Dialect;
 using NHibernate.Mapping.ByCode;
-using RepoDb.Benchmarks.SqlServer.Configurations;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.SqlServer.NHibernate.Models;
 using RepoDb.Benchmarks.SqlServer.Setup;
 
 namespace RepoDb.Benchmarks.SqlServer.NHibernate
 {
-    [Description(OrmNameConstants.NHibernate)]
-    public class NHibernateBaseBenchmarks : BaseBenchmark
+    [Description("NHibernate")]
+    public class NHibernateBaseBenchmarks : SqlServerBenchmark
     {
         protected ISessionFactory SessionFactory;
 

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/NHibernate/NHibernateBaseBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/NHibernate/NHibernateBaseBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright Attributions
+#region Copyright Attributions
 
 // Copyright (c) 2020 SergerGood and Michael Camara Pendon.
 // Licensed under the Apache License, Version 2.0.
@@ -11,6 +11,7 @@ using BenchmarkDotNet.Attributes;
 using NHibernate;
 using NHibernate.Cfg;
 using NHibernate.Dialect;
+using NHibernate.Driver;
 using NHibernate.Mapping.ByCode;
 using RepoDb.Benchmarks.SqlServer.NHibernate.Models;
 using RepoDb.Benchmarks.SqlServer.Setup;
@@ -31,6 +32,7 @@ namespace RepoDb.Benchmarks.SqlServer.NHibernate
             configuration.DataBaseIntegration(properties =>
             {
                 properties.Dialect<MsSql2005Dialect>();
+                properties.Driver<MicrosoftDataSqlClientDriver>(); // Use Microsoft.Data.SqlClient instead of the legacy System.Data.SqlClient
                 properties.ConnectionString = DatabaseHelper.ConnectionString;
             });
 

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Program.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Program.cs
@@ -6,8 +6,9 @@
 
 #endregion
 
+using System.Reflection;
 using BenchmarkDotNet.Running;
-using RepoDb.Benchmarks.SqlServer.Configurations;
+using RepoDb.Benchmarks.Core.Configurations;
 
 namespace RepoDb.Benchmarks.SqlServer
 {
@@ -15,10 +16,7 @@ namespace RepoDb.Benchmarks.SqlServer
     {
         private static void Main(string[] args)
         {
-            var switcher = new BenchmarkSwitcher(typeof(BenchmarkConfig).Assembly);
-            //switcher.RunAll(new BenchmarkConfigWitRows());
-
-            //For single run.
+            var switcher = new BenchmarkSwitcher(Assembly.GetExecutingAssembly());
             switcher.Run(args, new BenchmarkConfigWitRows());
         }
     }

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb.Benchmarks.SqlServer.csproj
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb.Benchmarks.SqlServer.csproj
@@ -11,12 +11,12 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8"/>
     <PackageReference Include="Dapper" Version="2.1.79"/>
     <PackageReference Include="Dapper.Contrib" Version="2.0.78"/>
-    <PackageReference Include="NHibernate" Version="5.6.1"/>
+    <PackageReference Include="NHibernate" Version="5.7.0"/>
     <PackageReference Include="System.Linq.Async" Version="7.0.1"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11"/>
     <PackageReference Remove="System.Linq.Async" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb.Benchmarks.SqlServer.csproj
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb.Benchmarks.SqlServer.csproj
@@ -23,6 +23,8 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="Dapper" Version="2.1.79" />
     <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
+    <PackageReference Include="linq2db" Version="6.4.0" />
+    <PackageReference Include="linq2db.SqlServer" Version="6.4.0" />
     <PackageReference Include="NHibernate" Version="5.7.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb.Benchmarks.SqlServer.csproj
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb.Benchmarks.SqlServer.csproj
@@ -6,22 +6,36 @@
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>
     <Nullable>annotations</Nullable>
+    <Optimize>true</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.8"/>
-    <PackageReference Include="Dapper" Version="2.1.79"/>
-    <PackageReference Include="Dapper.Contrib" Version="2.0.78"/>
-    <PackageReference Include="NHibernate" Version="5.7.0"/>
-    <PackageReference Include="System.Linq.Async" Version="7.0.1"/>
+    <Compile Remove="Configurations\**" />
+    <Compile Remove="Models\**" />
+    <EmbeddedResource Remove="Configurations\**" />
+    <EmbeddedResource Remove="Models\**" />
+    <None Remove="Configurations\**" />
+    <None Remove="Models\**" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="BaseBenchmark.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageReference Include="Dapper" Version="2.1.79" />
+    <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
+    <PackageReference Include="NHibernate" Version="5.7.0" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.11" />
     <PackageReference Remove="System.Linq.Async" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Providers\RepoDb.Core\RepoDb\RepoDb.csproj" />
     <ProjectReference Include="..\..\..\Providers\RepoDb.SqlServer.BulkOperations\RepoDb.SqlServer.BulkOperations\RepoDb.SqlServer.BulkOperations.csproj" />
     <ProjectReference Include="..\..\..\Providers\RepoDb.PostgreSql\RepoDb.PostgreSql\RepoDb.PostgreSql.csproj" />
     <ProjectReference Include="..\..\..\Providers\RepoDb.SqlServer\RepoDb.SqlServer\RepoDb.SqlServer.csproj" />
+    <ProjectReference Include="..\RepoDb.Benchmarks.Core\RepoDb.Benchmarks.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb/GetAllRepoDbBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb/GetAllRepoDbBenchmarks.cs
@@ -8,7 +8,7 @@
 
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.Core.Models;
 
 namespace RepoDb.Benchmarks.SqlServer.RepoDb
 {

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb/GetFirstRepoDbBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb/GetFirstRepoDbBenchmarks.cs
@@ -8,7 +8,7 @@
 
 using System.Linq;
 using BenchmarkDotNet.Attributes;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.Core.Models;
 
 namespace RepoDb.Benchmarks.SqlServer.RepoDb
 {

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb/InsertAllRepoDbBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb/InsertAllRepoDbBenchmarks.cs
@@ -12,7 +12,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Data.SqlClient;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.Core.Models;
 
 namespace RepoDb.Benchmarks.SqlServer.RepoDb
 {

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb/InsertAllRepoDbBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb/InsertAllRepoDbBenchmarks.cs
@@ -48,15 +48,6 @@ namespace RepoDb.Benchmarks.SqlServer.RepoDb
             await connection.BulkInsertAsync(persons);
         }
         
-        [Benchmark]
-        public async Task BulkInsertAllAsyncEnumerable()
-        {
-            await using var connection = await GetConnection().EnsureOpenAsync() as SqlConnection;
-
-            var persons = GetPersons(Rows).ToAsyncEnumerable();
-            await connection.BulkInsertAsync(persons);
-        }
-        
         private static IEnumerable<Person> GetPersons(int count)
         {
             for (var i = 0; i < count; i++)

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb/RepoDbBaseBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb/RepoDbBaseBenchmarks.cs
@@ -10,13 +10,12 @@ using System;
 using System.ComponentModel;
 using System.Data;
 using BenchmarkDotNet.Attributes;
-using RepoDb.Benchmarks.SqlServer.Configurations;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.Core.Models;
 
 namespace RepoDb.Benchmarks.SqlServer.RepoDb
 {
-    [Description(OrmNameConstants.RepoDB)]
-    public class RepoDbBaseBenchmarks : BaseBenchmark
+    [Description("RepoDB")]
+    public class RepoDbBaseBenchmarks : SqlServerBenchmark
     {
         [GlobalSetup]
         public void Setup()

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb/UpdateAllRepoDbBenchmarks.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/RepoDb/UpdateAllRepoDbBenchmarks.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Microsoft.Data.SqlClient;
-using RepoDb.Benchmarks.SqlServer.Models;
+using RepoDb.Benchmarks.Core.Models;
 
 namespace RepoDb.Benchmarks.SqlServer.RepoDb
 {

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Setup/DatabaseHelper.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Setup/DatabaseHelper.cs
@@ -19,7 +19,7 @@ namespace RepoDb.Benchmarks.SqlServer.Setup
         {
             var connectionString = Environment.GetEnvironmentVariable("REPODB_CONSTR", EnvironmentVariableTarget.Process);
 
-            ConnectionString = connectionString ?? @"Server=(local);Database=RepoDb;Integrated Security=False;User Id=michael;Password=Password123;";
+            ConnectionString = connectionString ?? @"Server=tcp:127.0.0.1,1433;Database=RepoDbBulk;User ID=sa;Password=RepoDB2026;TrustServerCertificate=True;";
 
             CreateDatabase();
             CreatePersonTable();

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/SqlServerBenchmark.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/SqlServerBenchmark.cs
@@ -1,0 +1,33 @@
+﻿#region Copyright Attributions
+
+// Copyright (c) 2026 Michael Camara Pendon.
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for full license information.
+
+#endregion
+
+using System.Data;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Data.SqlClient;
+using RepoDb.Benchmarks.Core;
+using RepoDb.Benchmarks.SqlServer.Setup;
+
+namespace RepoDb.Benchmarks.SqlServer
+{
+    public abstract class SqlServerBenchmark : BaseBenchmark
+    {
+        [GlobalCleanup]
+        public override void Cleanup() => DatabaseHelper.Cleanup();
+
+        [IterationSetup]
+        public override void IterationSetup() => CurrentId++;
+        
+        protected override void BaseSetup()
+        {
+            DatabaseHelper.Initialize(ElementsCount);
+            Bootstrap();
+        }
+
+        protected override IDbConnection GetConnection() => new SqlConnection(DatabaseHelper.ConnectionString);
+    }
+}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.sln
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.sln
@@ -20,6 +20,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{170EB4D0-4
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DbProviders", "DbProviders", "{DFC5265D-6BEC-4073-9302-4F9FF6319C02}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RepoDb.Benchmarks.Core", "RepoDb.Benchmarks.Core\RepoDb.Benchmarks.Core.csproj", "{57BF6CD9-29F6-0A1A-56FA-C832000B45EF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,10 @@ Global
 		{3180EF0C-01C0-4F8E-8AED-C605461CC393}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3180EF0C-01C0-4F8E-8AED-C605461CC393}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3180EF0C-01C0-4F8E-8AED-C605461CC393}.Release|Any CPU.Build.0 = Release|Any CPU
+		{57BF6CD9-29F6-0A1A-56FA-C832000B45EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57BF6CD9-29F6-0A1A-56FA-C832000B45EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57BF6CD9-29F6-0A1A-56FA-C832000B45EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57BF6CD9-29F6-0A1A-56FA-C832000B45EF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -61,6 +67,7 @@ Global
 		{6DC2760A-B41C-459A-8ABB-867F03B90AEC} = {DFC5265D-6BEC-4073-9302-4F9FF6319C02}
 		{C387EF36-8ED2-4056-94A0-F3347D681F56} = {11557363-B92A-4C24-8D03-80FE7219704A}
 		{3180EF0C-01C0-4F8E-8AED-C605461CC393} = {11557363-B92A-4C24-8D03-80FE7219704A}
+		{57BF6CD9-29F6-0A1A-56FA-C832000B45EF} = {11557363-B92A-4C24-8D03-80FE7219704A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5229CEA0-E4C0-482B-8BC3-FD9C540F583C}

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.sln
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30320.27
+# Visual Studio Version 18
+VisualStudioVersion = 18.7.11911.148 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RepoDb.SqlServer", "..\..\Providers\RepoDb.SqlServer\RepoDb.SqlServer\RepoDb.SqlServer.csproj", "{6D196ABF-4A38-43C1-8D31-2C5CECC0F2AF}"
 EndProject
@@ -14,6 +13,12 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RepoDb.Benchmarks.SqlServer", "RepoDb.Benchmarks.SqlServer\RepoDb.Benchmarks.SqlServer.csproj", "{C387EF36-8ED2-4056-94A0-F3347D681F56}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RepoDb.Benchmarks.PostgreSql", "RepoDb.Benchmarks.PostgreSql\RepoDb.Benchmarks.PostgreSql.csproj", "{3180EF0C-01C0-4F8E-8AED-C605461CC393}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Benchmarks", "Benchmarks", "{11557363-B92A-4C24-8D03-80FE7219704A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{170EB4D0-4042-4AAD-9511-2E2DBD1B2E65}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DbProviders", "DbProviders", "{DFC5265D-6BEC-4073-9302-4F9FF6319C02}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -48,6 +53,14 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{6D196ABF-4A38-43C1-8D31-2C5CECC0F2AF} = {DFC5265D-6BEC-4073-9302-4F9FF6319C02}
+		{9313409F-467E-40D7-874E-9105BBDDFA53} = {170EB4D0-4042-4AAD-9511-2E2DBD1B2E65}
+		{4B11CD99-AF04-415B-99FF-E52278CFA7FC} = {DFC5265D-6BEC-4073-9302-4F9FF6319C02}
+		{6DC2760A-B41C-459A-8ABB-867F03B90AEC} = {DFC5265D-6BEC-4073-9302-4F9FF6319C02}
+		{C387EF36-8ED2-4056-94A0-F3347D681F56} = {11557363-B92A-4C24-8D03-80FE7219704A}
+		{3180EF0C-01C0-4F8E-8AED-C605461CC393} = {11557363-B92A-4C24-8D03-80FE7219704A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5229CEA0-E4C0-482B-8BC3-FD9C540F583C}


### PR DESCRIPTION
# Add RepoDb.Benchmarks: independent, reproducible ORM benchmarks (SQL Server & PostgreSQL)

Ref: #1309

## Summary

This PR introduces `RepoDb.Benchmarks`, a new benchmarking suite that compares RepoDB against the most widely used .NET ORMs — Dapper, Entity Framework Core, Linq2Db, and NHibernate — under identical conditions, using [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet).

The goal is to give the .NET community, and enterprises evaluating RepoDB for production, a transparent and independently reproducible way to compare data-access libraries, rather than relying on hand-picked numbers.

## What's included

- **`RepoDb.Benchmarks.Core`** — shared infrastructure: the `Person` model, `BaseBenchmark`, `BenchmarkConfig`/`BenchmarkConfigWitRows`, and the ORM name/column constants reused by every provider project.
- **`RepoDb.Benchmarks.SqlServer`** — benchmarks against SQL Server for:
  - RepoDb (`GetFirst`, `GetAll`, `UpdateAll`, `InsertAll`)
  - Dapper (`GetFirst`, `GetAll`, `UpdateAll`)
  - EF Core (`GetFirst`, `GetAll`)
  - Linq2Db (`GetFirst`, `GetAll`, `UpdateAll`)
  - NHibernate (`GetFirst`, `GetAll`)
- **`RepoDb.Benchmarks.PostgreSql`** — the same operation matrix against PostgreSQL for RepoDb, Dapper, EF Core, Linq2Db, and NHibernate (`GetFirst`/`GetAll`/`UpdateAll` where each ORM supports it).
- **`README.md`** — documents the project's intentions and honesty principles (same rules for every ORM, open methodology, no cherry-picking), the enterprise notice (run it yourself against your own infrastructure before trusting our numbers), how to run each project via Docker + `dotnet run -c Release`, the list of ORMs/operations benchmarked, and a pros/cons summary per ORM.
- Row counts are parameterized (10 / 100 / 1000) so results show how each ORM scales, not just a single-size snapshot.

## Notable fixes made while wiring this up

- **NHibernate on SQL Server** now explicitly configures `NHibernate.Driver.MicrosoftDataSqlClientDriver` instead of relying on NHibernate's default `SqlClientDriver`. The project only references `Microsoft.Data.SqlClient` (not the legacy `System.Data.SqlClient`), so the default driver failed at `GlobalSetup` with `Could not create the driver from NHibernate.Driver.SqlClientDriver`. This keeps the SQL Server benchmark on the modern client library end-to-end.
- Various `Program.cs` / `.csproj` / solution updates to make both provider projects buildable and runnable standalone via `BenchmarkSwitcher`.

## How to test

```bash
# SQL Server
docker compose up -d mssql
cd src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer
dotnet run -c Release

# PostgreSQL
docker compose up -d postgresql
cd src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql
dotnet run -c Release
```

Connection strings default to the repo's local Docker instances and can be overridden with `REPODB_CONSTR` (and `REPODB_CONSTR_POSTGRESDB` for the PostgreSQL admin connection).

Always run in `Release` — Debug builds produce misleading benchmark numbers.

## Notes / follow-ups

- Only SQL Server and PostgreSQL are covered in this initial PR. Additional providers already supported by RepoDB (MySQL, SQLite, Oracle, DB2, ClickHouse, etc.) are intentionally left for follow-up PRs, per the "Contributions" section of the new README.
- There is no dedicated CI workflow for the benchmark projects yet — they currently run manually / locally. Worth a follow-up if we want benchmark regressions caught automatically.
- Bulk-operation benchmarks (`InsertAll`) are only present for RepoDb on SQL Server so far; extending bulk coverage to PostgreSQL and to more operations is a natural next step.
