### PR TITLE
Enterprise Benchmark for SECURITY and Notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,18 @@ It bridges different database systems with a single, unified connectivity layer:
 - **🧩 Consistent API Surface** — The same fluent methods and conventions work identically regardless of the underlying provider.
 - **⚙️ Provider-Native Optimizations** — Each connector is tuned to exploit the bulk and native capabilities of its target database.
 
-### Roadmap
+## 🏢 Enterprise Notice
+
+If your organization is evaluating or adopting RepoDB for production use, keep the following in mind:
+
+- **🖥️ Run the benchmark on your environment** — Published numbers (e.g., the [benchmark suite](src/Shared/RepoDb.Benchmarks/README.md)) are produced on infrastructure local to the project (local Docker containers, CI runners, contributor machines). Hardware, network topology, database configuration, cloud provider, virtualization/container overhead, and data volume all materially affect performance, so clone the repository and run the relevant benchmark project(s) against infrastructure and data shapes that mirror your own workload before relying on any published figure.
+- **⚠️ Be aware of the limitations** — RepoDB is a micro-ORM built for advanced use cases and has documented, provider-specific [limitations](src/Shared/RepoDb.Docs/limitations.md) (e.g., composite keys, JOINs, cache invalidation, and behaviors specific to SQL Server, Oracle, DB2, and other providers). Review these against your intended usage before committing to production.
+- **🔒 Security is best-effort, not SLA-backed** — There is no dedicated security team or response SLA. Read our [Security Policy](SECURITY.md) before adopting RepoDB in a security-sensitive context — it covers how to report a vulnerability, which versions get fixes, and the RepoDB-specific risk areas (raw SQL execution, reflection-based provider internals, unscanned third-party driver dependencies) along with how each is mitigated.
+- **🤝 Understand our contributions and support policy** — RepoDB is primarily maintained by a single individual, not an organization. Community contributions are welcome and encouraged (see [Contributing](CONTRIBUTING.md)), and all support is free (for now), but it follows a documented [support policy](src/Shared/RepoDb.Docs/support-policy.md) with defined hours and channels rather than an enterprise SLA. Plan your adoption and escalation paths accordingly, and consider [contributing back](#contributions) or arranging consultancy for dedicated needs.
+- **🚌 Factor in the bus factor** — RepoDB has no formal governance structure today; entitlement, succession, and legal/trademark ownership are not yet defined (see [Governance](src/Shared/RepoDb.Docs/support-policy.md#governance)). Account for this single-maintainer risk in your continuity and vendor-risk planning.
+- **🔢 No formal versioning/breaking-change policy** — RepoDB does not publish a documented SemVer or deprecation policy, and (per the [Security Policy](SECURITY.md#-supported-versions)) only the latest release of each package receives fixes — there is no backport process to older majors/minors. Pin exact package versions in production and review release notes before upgrading, rather than assuming strict backward compatibility across releases.
+
+## Roadmap
 
 RepoDB is evolving from an ORM into a broader data productivity platform, with Data Engineering capabilities — moving data between providers, on-premise or cloud-native — on the roadmap.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# 🛡️ Security Policy
+
+RepoDB takes security seriously, but is honest about what that means in practice: RepoDB is primarily maintained by a single individual, not a security team or a vendor with an SLA (see our [Support Policy](src/Shared/RepoDb.Docs/support-policy.md) and the [Governance](src/Shared/RepoDb.Docs/support-policy.md#governance) section). This document explains what is and isn't covered, how to report a vulnerability, and how we mitigate the security risks specific to a data-access library.
+
+## 📦 Supported Versions
+
+Only the **latest published release** of each RepoDB package (see the [package list](PACKAGES.md)) receives security fixes. There is no formal backport policy — fixes ship forward as a new version, not as a patch to an older major/minor line (see the [versioning notice](README.md#-enterprise-notice) in the root README).
+
+If you're running an older version, upgrade to the latest before reporting — the issue may already be fixed.
+
+## 🚨 Reporting a Vulnerability
+
+**Do not open a public GitHub issue for a suspected vulnerability.** Instead:
+
+1. 📧 Email **[michael.c.pendon@outlook.com](mailto:michael.c.pendon@outlook.com)** with a subject line starting with `[SECURITY]`.
+2. 📝 Include the affected package(s) and version(s), the database provider involved (if relevant), a minimal reproduction or proof of concept, and the impact you believe it has.
+3. ⏱️ You'll get an acknowledgment during the hours defined in the [Support Policy](src/Shared/RepoDb.Docs/support-policy.md) (CET timezone; single maintainer — there is no 24/7 security desk).
+
+There is no bug bounty program. Coordinated disclosure is appreciated: please give us a reasonable window to ship a fix before disclosing publicly, and we'll credit you in the release notes if you'd like.
+
+## 🔎 Known Risk Areas and How We Mitigate Them
+
+RepoDB's design surfaces a few security-relevant areas worth calling out explicitly, rather than leaving them implicit:
+
+- **💉 Raw SQL execution** — [ExecuteQuery](http://repodb.net/operation/executequery), [ExecuteNonQuery](http://repodb.net/operation/executenonquery), and related methods run SQL text you provide. RepoDB parameterizes every fluent operation ([Insert](http://repodb.net/operation/insert), [Query](http://repodb.net/operation/query), [Update](http://repodb.net/operation/update), [Delete](http://repodb.net/operation/delete), [Merge](http://repodb.net/operation/merge), etc.) by default, but the raw-SQL methods are only as safe as the SQL you hand them. Always pass user input as parameters (e.g. `@Name`), never by string-concatenating it into the command text.
+- **🔑 No credential handling** — RepoDB never stores, logs, or transmits your connection string or credentials. You own the `IDbConnection` and its connection string; RepoDB only consumes it for the lifetime of the call. Review the [Telemetry](README.md#telemetry) feature separately if you enable it, since it publishes operation metadata (not connection strings or row-level data) to a collector you configure.
+- **🪞 Reflection-based provider internals** — A small number of bulk-operation code paths use reflection against non-public members of underlying ADO.NET provider types (documented in [Limitations](src/Shared/RepoDb.Docs/limitations.md), e.g. `SqlBulkCopy` internals). These are reviewed and covered by tests, but they depend on the internal shape of a specific provider driver version. Pin your driver package version in production and re-run your test suite after upgrading it.
+- **📦 Third-party provider dependencies** — RepoDB depends on the official ADO.NET drivers for each provider (Npgsql, MySql.Data, MySqlConnector, Oracle.ManagedDataAccess.Core, Net.IBM.Data.Db2, ClickHouse.Driver, FirebirdSql.Data.FirebirdClient, Vertica.Data, Sap.Data.Hana.Net.v6.0, etc. — see [Credits](README.md#credits)). RepoDB does not currently run automated dependency-vulnerability scanning (e.g. Dependabot/CodeQL) across this repository. Track and update these driver dependencies in your own project independently; a CVE in a driver is not necessarily reflected in a new RepoDB release.
+- **✅ Continuous testing, not a security audit** — Every provider has a dedicated unit/integration test suite that runs in CI on every pull request and release (see [Packages and Build Status](PACKAGES.md)). This catches regressions and behavioral bugs, but RepoDB has not undergone a formal third-party security audit or penetration test.
+
+## 🗺️ Scope
+
+This policy covers the RepoDB libraries in this repository (core, provider packages, and bulk-operations add-ons). It does not cover the [documentation site](https://github.com/mikependon/RepoDb.NET) repository or third-party packages that merely integrate with RepoDB — report those upstream.

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/BenchmarkConfig.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/BenchmarkConfig.cs
@@ -18,13 +18,13 @@ namespace RepoDb.Benchmarks.Core.Configurations
 {
     public class BenchmarkConfig : ManualConfig
     {
-        public BenchmarkConfig()
+        public BenchmarkConfig(string provider)
         {
             AddLogger(ConsoleLogger.Default);
             AddExporter(MarkdownExporter.GitHub);
             AddDiagnoser(MemoryDiagnoser.Default);
 
-            AddColumn(new OrmColumn());
+            AddColumn(new OrmColumn(provider));
             AddColumn(TargetMethodColumn.Method);
             AddColumn(StatisticColumn.Mean);
             AddColumn(StatisticColumn.StdDev);

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/BenchmarkConfigWitRows.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/BenchmarkConfigWitRows.cs
@@ -12,7 +12,8 @@ namespace RepoDb.Benchmarks.Core.Configurations
 {
     public class BenchmarkConfigWitRows : BenchmarkConfig
     {
-        public BenchmarkConfigWitRows()
+        public BenchmarkConfigWitRows(string provider)
+            : base(provider)
         {
             AddColumn(new ParamColumn("Rows"));
         }

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/OrmColumn.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.Core/Configurations/OrmColumn.cs
@@ -16,9 +16,14 @@ namespace RepoDb.Benchmarks.Core.Configurations
 {
     public sealed class OrmColumn : IColumn
     {
+        public OrmColumn(string provider)
+        {
+            Legend = $"The object/relational mapper being tested for '{provider}'.";
+        }
+
         public string Id => nameof(OrmColumn);
         public string ColumnName { get; } = "ORM";
-        public string Legend => "The object/relational mapper being tested";
+        public string Legend { get; }
 
         public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
         public string GetValue(Summary summary, BenchmarkCase benchmarkCase)

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Program.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Program.cs
@@ -17,7 +17,7 @@ namespace RepoDb.Benchmarks.PostgreSql
         private static void Main(string[] args)
         {
             var switcher = new BenchmarkSwitcher(Assembly.GetExecutingAssembly());
-            switcher.Run(args, new BenchmarkConfigWitRows());
+            switcher.Run(args, new BenchmarkConfigWitRows("PostgreSQL"));
         }
     }
 }

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/README.md
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/README.md
@@ -1,0 +1,49 @@
+# 🐘 RepoDb.Benchmarks.PostgreSql
+
+Benchmarks comparing RepoDB against Dapper, Entity Framework Core, Linq2Db, and NHibernate on PostgreSQL. See the [main Benchmarks README](../README.md) for the full methodology, ORM list, and Enterprise Notice.
+
+## ❓ Why this Benchmark?
+
+This benchmark exists to give **visibility** into how RepoDB performs against other widely used .NET ORMs on PostgreSQL, and to do so in a way that avoids bias — the same schema, the same dataset, and the same operations are run against every ORM in a single pass, and all of the benchmarking code is open for anyone to read or challenge.
+
+That said, results produced here run on infrastructure local to this repository. If your organization is evaluating RepoDB for PostgreSQL workloads, we strongly encourage you to run this benchmark on your **own environment** — your own hardware, your own PostgreSQL configuration, and your own data shape — before making a collective and conclusive decision. See the [Enterprise Notice](../README.md#-enterprise-notice) in the main Benchmarks README for more on why this matters.
+
+## ▶️ Running the Benchmark
+
+1. Start a PostgreSQL instance using the repository's root [docker-compose.yml](../../../../docker-compose.yml):
+
+   ```bash
+   docker compose up -d postgresql
+   ```
+
+2. Run the benchmark project in `Release` configuration:
+
+   ```bash
+   cd src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql
+   dotnet run -c Release
+   ```
+
+3. Select the benchmark(s) you want to run from the interactive BenchmarkDotNet menu.
+
+> ⚠️ Always run in `Release` configuration — Debug builds produce misleading results.
+
+By default, the benchmark connects using:
+
+```
+Server=127.0.0.1;Port=5432;Database=RepoDb;User Id=postgres;Password=RepoDB2026;
+```
+
+and uses the following admin connection (pointing at the `postgres` database) to create the `RepoDb` database if it doesn't already exist:
+
+```
+Server=127.0.0.1;Port=5432;Database=postgres;User Id=postgres;Password=RepoDB2026;
+```
+
+To target a different instance or credentials, set these environment variables before running:
+
+```bash
+export REPODB_CONSTR="Server=<your-host>;Port=5432;Database=RepoDb;User Id=postgres;Password=<your-password>;"
+export REPODB_CONSTR_POSTGRESDB="Server=<your-host>;Port=5432;Database=postgres;User Id=postgres;Password=<your-password>;"
+```
+
+Results are written to `BenchmarkDotNet.Artifacts` as Markdown, HTML, and console reports.

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Setup/DatabaseHelper.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.PostgreSql/Setup/DatabaseHelper.cs
@@ -22,8 +22,8 @@ namespace RepoDb.Benchmarks.PostgreSql.Setup
             var connectionStringForPostgres = Environment.GetEnvironmentVariable("REPODB_CONSTR_POSTGRESDB", EnvironmentVariableTarget.Process);
             var connectionString = Environment.GetEnvironmentVariable("REPODB_CONSTR", EnvironmentVariableTarget.Process);
 
-            ConnectionStringForPostgres = connectionStringForPostgres ?? "Server=127.0.0.1;Port=5432;Database=postgres;User Id=postgres;Password=postgres;";
-            ConnectionString = connectionString ?? "Server=127.0.0.1;Port=5432;Database=RepoDb;User Id=postgres;Password=postgres;";
+            ConnectionStringForPostgres = connectionStringForPostgres ?? "Server=127.0.0.1;Port=5432;Database=postgres;User Id=postgres;Password=RepoDB2026;";
+            ConnectionString = connectionString ?? "Server=127.0.0.1;Port=5432;Database=RepoDb;User Id=postgres;Password=RepoDB2026;";
 
             CreateDatabase();
             CreatePersonTable();

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Program.cs
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/Program.cs
@@ -17,7 +17,7 @@ namespace RepoDb.Benchmarks.SqlServer
         private static void Main(string[] args)
         {
             var switcher = new BenchmarkSwitcher(Assembly.GetExecutingAssembly());
-            switcher.Run(args, new BenchmarkConfigWitRows());
+            switcher.Run(args, new BenchmarkConfigWitRows("SQL Server"));
         }
     }
 }

--- a/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/README.md
+++ b/src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer/README.md
@@ -1,0 +1,42 @@
+# 🟦 RepoDb.Benchmarks.SqlServer
+
+Benchmarks comparing RepoDB against Dapper, Entity Framework Core, Linq2Db, and NHibernate on SQL Server. See the [main Benchmarks README](../README.md) for the full methodology, ORM list, and Enterprise Notice.
+
+## ❓ Why this Benchmark?
+
+This benchmark exists to give **visibility** into how RepoDB performs against other widely used .NET ORMs on SQL Server, and to do so in a way that avoids bias — the same schema, the same dataset, and the same operations are run against every ORM in a single pass, and all of the benchmarking code is open for anyone to read or challenge.
+
+That said, results produced here run on infrastructure local to this repository. If your organization is evaluating RepoDB for SQL Server workloads, we strongly encourage you to run this benchmark on your **own environment** — your own hardware, your own SQL Server configuration, and your own data shape — before making a collective and conclusive decision. See the [Enterprise Notice](../README.md#-enterprise-notice) in the main Benchmarks README for more on why this matters.
+
+## ▶️ Running the Benchmark
+
+1. Start a SQL Server instance using the repository's root [docker-compose.yml](../../../../docker-compose.yml):
+
+   ```bash
+   docker compose up -d mssql
+   ```
+
+2. Run the benchmark project in `Release` configuration:
+
+   ```bash
+   cd src/Shared/RepoDb.Benchmarks/RepoDb.Benchmarks.SqlServer
+   dotnet run -c Release
+   ```
+
+3. Select the benchmark(s) you want to run from the interactive BenchmarkDotNet menu.
+
+> ⚠️ Always run in `Release` configuration — Debug builds produce misleading results.
+
+By default, the benchmark connects using:
+
+```
+Server=tcp:127.0.0.1,1433;Database=RepoDbBulk;User ID=sa;Password=RepoDB2026;TrustServerCertificate=True;
+```
+
+To target a different instance, set the `REPODB_CONSTR` environment variable before running:
+
+```bash
+export REPODB_CONSTR="Server=tcp:<your-host>,1433;Database=RepoDbBulk;User ID=sa;Password=<your-password>;TrustServerCertificate=True;"
+```
+
+Results are written to `BenchmarkDotNet.Artifacts` as Markdown, HTML, and console reports.


### PR DESCRIPTION
# Add Enterprise Notice and Security Policy documentation

## Summary

- Added a root-level [SECURITY.md](SECURITY.md) covering supported versions, how to report a vulnerability, RepoDB-specific risk areas (raw SQL execution, reflection-based provider internals, unscanned third-party driver dependencies), and how each is mitigated — since no formal security process existed before.
- Added an **Enterprise Notice** section to the root `README.md` (before *Roadmap*) so organizations evaluating RepoDB for production see, up front: benchmarking caveats, documented limitations, our security posture (linking to `SECURITY.md`), the support policy, single-maintainer/governance risk ("bus factor"), and the lack of a formal versioning/breaking-change policy.
- Cross-linked the README's versioning bullet to `SECURITY.md#-supported-versions` so the "latest release only gets fixes, no backport policy" fact lives in one place instead of being duplicated.

## Why

RepoDB has grown enterprise interest, but several operational realities (single maintainer, no formal SLA, no prior security disclosure process, no documented versioning policy) were previously undocumented. This makes those tradeoffs explicit so adopters can factor them into risk/continuity planning, instead of discovering them later.

## Test plan

- [ ] Render both files locally/on GitHub and confirm formatting (headings, emoji, bullet nesting) looks correct.
- [ ] Click through every link in the Enterprise Notice section and in `SECURITY.md` (benchmark README, limitations.md, support-policy.md + `#governance` anchor, CONTRIBUTING.md, SECURITY.md + `#-supported-versions` anchor) to confirm they resolve.
- [ ] Confirm the `SECURITY.md` file is picked up by GitHub's repository security tab (Security → Policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
